### PR TITLE
Fix spelling of Docker network parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,13 +329,13 @@ The simplest way to run some of the example is to get a Docker image of the **ze
 Assuming you've pulled the Docker image of the **zenoh** network router on a Linux host (to leverage UDP multicast scouting has explained [here](https://zenoh.io/docs/getting-started/quick-test/#run-zenoh-router-in-a-docker-container), then simply do:
 
 ```bash
-$ docker run --init -net host eclipse/zenoh:master
+$ docker run --init --net host eclipse/zenoh:master
 ```
 
 To see the zenoh manual page, simply do:
 
 ```bash
-$ docker run --init -net host eclipse/zenoh:master --help
+$ docker run --init --net host eclipse/zenoh:master --help
 ```
 
 ### 3.2. Basic Pub/Sub Example


### PR DESCRIPTION
The `docker run` example was not copy-paste-able, missing a dash. I was tempted to use the full `--network` spelling, but left it as `--net`, since that is what is use in the linked ["Getting Started"](https://zenoh.io/docs/getting-started/quick-test/) documentation.