### PR TITLE
Fix the ReadTheDocs clang dependency

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - libclang-dev
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -17,6 +19,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,4 +48,4 @@ elif platform == "win32":
     raise ValueError("Windows not supported yet for building docs.")
 
 else:
-    Config.set_library_file('/usr/lib/llvm-6.0/lib/libclang.so.1') # Required for readthedocs
+    Config.set_library_file('/usr/lib/llvm-14/lib/libclang.so.1') # Required for readthedocs


### PR DESCRIPTION
It seems like ReadTheDocs uses Ubuntu-22.04 instead Ubuntu-18.04 now.
The clang should also be updated.
I generated my own ReadTheDocs to see whether it makes any difference.

Original one: https://zenoh-pico.readthedocs.io/en/0.7.2-rc/index.html
After update: https://evshary-zenoh-pico.readthedocs.io/en/latest/index.html

There are some display differences on the web page. 
@Mallets Could you please check whether this is acceptable or not?
