### PR TITLE
Split CMake for cross-compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ message(STATUS "Zenoh Level Log: ${ZENOH_DEBUG}")
 
 message(STATUS "Configuring for ${CMAKE_SYSTEM_NAME}")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR POSIX_COMPATIBLE)
   add_definitions(-DZENOH_LINUX)
   set(JNI_PLATFORM_NAME "linux")
 elseif(CMAKE_SYSTEM_NAME MATCHES "BSD")
@@ -109,65 +109,17 @@ endif()
 
 set(Libname "zenohpico")
 
-file(GLOB PublicHeaders "include/*.h"
-  "include/zenoh-pico/*.h"
-  "include/zenoh-pico/api/*.h"
-  "include/zenoh-pico/collections/*.h"
-  "include/zenoh-pico/link/*.h"
-  "include/zenoh-pico/link/config/*.h"
-  "include/zenoh-pico/protocol/*.h"
-  "include/zenoh-pico/session/*.h"
-  "include/zenoh-pico/system/*.h"
-  "include/zenoh-pico/system/link/*.h"
-  "include/zenoh-pico/transport/*.h"
-  "include/zenoh-pico/utils/*.h"
-)
 include_directories(
   ${PROJECT_SOURCE_DIR}/include
 )
 
-file(GLOB Sources "src/*.c"
-  "src/api/*.c"
-  "src/net/*.c"
-  "src/collections/*.c"
-  "src/link/*.c"
-  "src/link/config/*.c"
-  "src/link/unicast/*.c"
-  "src/link/multicast/*.c"
-  "src/protocol/*.c"
-  "src/protocol/keyexpr/*.c"
-  "src/session/*.c"
-  "src/system/*.c"
-  "src/transport/*.c"
-  "src/transport/common/*.c"
-  "src/transport/unicast/*.c"
-  "src/transport/unicast/link/*.c"
-  "src/transport/unicast/link/task/*.c"
-  "src/transport/multicast/*.c"
-  "src/transport/multicast/link/*.c"
-  "src/transport/multicast/link/task/*.c"
-  "src/utils/*.c"
-)
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "BSD")
-  file (GLOB Sources_Unix "src/system/unix/*.c")
-  list(APPEND Sources ${Sources_Unix})
-endif()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
-  file (GLOB Sources_Emscripten "src/system/emscripten/*.c")
-  list(APPEND Sources ${Sources_Emscripten})
-endif()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-  file (GLOB Sources_Windows "src/system/windows/*.c")
-  list(APPEND Sources ${Sources_Windows})
-endif()
+add_subdirectory(include)
+add_subdirectory(src)
 
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 link_directories(${LIBRARY_OUTPUT_PATH})
 
-add_library(${Libname} ${Sources})
+add_library(${Libname} ${ZenohPicoSources})
 
 target_link_libraries(${Libname} Threads::Threads)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2022 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+# ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+
+file(GLOB PublicHeaders "*.h"
+  "zenoh-pico/*.h"
+  "zenoh-pico/api/*.h"
+  "zenoh-pico/collections/*.h"
+  "zenoh-pico/link/*.h"
+  "zenoh-pico/link/config/*.h"
+  "zenoh-pico/protocol/*.h"
+  "zenoh-pico/session/*.h"
+  "zenoh-pico/system/*.h"
+  "zenoh-pico/system/link/*.h"
+  "zenoh-pico/transport/*.h"
+  "zenoh-pico/utils/*.h"
+)
+
+set(PublicHeaders ${PublicHeaders} PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2022 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+# ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+
+file(GLOB Sources "*.c"
+  "api/*.c"
+  "net/*.c"
+  "collections/*.c"
+  "link/*.c"
+  "link/config/*.c"
+  "link/unicast/*.c"
+  "link/multicast/*.c"
+  "protocol/*.c"
+  "protocol/keyexpr/*.c"
+  "session/*.c"
+  "system/*.c"
+  "transport/*.c"
+  "transport/common/*.c"
+  "transport/unicast/*.c"
+  "transport/unicast/link/*.c"
+  "transport/unicast/link/task/*.c"
+  "transport/multicast/*.c"
+  "transport/multicast/link/*.c"
+  "transport/multicast/link/task/*.c"
+  "utils/*.c"
+)
+
+if(POSIX_COMPATIBLE OR
+   CMAKE_SYSTEM_NAME MATCHES "Linux" OR
+   CMAKE_SYSTEM_NAME MATCHES "Darwin" OR
+   CMAKE_SYSTEM_NAME MATCHES "BSD")
+  file (GLOB Sources_Unix "system/unix/*.c")
+  list(APPEND Sources ${Sources_Unix})
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
+  file (GLOB Sources_Emscripten "system/emscripten/*.c")
+  list(APPEND Sources ${Sources_Emscripten})
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  file (GLOB Sources_Windows "system/windows/*.c")
+  list(APPEND Sources ${Sources_Windows})
+endif()
+
+set(ZenohPicoSources ${Sources} PARENT_SCOPE)

--- a/src/system/unix/network.c
+++ b/src/system/unix/network.c
@@ -316,6 +316,7 @@ int8_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_endpoin
                 ret = _Z_ERR_GENERIC;
             }
 
+#ifndef UNIX_NO_MULTICAST_IF
             if (lsockaddr->sa_family == AF_INET) {
                 if ((ret == _Z_RES_OK) &&
                     (setsockopt(sock->_fd, IPPROTO_IP, IP_MULTICAST_IF, &((struct sockaddr_in *)lsockaddr)->sin_addr,
@@ -331,6 +332,7 @@ int8_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_endpoin
             } else {
                 ret = _Z_ERR_GENERIC;
             }
+#endif
 
             // Create lep endpoint
             if (ret == _Z_RES_OK) {


### PR DESCRIPTION
Split CMakeLists into standalone subdirectories so that external projects easily can include the objects that have to be compiled.

Add POSIX_COMPATIBLE macro for any POSIX compliant RTOS can use the UNIX hal layer.

For the UNIX hal layer add the UNIX_NO_MULTICAST_IF define for systems that don't support the IP_MULTICAST_IF socket option can exclude the call, since this can be optional for a small RTOS.