### PR TITLE
Fix transport/rx unused-variable warnings

### DIFF
--- a/src/transport/multicast/link/rx.c
+++ b/src/transport/multicast/link/rx.c
@@ -86,7 +86,7 @@ int8_t _z_multicast_recv_t_msg_na(_z_transport_multicast_t *ztm, _z_transport_me
     } while (false);  // The 1-iteration loop to use continue to break the entire loop on error
 
     // Wrap the main buffer for to_read bytes
-    _z_zbuf_t zbuf = _z_zbuf_view(&ztm->_zbuf, to_read);
+    _z_zbuf_view(&ztm->_zbuf, to_read);
 
     if (ret == _Z_RES_OK) {
         _Z_DEBUG(">> \t transport_message_decode\n");

--- a/src/transport/unicast/link/rx.c
+++ b/src/transport/unicast/link/rx.c
@@ -66,7 +66,7 @@ int8_t _z_unicast_recv_t_msg_na(_z_transport_unicast_t *ztu, _z_transport_messag
     } while (false);  // The 1-iteration loop to use continue to break the entire loop on error
 
     // Wrap the main buffer for to_read bytes
-    _z_zbuf_t zbuf = _z_zbuf_view(&ztu->_zbuf, to_read);
+    _z_zbuf_view(&ztu->_zbuf, to_read);
 
     if (ret == _Z_RES_OK) {
         _Z_DEBUG(">> \t transport_message_decode\n");


### PR DESCRIPTION
I'm compiling with werror thus the unused zbuf variable come up as an errror.
Since they aren't used I'm just calling `_z_zbuf_view`