### PR TITLE
Zephyr Module Support

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: zenoh-pico
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
By adding a zephyr/module.yml file, zenoh-pico can be brought in as an external module in idiomatic Zephyr workflows that aren't using Platform.IO.

A complete example application that leverages this change can be found here:
https://github.com/spiderkeys/zephyr-zenoh-example

The key parts in the example that demonstrate integration of Zenoh-Pico:
- ./west.yml: specifies external module dependency on the zenoh-pico git repo
- ./modules/: contains a module definition for zenoh-pico and specifies the important cmake/kconfig settings to bring it in as module
- ./app/: prj.conf, CMakeLists.txt, and Kconfig that demonstrates use of zenoh-pico module target