### PR TITLE
fix warnings when zenoh-pico included into C++ project

### DIFF
--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -109,7 +109,8 @@ static inline _Bool _z_keyexpr_is_local(const _z_keyexpr_t *key) {
 }
 static inline _z_mapping_t _z_keyexpr_mapping(uint16_t id, _Bool owns_suffix) {
     assert(id <= _Z_KEYEXPR_MAPPING_UNKNOWN_REMOTE);
-    return (_z_mapping_t){._val = (uint16_t)((owns_suffix ? 0x8000 : 0) | id)};
+    _z_mapping_t mapping = {(uint16_t)((owns_suffix ? 0x8000 : 0) | id)};
+    return mapping;
 }
 static inline void _z_keyexpr_set_mapping(_z_keyexpr_t *ke, uint16_t id) {
     assert(id <= _Z_KEYEXPR_MAPPING_UNKNOWN_REMOTE);

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -30,7 +30,10 @@ _z_keyexpr_t _z_keyexpr_duplicate(_z_keyexpr_t src);
 _z_keyexpr_t _z_keyexpr_to_owned(_z_keyexpr_t src);
 _z_keyexpr_t _z_keyexpr_alias(_z_keyexpr_t src);
 _z_keyexpr_t _z_keyexpr_steal(_Z_MOVE(_z_keyexpr_t) src);
-static inline _z_keyexpr_t _z_keyexpr_null(void) { return (_z_keyexpr_t){._id = 0, ._mapping = {0}, ._suffix = NULL}; }
+static inline _z_keyexpr_t _z_keyexpr_null(void) {
+    _z_keyexpr_t keyexpr = {0, {0}, NULL};
+    return keyexpr;
+}
 _z_timestamp_t _z_timestamp_duplicate(const _z_timestamp_t *tstamp);
 void _z_timestamp_clear(_z_timestamp_t *tstamp);
 void _z_keyexpr_clear(_z_keyexpr_t *rk);


### PR DESCRIPTION
when zenoh-pico headers are included into C++ sources the warnings:
"ISO C++ forbids compound-literals" and "designated initalizers forbidden in lower than C++20" appears.
This update fixes this.