### PR TITLE
fix u_int64_t undeclared error

### DIFF
--- a/tests/zn_msgcodec_test.c
+++ b/tests/zn_msgcodec_test.c
@@ -290,7 +290,7 @@ void payload_field(void)
 z_timestamp_t gen_timestamp(void)
 {
     z_timestamp_t ts;
-    ts.time = (u_int64_t)time(NULL);
+    ts.time = (uint64_t)time(NULL);
     ts.id = gen_bytes(16);
 
     return ts;


### PR DESCRIPTION
fix u_int64_t typo which is throwing an undeclared error.
Replacing it with uint64_t