### PR TITLE
Changed zephyr include to quiet down warnings with newer versions of Zephyr

### DIFF
--- a/include/zenoh-pico/net/zenoh-pico.h
+++ b/include/zenoh-pico/net/zenoh-pico.h
@@ -25,7 +25,7 @@
 #include "zenoh-pico/net/subscribe.h"
 
 #if defined(ZENOH_ZEPHYR)
-#include <zephyr.h>
+#include <kernel.h>
 #endif
 
 #endif /* ZENOH_PICO_NET_H */

--- a/include/zenoh-pico/system/platform/zephyr.h
+++ b/include/zenoh-pico/system/platform/zephyr.h
@@ -16,7 +16,7 @@
 #define ZENOH_PICO_SYSTEM_ZEPHYR_TYPES_H
 
 #include <pthread.h>
-#include <zephyr.h>
+#include <kernel.h>
 
 #include "zenoh-pico/config.h"
 

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -16,7 +16,7 @@
 #include <stddef.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <zephyr.h>
+#include <kernel.h>
 
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/system/platform.h"


### PR DESCRIPTION
On Zephyr commit [7f2ad2e2](https://github.com/zephyrproject-rtos/zephyr/commit/7f2ad2e27d6e887291abcc34fadca8699d495523), Zephyr added a `#warning` on deprecated `#include <zephyr/zephyr.h>` so it create a lot of noise on `zenoh-pico` builds when using newer zephyr commits.