### PR TITLE
Fix #234

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.13)
 project(zenohpico VERSION 0.10.0.0 LANGUAGES C)
 
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 option(BUILD_SHARED_LIBS "Build shared libraries if ON, otherwise build static libraries" ON)
 option(ZENOH_DEBUG "Use this to set the ZENOH_DEBUG variable." 0)


### PR DESCRIPTION
The ```GNUInstallDirs``` is not included by default. It is needed to use the ```CMAKE_INSTALL_LIBDIR``` variable.