### PR TITLE
Declare _z_i_map_empty as extern

### DIFF
--- a/include/zenoh/private/collection.h
+++ b/include/zenoh/private/collection.h
@@ -108,7 +108,7 @@ void _z_list_free(_z_list_t **xs);
 /*-------- Int Map --------*/
 #define _Z_DEFAULT_I_MAP_CAPACITY 64
 
-_z_i_map_t *_z_i_map_empty;
+extern _z_i_map_t *_z_i_map_empty;
 _z_i_map_t *_z_i_map_make(size_t capacity);
 
 size_t _z_i_map_capacity(_z_i_map_t *map);


### PR DESCRIPTION
This fixes an issue where `_z_i_map_empty` is reported to be declared as twice when a project includes `zenoh.h` (and therefore `collection.h`)