### PR TITLE
Add check for if ifa_addr is null

### DIFF
--- a/src/net/unix/network.c
+++ b/src/net/unix/network.c
@@ -44,12 +44,9 @@ char *_zn_select_scout_iface()
     else
     {
         current = ifap;
-        int family;
         do
         {
-            family = current->ifa_addr->sa_family;
-
-            if (family == AF_INET)
+            if (current->ifa_addr != 0 && current->ifa_addr->sa_family == AF_INET)
             {
                 if (memcmp(current->ifa_name, eth_prefix, len) == 0)
                 {


### PR DESCRIPTION
This commits adds a check for if ifa_addr is null when looping through network interfaces on a Unix system.

I got a crash when running the examples on a system that had an interface without any address assigned to it. 