### PR TITLE
Added colcon.pkg for colcon

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,8 @@
+{
+    "name": "zenoh_pico",
+    "type": "cmake",
+    "cmake-args":[
+        "-DTESTS=OFF",
+        "-DEXAMPLES=OFF",
+    ],
+}


### PR DESCRIPTION
This adds the `colcon.pkg` file to give colcon hints about how to build `zenoh-pico`