### PR TITLE
NULL task pointers when creation fails.

### DIFF
--- a/src/net/session.c
+++ b/src/net/session.c
@@ -177,6 +177,7 @@ int8_t _zp_start_read_task(_z_session_t *zn) {
                 zn->_tp._transport._unicast._read_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
+                zn->_tp._transport._unicast._read_task = NULL;
             }
         } else
 #endif  // Z_UNICAST_TRANSPORT == 1
@@ -188,6 +189,7 @@ int8_t _zp_start_read_task(_z_session_t *zn) {
                 zn->_tp._transport._multicast._read_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
+                zn->_tp._transport._multicast._read_task = NULL;
             }
         } else
 #endif  // Z_MULTICAST_TRANSPORT == 1
@@ -235,6 +237,7 @@ int8_t _zp_start_lease_task(_z_session_t *zn) {
                 zn->_tp._transport._unicast._lease_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
+                zn->_tp._transport._unicast._lease_task = NULL;
             }
         } else
 #endif  // Z_UNICAST_TRANSPORT == 1
@@ -246,6 +249,7 @@ int8_t _zp_start_lease_task(_z_session_t *zn) {
                 zn->_tp._transport._multicast._lease_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
+                zn->_tp._transport._multicast._lease_task = NULL;
             }
         } else
 #endif  // Z_MULTICAST_TRANSPORT == 1

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -171,13 +171,13 @@ int8_t _zp_start_read_task(_z_session_t *zn) {
 
 #if Z_UNICAST_TRANSPORT == 1
         if (zn->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
-            zn->_tp._transport._unicast._read_task = task;
             zn->_tp._transport._unicast._read_task_running = true;
-            if (_z_task_init(task, NULL, _zp_unicast_read_task, &zn->_tp._transport._unicast) != _Z_RES_OK) {
+            if (_z_task_init(task, NULL, _zp_unicast_read_task, &zn->_tp._transport._unicast) == _Z_RES_OK) {
+                zn->_tp._transport._unicast._read_task = task;
+            } else {
                 zn->_tp._transport._unicast._read_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
-                zn->_tp._transport._unicast._read_task = NULL;
             }
         } else
 #endif  // Z_UNICAST_TRANSPORT == 1
@@ -185,11 +185,12 @@ int8_t _zp_start_read_task(_z_session_t *zn) {
             if (zn->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
             zn->_tp._transport._multicast._read_task = task;
             zn->_tp._transport._multicast._read_task_running = true;
-            if (_z_task_init(task, NULL, _zp_multicast_read_task, &zn->_tp._transport._multicast) != _Z_RES_OK) {
+            if (_z_task_init(task, NULL, _zp_multicast_read_task, &zn->_tp._transport._multicast) == _Z_RES_OK) {
+                zn->_tp._transport._multicast._read_task = task;
+            } else {
                 zn->_tp._transport._multicast._read_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
-                zn->_tp._transport._multicast._read_task = NULL;
             }
         } else
 #endif  // Z_MULTICAST_TRANSPORT == 1
@@ -231,25 +232,25 @@ int8_t _zp_start_lease_task(_z_session_t *zn) {
 
 #if Z_UNICAST_TRANSPORT == 1
         if (zn->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
-            zn->_tp._transport._unicast._lease_task = task;
             zn->_tp._transport._unicast._lease_task_running = true;
-            if (_z_task_init(task, NULL, _zp_unicast_lease_task, &zn->_tp._transport._unicast) != _Z_RES_OK) {
+            if (_z_task_init(task, NULL, _zp_unicast_lease_task, &zn->_tp._transport._unicast) == _Z_RES_OK) {
+                zn->_tp._transport._unicast._lease_task = task;
+            } else {
                 zn->_tp._transport._unicast._lease_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
-                zn->_tp._transport._unicast._lease_task = NULL;
             }
         } else
 #endif  // Z_UNICAST_TRANSPORT == 1
 #if Z_MULTICAST_TRANSPORT == 1
-            if (zn->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
-            zn->_tp._transport._multicast._lease_task = task;
+        if (zn->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
             zn->_tp._transport._multicast._lease_task_running = true;
-            if (_z_task_init(task, NULL, _zp_multicast_lease_task, &zn->_tp._transport._multicast) != _Z_RES_OK) {
+            if (_z_task_init(task, NULL, _zp_multicast_lease_task, &zn->_tp._transport._multicast) == _Z_RES_OK) {
+                zn->_tp._transport._multicast._lease_task = task;
+            } else {
                 zn->_tp._transport._multicast._lease_task_running = false;
                 ret = _Z_ERR_SYSTEM_TASK_FAILED;
                 z_free(task);
-                zn->_tp._transport._multicast._lease_task = NULL;
             }
         } else
 #endif  // Z_MULTICAST_TRANSPORT == 1


### PR DESCRIPTION
If task creation (start read/lease tasks) failed the _z_task_t was freed but the pointer was left in session.  This caused invalid memory access on FreeRTOS based ports (e.g. ESP IDF) when the session was subsequently closed.