### PR TITLE
"docker rmi " of 'FROM' docker fails now

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -89,7 +89,6 @@ crossbuild: check-docker
 		cmake $(CMAKE_OPT) -DPACKAGING=DEB,RPM -DDEBARCH=$(DEBARCH) -DRPMARCH=$(RPMARCH) -B$(CROSSBUILD_DIR)/$(CROSSIMG) && \
 		make VERBOSE=1 -C$(CROSSBUILD_DIR)/$(CROSSIMG) all package"
 	docker rmi $(CROSSIMG_PREFIX)$(CROSSIMG)
-	docker rmi dockcross/$(CROSSIMG)
 
 linux-armv5:
 	CROSSIMG=$@ DEBARCH=arm RPMARCH=arm make crossbuild

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,7 +89,6 @@ crossbuild: check-docker
 		cmake $(CMAKE_OPT) -DPACKAGING=DEB,RPM -DDEBARCH=$(DEBARCH) -DRPMARCH=$(RPMARCH) -B$(CROSSBUILD_DIR)/$(CROSSIMG) && \
 		make VERBOSE=1 -C$(CROSSBUILD_DIR)/$(CROSSIMG) all package"
 	docker rmi $(CROSSIMG_PREFIX)$(CROSSIMG)
-	docker rmi dockcross/$(CROSSIMG)
 
 linux-armv5:
 	CROSSIMG=$@ DEBARCH=arm RPMARCH=arm make crossbuild


### PR DESCRIPTION
Since today it seems that base docker image (the one which was used in "FROM" clause) doesn't appear in the list of the images. Attempt to remove it causes build failure.
Removed command "dorcker rmi" for this image to fix the build failure. 