### PR TITLE
Add POSIX target for small posix based RTOS's i.e. NuttX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Contributors:
 # ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 project(libzenohpico VERSION 0.7.0.1 LANGUAGES C)
 
@@ -61,8 +61,14 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 
+
+set(CHECK_THREADS "ON")
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_definition(ZENOH_LINUX)
+elseif(POSIX_COMPATIBLE)
+  add_definition(ZENOH_LINUX)
+  set(CHECK_THREADS "OFF")
 elseif(CMAKE_SYSTEM_NAME MATCHES "BSD")
   add_definition(ZENOH_BSD)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -99,7 +105,9 @@ if(SKBUILD)
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+if(CHECK_THREADS)
+  find_package(Threads REQUIRED)
+endif()
 
 if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
   if(UNIX)
@@ -160,7 +168,7 @@ file(GLOB Sources "src/*.c"
 if(WITH_ZEPHYR)
   file (GLOB Sources_Zephyr "src/system/zephyr/*.c")
   list(APPEND Sources ${Sources_Zephyr})
-elseif(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "BSD")
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "BSD" OR POSIX_COMPATIBLE)
   file (GLOB Sources_Unix "src/system/unix/*.c")
   list(APPEND Sources ${Sources_Unix})
 elseif(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
@@ -176,7 +184,9 @@ link_directories(${LIBRARY_OUTPUT_PATH})
 
 target_sources(${Libname} PRIVATE ${Sources})
 
-target_link_libraries(${Libname} Threads::Threads)
+if(CHECK_THREADS)
+  target_link_libraries(${Libname} Threads::Threads)
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(${Libname} rt)

--- a/src/system/unix/network.c
+++ b/src/system/unix/network.c
@@ -316,6 +316,7 @@ int8_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_endpoin
                 ret = _Z_ERR_GENERIC;
             }
 
+#ifndef UNIX_NO_MULTICAST_IF
             if (lsockaddr->sa_family == AF_INET) {
                 if ((ret == _Z_RES_OK) &&
                     (setsockopt(sock->_fd, IPPROTO_IP, IP_MULTICAST_IF, &((struct sockaddr_in *)lsockaddr)->sin_addr,
@@ -331,6 +332,7 @@ int8_t _z_open_udp_multicast(_z_sys_net_socket_t *sock, const _z_sys_net_endpoin
             } else {
                 ret = _Z_ERR_GENERIC;
             }
+#endif
 
             // Create lep endpoint
             if (ret == _Z_RES_OK) {


### PR DESCRIPTION
Adds POSIX_COMPATIBLE CMake variable so that any POSIX compatible operating system i.e. NuttX can include Zenoh-pico as a module in their CMake build system.

Furthermore this adds a define `UNIX_NO_MULTICAST_IF` to disable the `IP_MULTICAST_IF` socketoption which isn't supported in NuttX.