### PR TITLE
Avoid casting on encode and decode enums (#167)

### DIFF
--- a/include/zenoh-pico/protocol/codec.h
+++ b/include/zenoh-pico/protocol/codec.h
@@ -28,8 +28,14 @@
     }
 
 /*------------------ Internal Zenoh-net Macros ------------------*/
-int8_t _z_enum_encode(_z_wbuf_t *wbf, int en);
-int8_t _z_enum_decode(int *en, _z_zbuf_t *zbf);
+int8_t _z_encoding_prefix_encode(_z_wbuf_t *wbf, z_encoding_prefix_t en);
+int8_t _z_encoding_prefix_decode(z_encoding_prefix_t *en, _z_zbuf_t *zbf);
+int8_t _z_consolidation_mode_encode(_z_wbuf_t *wbf, z_consolidation_mode_t en);
+int8_t _z_consolidation_mode_decode(z_consolidation_mode_t *en, _z_zbuf_t *zbf);
+int8_t _z_query_target_encode(_z_wbuf_t *wbf, z_query_target_t en);
+int8_t _z_query_target_decode(z_query_target_t *en, _z_zbuf_t *zbf);
+int8_t _z_whatami_encode(_z_wbuf_t *wbf, z_whatami_t en);
+int8_t _z_whatami_decode(z_whatami_t *en, _z_zbuf_t *zbf);
 
 int8_t _z_uint_encode(_z_wbuf_t *buf, unsigned int v);
 int8_t _z_uint_decode(unsigned int *u, _z_zbuf_t *buf);

--- a/src/protocol/codec.c
+++ b/src/protocol/codec.c
@@ -49,18 +49,50 @@ int8_t _z_period_decode_na(_z_period_t *p, _z_zbuf_t *buf) {
 int8_t _z_period_decode(_z_period_t *p, _z_zbuf_t *buf) { return _z_period_decode_na(p, buf); }
 
 /*------------------ uint8 -------------------*/
-int8_t _z_enum_encode(_z_wbuf_t *wbf, int en) { return _z_wbuf_write(wbf, (uint8_t)en); }
+int8_t _z_encoding_prefix_encode(_z_wbuf_t *wbf, z_encoding_prefix_t en) { return _z_zint_encode(wbf, en); }
 
-int8_t _z_enum_decode(int *en, _z_zbuf_t *zbf) {
+int8_t _z_encoding_prefix_decode(z_encoding_prefix_t *en, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
-    *en = 0;
 
-    if (_z_zbuf_can_read(zbf) == true) {
-        *en = _z_zbuf_read(zbf);
-    } else {
-        _Z_DEBUG("WARNING: Not enough bytes to read\n");
-        ret |= _Z_ERR_MESSAGE_DESERIALIZATION_FAILED;
-    }
+    _z_zint_t tmp;
+    _z_zint_decode(&tmp, zbf);
+    *en = tmp;
+
+    return ret;
+}
+
+int8_t _z_consolidation_mode_encode(_z_wbuf_t *wbf, z_consolidation_mode_t en) { return _z_zint_encode(wbf, en); }
+
+int8_t _z_consolidation_mode_decode(z_consolidation_mode_t *en, _z_zbuf_t *zbf) {
+    int8_t ret = _Z_RES_OK;
+
+    _z_zint_t tmp;
+    _z_zint_decode(&tmp, zbf);
+    *en = tmp;
+
+    return ret;
+}
+
+int8_t _z_query_target_encode(_z_wbuf_t *wbf, z_query_target_t en) { return _z_zint_encode(wbf, en); }
+
+int8_t _z_query_target_decode(z_query_target_t *en, _z_zbuf_t *zbf) {
+    int8_t ret = _Z_RES_OK;
+
+    _z_zint_t tmp;
+    _z_zint_decode(&tmp, zbf);
+    *en = tmp;
+
+    return ret;
+}
+
+int8_t _z_whatami_encode(_z_wbuf_t *wbf, z_whatami_t en) { return _z_zint_encode(wbf, en); }
+
+int8_t _z_whatami_decode(z_whatami_t *en, _z_zbuf_t *zbf) {
+    int8_t ret = _Z_RES_OK;
+
+    _z_zint_t tmp;
+    _z_zint_decode(&tmp, zbf);
+    *en = tmp;
 
     return ret;
 }

--- a/src/protocol/codec.c
+++ b/src/protocol/codec.c
@@ -55,7 +55,7 @@ int8_t _z_encoding_prefix_decode(z_encoding_prefix_t *en, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
 
     _z_zint_t tmp;
-    _z_zint_decode(&tmp, zbf);
+    ret |= _z_zint_decode(&tmp, zbf);
     *en = tmp;
 
     return ret;
@@ -67,7 +67,7 @@ int8_t _z_consolidation_mode_decode(z_consolidation_mode_t *en, _z_zbuf_t *zbf) 
     int8_t ret = _Z_RES_OK;
 
     _z_zint_t tmp;
-    _z_zint_decode(&tmp, zbf);
+    ret |= _z_zint_decode(&tmp, zbf);
     *en = tmp;
 
     return ret;
@@ -79,7 +79,7 @@ int8_t _z_query_target_decode(z_query_target_t *en, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
 
     _z_zint_t tmp;
-    _z_zint_decode(&tmp, zbf);
+    ret |= _z_zint_decode(&tmp, zbf);
     *en = tmp;
 
     return ret;
@@ -91,7 +91,7 @@ int8_t _z_whatami_decode(z_whatami_t *en, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
 
     _z_zint_t tmp;
-    _z_zint_decode(&tmp, zbf);
+    ret |= _z_zint_decode(&tmp, zbf);
     *en = tmp;
 
     return ret;


### PR DESCRIPTION
Fixes https://github.com/eclipse-zenoh/zenoh-pico/issues/167.