### PR TITLE
Session restart example

### DIFF
--- a/examples/zephyr/z_pub_session_retry.c
+++ b/examples/zephyr/z_pub_session_retry.c
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <zenoh-pico.h>
+
+#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
+#if CLIENT_OR_PEER == 0
+#define MODE "client"
+#define PEER ""  // If empty, it will scout
+#elif CLIENT_OR_PEER == 1
+#define MODE "peer"
+#define PEER "udp/224.0.0.225:7447#iface=en0"
+#else
+#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
+#endif
+
+#define KEYEXPR "demo/example/zenoh-pico-pub"
+#define VALUE "[STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!"
+
+int main(int argc, char **argv) {
+
+    while (true) {
+        sleep(5);
+
+        // Initialize Zenoh Session and other parameters
+        z_owned_config_t config = z_config_default();
+        zp_config_insert(z_loan(config), Z_CONFIG_MODE_KEY, z_string_make(MODE));
+        if (strcmp(PEER, "") != 0) {
+            zp_config_insert(z_loan(config), Z_CONFIG_PEER_KEY, z_string_make(PEER));
+        }
+
+        // Open Zenoh session
+        printf("Opening Zenoh Session...");
+        z_owned_session_t s = z_open(z_move(config));
+        if (!z_check(s)) {
+            printf("Unable to open session!\n");
+            exit(-1);
+        }
+        printf("OK\n");
+        bool session_is_valid = true;
+
+        // Start the receive and the session lease loop for zenoh-pico
+        zp_start_read_task(z_loan(s), NULL);
+        zp_start_lease_task(z_loan(s), NULL);
+
+        printf("Declaring publisher for '%s'...", KEYEXPR);
+        z_owned_publisher_t pub = z_declare_publisher(z_loan(s), z_keyexpr(KEYEXPR), NULL);
+        if (!z_check(pub)) {
+            printf("Unable to declare publisher for key expression!\n");
+            exit(-1);
+        }
+        printf("OK\n");
+
+        char buf[256];
+        for (int idx = 0; session_is_valid; ++idx) {
+            sleep(1);
+            sprintf(buf, "[%4d] %s", idx, VALUE);
+            printf("Putting Data ('%s': '%s')...\n", KEYEXPR, buf);
+            int put_res = z_publisher_put(z_loan(pub), (const uint8_t *)buf, strlen(buf), NULL);
+            if (put_res != _Z_RES_OK) {
+                printf("Error publishing message (%d)\n", put_res);
+                session_is_valid = false;
+            }
+            if(!z_check(s)) {
+                printf("Zenoh session has become invalid\n");
+            }
+        }
+
+        printf("Closing Zenoh Session...");
+        z_undeclare_publisher(z_move(pub));
+
+        // Stop the receive and the session lease loop for zenoh-pico
+        zp_stop_read_task(z_loan(s));
+        zp_stop_lease_task(z_loan(s));
+
+        z_close(z_move(s));
+        printf("OK!\n");
+
+    }
+
+    return 0;
+}

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -222,7 +222,7 @@
  */
 #ifndef Z_BATCH_SIZE_RX
 #define Z_BATCH_SIZE_RX \
-    65535  // Warning: changing this value can break the communication
+    3072  // Warning: changing this value can break the communication
            //          with zenohd in the current protocol version.
            //          In the future, it will be possible to negotiate such value.
            // Change it at your own risk.
@@ -232,7 +232,7 @@
  * Defaulf maximum batch size possible to be sent.
  */
 #ifndef Z_BATCH_SIZE_TX
