### PR TITLE
Align misdefined z_config_t and z_scouting_config_t (#146)

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -89,9 +89,9 @@ _OWNED_TYPE(z_keyexpr_t, keyexpr)
  *   - :c:func:`zp_config_insert`
  */
 typedef struct {
-    _z_scouting_config_t *_val;
+    _z_config_t *_val;
 } z_config_t;
-_OWNED_TYPE(_z_scouting_config_t, config)
+_OWNED_TYPE(_z_config_t, config)
 
 /**
  * Represents a scouting configuration.
@@ -106,9 +106,9 @@ _OWNED_TYPE(_z_scouting_config_t, config)
  *   - :c:func:`zp_scouting_config_insert`
  */
 typedef struct {
-    _z_config_t *_val;
+    _z_scouting_config_t *_val;
 } z_scouting_config_t;
-_OWNED_TYPE(_z_config_t, scouting_config)
+_OWNED_TYPE(_z_scouting_config_t, scouting_config)
 
 /**
  * Represents a Zenoh session.


### PR DESCRIPTION
Fixes #146 