### PR TITLE
Fixes implicit declaration warnings in Zephyr

### DIFF
--- a/include/zenoh-pico/system/private/zephyr/types.h
+++ b/include/zenoh-pico/system/private/zephyr/types.h
@@ -17,6 +17,7 @@
 
 #include <zephyr.h>
 #include <pthread.h>
+#include "utils.h"
 
 typedef int _zn_socket_t;
 

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -14,6 +14,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "zenoh-pico/system/common.h"
 #include "zenoh-pico/utils/collections.h"
 #include "zenoh-pico/utils/types.h"
 


### PR DESCRIPTION
This fixes warnings that popped up in the Zephyr build process relating to implicit declaration of strdup.

This is done by making sure that zephyr/utils.h (which has the prototype for strdup) ultimately gets included in all files that make use of it.