-#define Z_BATCH_SIZE_TX 65535
+#define Z_BATCH_SIZE_TX 3072
 #endif
 
 /**


### PR DESCRIPTION
Hi, 

A couple weeks back I asked on the Discord about how to handle the situation where in a multi-router network, the router that the zenoh-pico client is connected to goes down. The recommendation that I was given was to check whether the session is still valid is by periodically calling `z_check()`. I tried doing just that but it didn't work. Even if the router that the zenoh-pico client was connected to went down for whatever reason, `z_check()` kept returning `true`. For the use-case of a publisher I ended up using the return value from `z_publisher_put()`. This works well for one restart.

The problem that I run into is that the _second_ restart triggers a `USAGE FAULT`:

```
uart:~$ *** Booting Zephyr OS build zephyr-v20701  ***
[00:00:01.642,000] <inf> net_config: Initializing network
[00:00:01.642,000] <inf> net_config: Waiting interface 1 (0x20001c58) to be up...
[00:00:01.931,000] <err> eth_stm32_hal: Failed to enqueue frame into RX queue: -115
[00:00:01.932,000] <inf> net_config: Interface 1 (0x20001c58) coming up
[00:00:01.932,000] <inf> net_config: IPv4 address: 192.0.2.4
[00:00:02.033,000] <inf> net_config: IPv6 address: 2001:db8::2
uart:~$ Opening Zenoh Session...OK
Declaring publisher for 'demo/example/zenoh-pico-pub'...OK
Putting Data ('demo/example/zenoh-pico-pub': '[   0] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   1] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   2] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   3] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   4] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   5] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   6] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   7] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   8] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   9] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  10] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  11] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  12] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  13] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  14] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  15] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[  16] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Error publishing message (-100)
Closing Zenoh Session...OK!
Opening Zenoh Session...OK
Declaring publisher for 'demo/example/zenoh-pico-pub'...OK
Putting Data ('demo/example/zenoh-pico-pub': '[   0] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   1] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   2] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   3] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   4] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   5] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   6] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   7] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   8] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Putting Data ('demo/example/zenoh-pico-pub': '[   9] [STSTM32]{nucleo-F767ZI} Pub from Zenoh-Pico!')...
Error publishing message (-100)
Closing Zenoh Session...OK!
Opening Zenoh Session...OK
Declaring publisher for 'demo/example/zenoh-pico-pub'...OK
[00:00:44.337,000] <err> os: ***** USAGE FAULT *****
[00:00:44.337,000] <err> os:   Illegal load of EXC_RETURN into PC
[00:00:44.337,000] <err> os: r0/a1:  0x200025f0  r1/a2:  0x0802ddff  r2/a3:  0x00000010
[00:00:44.337,000] <err> os: r3/a4:  0xffffffff r12/ip:  0xffffffff r14/lr:  0x0801985f
[00:00:44.337,000] <err> os:  xpsr:  0xe000ec00
[00:00:44.337,000] <err> os: Faulting instruction address (r15/pc): 0x00000000
[00:00:44.337,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:44.337,000] <err> os: Current thread: 0x20002300 (unknown)
[00:00:44.400,000] <err> os: Halting system
```

Setup:
- Microcontroller 1x
  - User code: `z_pub_session_retry.c` 
  - Board: Nucleo-F429zi
  - Build system: PlatformIO as per the [README.md](https://github.com/eclipse-zenoh/zenoh-pico#221-zephyr)
  - OS: ZephyrRTOS v2.7.1 default from PlatformIO
- Router 2x
  - `zenohd` v0.7.0-rc
  - Board: Raspberry Pi CM4
  - OS: Custom buildroot

Steps to reproduce:
1. Follow Zephyr instruction from the zenoh-pico [README.md](https://github.com/eclipse-zenoh/zenoh-pico#221-zephyr) to build and flash the `z_pub_session_retry.c` example from this PR
2. Start a `zenohd` on two different machines that can function has a zenoh router (I started it by running `RUST_LOG=DEBUG zenohd`. The debug output makes it very easy to know which one is connected to the zenoh-pico client)
3. Upload/start the microcontroller running the example
4. Wait for the publisher from the example to start publishing
5. Note which of the two routers the client connected itself to (Let's call it router X)
6. Terminate (Ctrl+C) router X
7. Note that the client reconnects itself to router Y
8. Restart router X
9. Terminate router Y
10. Notice the `USAGE FAULT` on the microcontroller

Expected behavior:
- Be able to switch back and forth between the two routers indefinitely at runtime

My intent with this PR is two easily show the code that I'm using and solve this issue and find the solution to that problem.

I initially ran into a slightly different issue that this one while using a fairly recent version of Zephyr ([30efd04](https://github.com/zephyrproject-rtos/zephyr/tree/30efd04060579e97b6b9967a1d06cd971e72cd5b)) but for the sake of simplicity and removing variables I'm reporting the issue as if I'm using PlatformIO.  I suppose that you guys are all using PlaftormIO for zenoh-pico development?


