### PR TITLE
Fixed wrong type in serial CRC function

### DIFF
--- a/src/utils/checksum.c
+++ b/src/utils/checksum.c
@@ -15,11 +15,11 @@
 #include "zenoh-pico/utils/checksum.h"
 
 uint32_t _z_crc32(const uint8_t *message, size_t len) {
-    int32_t crc = 0xFFFFFFFF;
+    uint32_t crc = 0xFFFFFFFF;
     for (size_t i = 0; i < len; i++) {
-        crc = crc ^ (int32_t)message[i];
-        for (int j = 0; j < 8; j++) {
-            crc = (crc >> 1) ^ ((int32_t)0x04C11DB7 & (-(crc & (int32_t)1)));
+        crc = crc ^ (uint32_t)message[i];
+        for (uint j = 0; j < 8; j++) {
+            crc = (crc >> 1) ^ ((uint32_t)0x04C11DB7 & (-(crc & (uint32_t)1)));
         }
     }
     return ~crc;

--- a/src/utils/checksum.c
+++ b/src/utils/checksum.c
@@ -18,7 +18,7 @@ uint32_t _z_crc32(const uint8_t *message, size_t len) {
     uint32_t crc = 0xFFFFFFFF;
     for (size_t i = 0; i < len; i++) {
         crc = crc ^ (uint32_t)message[i];
-        for (uint j = 0; j < 8; j++) {
+        for (int j = 0; j < 8; j++) {
             crc = (crc >> 1) ^ ((uint32_t)0x04C11DB7 & (-(crc & (uint32_t)1)));
         }
     }


### PR DESCRIPTION
The CRC function was calculating the wrong CRC due to a regression in the variable type.