### PR TITLE
Remove config empty and expose only new

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -191,7 +191,6 @@ Primitives
 .. autocfunction:: primitives.h::z_keyexpr_equals
 .. autocfunction:: primitives.h::zp_keyexpr_equals_null_terminated
 .. autocfunction:: primitives.h::z_config_new
-.. autocfunction:: primitives.h::z_config_empty
 .. autocfunction:: primitives.h::z_config_default
 .. autocfunction:: primitives.h::zp_config_get
 .. autocfunction:: primitives.h::zp_config_insert

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -240,28 +240,6 @@ _Bool zp_keyexpr_equals_null_terminated(const char *l, const char *r);
 z_owned_config_t z_config_new(void);
 
 /**
- * Return a new, zenoh-allocated, empty configuration.
- * It consists in an empty set of properties for zenoh session configuration.
- *
- * Like most ``z_owned_X_t`` types, you may obtain an instance of :c:type:`z_owned_config_t` by loaning it using
- * ``z_config_loan(&val)``. The ``z_loan(val)`` macro, available if your compiler supports C11's ``_Generic``, is
- * equivalent to writing ``z_config_loan(&val)``.
- *
- * Like all ``z_owned_X_t``, an instance will be destroyed by any function which takes a mutable pointer to said
- * instance, as this implies the instance's inners were moved. To make this fact more obvious when reading your code,
- * consider using ``z_move(val)`` instead of ``&val`` as the argument. After a ``z_move``, ``val`` will still exist, but
- * will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your ``val``
- * is valid.
- *
- * To check if ``val`` is still valid, you may use ``z_config_check(&val)`` or ``z_check(val)`` if your compiler
- * supports ``_Generic``, which will return ``true`` if ``val`` is valid, or ``false`` otherwise.
- *
- * Returns:
- *   Returns a new, zenoh-allocated, empty configuration.
- */
-z_owned_config_t z_config_empty(void);
-
-/**
  * Return a new, zenoh-allocated, default configuration.
  * It consists in a default set of properties for zenoh session configuration.
  *

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -86,7 +86,6 @@ _OWNED_TYPE(z_keyexpr_t, keyexpr)
  * Operations over :c:type:`z_config_t` must be done using the provided functions:
  *
  *   - :c:func:`z_config_new`
- *   - :c:func:`z_config_empty`
  *   - :c:func:`z_config_default`
  *   - :c:func:`zp_config_get`
  *   - :c:func:`zp_config_insert`

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -106,8 +106,6 @@ _Bool zp_keyexpr_equals_null_terminated(const char *l, const char *r) {
 
 z_owned_config_t z_config_new(void) { return (z_owned_config_t){._value = _z_config_empty()}; }
 
-z_owned_config_t z_config_empty(void) { return (z_owned_config_t){._value = _z_config_empty()}; }
-
 z_owned_config_t z_config_default(void) { return (z_owned_config_t){._value = _z_config_default()}; }
 
 const char *zp_config_get(z_config_t *config, unsigned int key) { return _z_config_get(config, key); }

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -153,9 +153,6 @@ int main(int argc, char **argv) {
     z_owned_config_t _ret_config = z_config_new();
     assert(z_check(_ret_config));
     z_drop(z_move(_ret_config));
-    _ret_config = z_config_empty();
-    assert(z_check(_ret_config));
-    z_drop(z_move(_ret_config));
     _ret_config = z_config_default();
     assert(z_check(_ret_config));
 #ifdef ZENOH_PICO


### PR DESCRIPTION
`z_config_new` and `z_config_empty` create an empty config.
For simplicity expose only one of these functions at the user API.