### PR TITLE
Remove typos in constants and comments

### DIFF
--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -46,7 +46,7 @@
                   z_owned_str_array_t : z_str_array_loan              \
             )(&x)
 /**
- * Defines a generic function for droping any of the ``z_owned_X_t`` types.
+ * Defines a generic function for dropping any of the ``z_owned_X_t`` types.
  *
  * Parameters:
  *   x: The instance to drop.
@@ -75,7 +75,7 @@
  * Defines a generic function for making null object of any of the ``z_owned_X_t`` types.
  *
  * Returns:
- *   Returns the unitialized instance of `x`.
+ *   Returns the uninitialized instance of `x`.
  */
 #define z_null(x) (*x = _Generic((x), \
                   z_owned_session_t * : z_session_null,                             \
@@ -193,7 +193,7 @@
  * Defines a generic function for making null object of any of the ``z_owned_X_t`` types.
  *
  * Returns:
- *   Returns the unitialized instance of `x`.
+ *   Returns the uninitialized instance of `x`.
  */
 #define z_null(x) (*x = _Generic((x), \
                   z_owned_session_t * : z_session_null,                             \
@@ -216,15 +216,15 @@
 
 // clang-format on
 
-#define _z_closure_overloader(callback, droper, ctx, ...) \
-    { .call = callback, .drop = droper, .context = ctx }
+#define _z_closure_overloader(callback, dropper, ctx, ...) \
+    { .call = callback, .drop = dropper, .context = ctx }
 
 /**
  * Defines a variadic macro to ease the definition of callback closures.
  *
  * Parameters:
  *   callback: the typical ``callback`` function. ``context`` will be passed as its last argument.
- *   droper: allows the callback's state to be freed. ``context`` will be passed as its last argument.
+ *   dropper: allows the callback's state to be freed. ``context`` will be passed as its last argument.
  *   context: a pointer to an arbitrary state.
  *
  * Returns:
@@ -334,8 +334,8 @@ inline void z_call(const z_owned_closure_zid_t &closure, const z_id_t *zid)
     { z_closure_zid_call(&closure, zid); }
 // clang-format on
 
-#define _z_closure_overloader(callback, droper, ctx, ...) \
-    { .context = const_cast<void *>(static_cast<const void *>(ctx)), .call = callback, .drop = droper }
+#define _z_closure_overloader(callback, dropper, ctx, ...) \
+    { .context = const_cast<void *>(static_cast<const void *>(ctx)), .call = callback, .drop = dropper }
 #define z_closure(...) _z_closure_overloader(__VA_ARGS__, NULL, NULL)
 #define z_move(x) (&x)
 

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -73,7 +73,7 @@ z_keyexpr_t z_keyexpr_unchecked(const char *name);
 /**
  * Get null-terminated string departing from a :c:type:`z_keyexpr_t`.
  *
- * If given keyexpr contains a declared keyexpr, the resulting owned string will be unitialized.
+ * If given keyexpr contains a declared keyexpr, the resulting owned string will be uninitialized.
  * In that case, the user must use :c:func:`zp_keyexpr_resolve` to resolve the nesting declarations
  * and get its full expanded representation.
  *
@@ -99,7 +99,7 @@ z_bytes_t z_keyexpr_as_bytes(z_keyexpr_t keyexpr);
 
 /**
  * Constructs a null-terminated string departing from a :c:type:`z_keyexpr_t` for a given :c:type:`z_session_t`.
- * The user is responsible of droping the returned string using ``z_free``.
+ * The user is responsible of dropping the returned string using ``z_free``.
  *
  * Parameters:
  *   zs: A loaned instance of the the :c:type:`z_session_t` to resolve the keyexpr.
@@ -471,7 +471,7 @@ z_query_consolidation_t z_query_consolidation_latest(void);
  * Monotonic consolidation.
  *
  * This strategy offers the best latency. Replies are directly transmitted to the application when received
- * without needing to wait for all replies. This mode does not garantee that there will be no duplicates.
+ * without needing to wait for all replies. This mode does not guarantee that there will be no duplicates.
  *
  * Returns:
  *   Returns the constructed :c:type:`z_query_consolidation_t`.
@@ -481,7 +481,7 @@ z_query_consolidation_t z_query_consolidation_monotonic(void);
 /**
  * No consolidation.
  *
- * This strategy is usefull when querying timeseries data bases or when using quorums.
+ * This strategy is useful when querying timeseries data bases or when using quorums.
  *
  * Returns:
  *   Returns the constructed :c:type:`z_query_consolidation_t`.
@@ -697,7 +697,7 @@ _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid)
  *
  * Parameters:
  *   config: A moved instance of :c:type:`z_owned_scouting_config_t` containing the set properties to configure the
- * scouting. callback: A moved instance of :c:type:`z_owned_closure_hello_t` containg the callbacks to be called.
+ * scouting. callback: A moved instance of :c:type:`z_owned_closure_hello_t` containing the callbacks to be called.
  *
  * Returns:
  *   Returns ``0`` if the scouting is successful triggered, or a ``negative value`` otherwise.
@@ -748,7 +748,7 @@ int8_t z_close(z_owned_session_t *zs);
  *
  * Parameters:
  *   zs: A loaned instance of the the :c:type:`z_session_t` to inquiry.
- *   callback: A moved instance of :c:type:`z_owned_closure_zid_t` containg the callbacks to be called.
+ *   callback: A moved instance of :c:type:`z_owned_closure_zid_t` containing the callbacks to be called.
  *
  * Returns:
  *   Returns ``0`` if the info is successful triggered, or a ``negative value`` otherwise.
@@ -763,7 +763,7 @@ int8_t z_info_peers_zid(const z_session_t zs, z_owned_closure_zid_t *callback);
  *
  * Parameters:
  *   zs: A loaned instance of the the :c:type:`z_session_t` to inquiry.
- *   callback: A moved instance of :c:type:`z_owned_closure_zid_t` containg the callbacks to be called.
+ *   callback: A moved instance of :c:type:`z_owned_closure_zid_t` containing the callbacks to be called.
  *
  * Returns:
  *   Returns ``0`` if the info is successful triggered, or a ``negative value`` otherwise.
@@ -844,8 +844,8 @@ z_get_options_t z_get_options_default(void);
  *   zs: A loaned instance of the the :c:type:`z_session_t` through where data will be put.
  *   keyexpr: A loaned instance of :c:type:`z_keyexpr_t` to put.
  *   parameters: Pointer to the parameters as a null-terminated string.
- *   callback: A moved instance of :c:type:`z_owned_closure_reply_t` containg the callbacks to be called.
- *   options: The get options to be aplied in the distributed query.
+ *   callback: A moved instance of :c:type:`z_owned_closure_reply_t` containing the callbacks to be called.
+ *   options: The get options to be applied in the distributed query.
  *
  * Returns:
  *   Returns ``0`` if the put operation is successful, or a ``negative value`` otherwise.
@@ -1078,7 +1078,7 @@ z_pull_subscriber_options_t z_pull_subscriber_options_default(void);
  * Parameters:
  *   zs: A loaned instance of the the :c:type:`z_session_t` where to declare the subscriber.
  *   keyexpr: A loaned instance of :c:type:`z_keyexpr_t` to associate with the subscriber.
- *   callback: A moved instance of :c:type:`z_owned_closure_sample_t` containg the callbacks to be called and the
+ *   callback: A moved instance of :c:type:`z_owned_closure_sample_t` containing the callbacks to be called and the
  * context to pass to them. options: The options to apply to the pull subscriber. If ``NULL`` is passed, the default
  * options will be applied.
  *
@@ -1142,7 +1142,7 @@ z_queryable_options_t z_queryable_options_default(void);
  * Parameters:
  *   zs: A loaned instance of the the :c:type:`z_session_t` where to declare the subscriber.
  *   keyexpr: A loaned instance of :c:type:`z_keyexpr_t` to associate with the subscriber.
- *   callback: A moved instance of :c:type:`z_owned_closure_query_t` containg the callbacks to be called and the context
+ *   callback: A moved instance of :c:type:`z_owned_closure_query_t` containing the callbacks to be called and the context
  * to pass to them. options: The options to apply to the queryable. If ``NULL`` is passed, the default options will be
  * applied.
  *
@@ -1246,7 +1246,7 @@ z_value_t z_reply_err(const z_owned_reply_t *reply);
  */
 _Bool z_value_is_initialized(z_value_t *value);
 
-/************* Multi Thread Taks helpers **************/
+/************* Multi Thread Tasks helpers **************/
 /**
  * Constructs the default values for the session read task.
  *

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -57,7 +57,7 @@
 #define Z_CONFIG_PASSWORD_KEY 0x44
 
 /**
- * Activates/Desactivates multicast scouting.
+ * Activates/Deactivates multicast scouting.
  * Accepted values : `false`, `true`.
  * Default value : `true`.
  */
@@ -223,20 +223,20 @@
 #endif
 
 /**
- * Defaulf maximum batch size possible to be received or sent.
+ * Default maximum batch size possible to be received or sent.
  */
 #ifndef Z_BATCH_UNICAST_SIZE
 #define Z_BATCH_UNICAST_SIZE 65535
 #endif
 /**
- * Defaulf maximum batch size possible to be received or sent.
+ * Default maximum batch size possible to be received or sent.
  */
 #ifndef Z_BATCH_MULTICAST_SIZE
 #define Z_BATCH_MULTICAST_SIZE 8192
 #endif
 
 /**
- * Defaulf maximum size for fragmented messages.
+ * Default maximum size for fragmented messages.
  */
 #ifndef Z_FRAG_MAX_SIZE
 #define Z_FRAG_MAX_SIZE 300000

--- a/include/zenoh-pico/link/link.h
+++ b/include/zenoh-pico/link/link.h
@@ -47,18 +47,18 @@
  *
  * Enumerators:
  *     Z_LINK_CAPABILITY_NONE: Bitmask to define that link has no capabilities.
- *     Z_LINK_CAPABILITY_RELIEABLE: Bitmask to define and check if link is reliable.
+ *     Z_LINK_CAPABILITY_RELIABLE: Bitmask to define and check if link is reliable.
  *     Z_LINK_CAPABILITY_STREAMED: Bitmask to define and check if link is streamed.
  *     Z_LINK_CAPABILITY_MULTICAST: Bitmask to define and check if link is multicast.
  */
 typedef enum {
     Z_LINK_CAPABILITY_NONE = 0x00,       // 0
-    Z_LINK_CAPABILITY_RELIEABLE = 0x01,  // 1 << 0
+    Z_LINK_CAPABILITY_RELIABLE = 0x01,  // 1 << 0
     Z_LINK_CAPABILITY_STREAMED = 0x02,   // 1 << 1
     Z_LINK_CAPABILITY_MULTICAST = 0x04   // 1 << 2
 } _z_link_capabilities_t;
 
-#define _Z_LINK_IS_RELIABLE(X) ((X & Z_LINK_CAPABILITY_RELIEABLE) == Z_LINK_CAPABILITY_RELIEABLE)
+#define _Z_LINK_IS_RELIABLE(X) ((X & Z_LINK_CAPABILITY_RELIABLE) == Z_LINK_CAPABILITY_RELIABLE)
 #define _Z_LINK_IS_STREAMED(X) ((X & Z_LINK_CAPABILITY_STREAMED) == Z_LINK_CAPABILITY_STREAMED)
 #define _Z_LINK_IS_MULTICAST(X) ((X & Z_LINK_CAPABILITY_MULTICAST) == Z_LINK_CAPABILITY_MULTICAST)
 

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -34,7 +34,7 @@
  *     what: A what bitmask of zenoh entities kind to scout for.
  *     zid: The ZenohID of the scouting origin.
  *     locator: The locator where to scout.
- *     timeout: The time that should be spent scouting before returnng the results.
+ *     timeout: The time that should be spent scouting before returning the results.
  */
 void _z_scout(const z_what_t what, const _z_id_t zid, const char *locator, const uint32_t timeout,
               _z_hello_handler_t callback, void *arg_call, _z_drop_handler_t dropper, void *arg_drop);

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -90,7 +90,7 @@ void _z_close(_z_session_t *session);
  */
 _z_config_t *_z_info(const _z_session_t *session);
 
-/*------------------ Zenoh-Pico Session Management Auxiliar------------------*/
+/*------------------ Zenoh-Pico Session Management Auxiliary ------------------*/
 /**
  * Read from the network. This function should be called manually called when
  * the read loop has not been started, e.g., when running in a single thread.

--- a/include/zenoh-pico/net/zenoh-pico.h
+++ b/include/zenoh-pico/net/zenoh-pico.h
@@ -20,7 +20,6 @@
 #include "zenoh-pico/net/primitives.h"
 #include "zenoh-pico/net/publish.h"
 #include "zenoh-pico/net/query.h"
-#include "zenoh-pico/net/resource.h"
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/net/subscribe.h"
 

--- a/include/zenoh-pico/protocol/codec/ext.h
+++ b/include/zenoh-pico/protocol/codec/ext.h
@@ -28,7 +28,7 @@ int8_t _z_msg_ext_decode_na(_z_msg_ext_t *ext, _z_zbuf_t *zbf, _Bool *has_next);
 int8_t _z_msg_ext_vec_encode(_z_wbuf_t *wbf, const _z_msg_ext_vec_t *extensions);
 int8_t _z_msg_ext_vec_decode(_z_msg_ext_vec_t *extensions, _z_zbuf_t *zbf);
 /**
- * Iterates through the extensions in `zbf`, assuming at least one is present at its begining
+ * Iterates through the extensions in `zbf`, assuming at least one is present at its beginning
  * (calling this function otherwise is UB). Short-circuits if `callback` returns a non-zero value.
  *
  * `callback` will receive `context` as its second argument, and may "steal" its first argument by
@@ -36,7 +36,7 @@ int8_t _z_msg_ext_vec_decode(_z_msg_ext_vec_t *extensions, _z_zbuf_t *zbf);
  */
 int8_t _z_msg_ext_decode_iter(_z_zbuf_t *zbf, int8_t (*callback)(_z_msg_ext_t *, void *), void *context);
 /**
- * Iterates through the extensions in `zbf`, assuming at least one is present at its begining.
+ * Iterates through the extensions in `zbf`, assuming at least one is present at its beginning.
  * Returns `_Z_ERR_MESSAGE_EXTENSION_MANDATORY_AND_UNKNOWN` if a mandatory extension is found,
  * `_Z_RES_OK` otherwise.
  */

--- a/include/zenoh-pico/protocol/definitions/transport.h
+++ b/include/zenoh-pico/protocol/definitions/transport.h
@@ -111,7 +111,7 @@
 // +---------------+
 //
 // (#) ZID length. If Flag(I)==1 it indicates how many bytes are used for the ZenohID bytes.
-//     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual lenght is computed as:
+//     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual length is computed as:
 //         real_zid_len := 1 + zid_len
 //
 // (*) What. It indicates a bitmap of WhatAmI interests.
@@ -138,7 +138,7 @@ void _z_s_msg_scout_clear(_z_s_msg_scout_t *msg);
 //     1) in response to a SCOUT message;
 //     2) to (periodically) advertise (e.g., on multicast) the Peer and the locators it is reachable at;
 //     3) in a already established session to update the corresponding peer on the new capabilities
-//        (i.e., whatmai) and/or new set of locators (i.e., added or deleted).
+//        (i.e., whatami) and/or new set of locators (i.e., added or deleted).
 // Locators are expressed as:
 // <code>
 //  udp/192.168.0.2:1234
@@ -285,7 +285,7 @@ void _z_t_msg_join_clear(_z_t_msg_join_t *msg);
 //
 // (#) ZID length. It indicates how many bytes are used for the ZenohID bytes.
 //     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual
-//     lenght is computed as:
+//     length is computed as:
 //         real_zid_len := 1 + zid_len
 //
 // (+) Sequence Number/ID resolution. It indicates the resolution and
@@ -315,11 +315,11 @@ typedef struct {
 void _z_t_msg_init_clear(_z_t_msg_init_t *msg);
 
 /*------------------ Open Message ------------------*/
-// NOTE: 16 bits (2 bytes) may be prepended to the serialized message indicating the total lenght
-//       in bytes of the message, resulting in the maximum lenght of a message being 65_535 bytes.
+// NOTE: 16 bits (2 bytes) may be prepended to the serialized message indicating the total length
+//       in bytes of the message, resulting in the maximum length of a message being 65_535 bytes.
 //       This is necessary in those stream-oriented transports (e.g., TCP) that do not preserve
 //       the boundary of the serialized messages. The length is encoded as little-endian.
-//       In any case, the lenght of a message must not exceed 65_535 bytes.
+//       In any case, the length of a message must not exceed 65_535 bytes.
 //
 // The OPEN message is sent on a link to finally open an initialized session with the peer.
 //
@@ -361,7 +361,7 @@ void _z_t_msg_open_clear(_z_t_msg_open_t *msg);
 //
 // The CLOSE message is sent in any of the following two cases:
 //     1) in response to an OPEN message which is not accepted;
-//     2) at any time to arbitrarly close the session with the corresponding peer.
+//     2) at any time to arbitrarily close the session with the corresponding peer.
 //
 // Flags:
 // - S: Session Close  if S==1 Session close or S==0 Link close
@@ -451,7 +451,7 @@ void _z_t_msg_frame_clear(_z_t_msg_frame_t *msg);
 
 /*------------------ Fragment Message ------------------*/
 // The Fragment message is used to transmit on the wire large Zenoh Message that require fragmentation
-// because they are larger thatn the maximum batch size (i.e. 2^16-1) and/or the link MTU.
+// because they are larger than the maximum batch size (i.e. 2^16-1) and/or the link MTU.
 //
 // The [`Fragment`] message flow is the following:
 //

--- a/include/zenoh-pico/utils/string.h
+++ b/include/zenoh-pico/utils/string.h
@@ -30,7 +30,7 @@ typedef struct {
  * The reverse equivalent of libc's `strstr`.
  *
  * Returns NULL if the needle is not found.
- * If found, the return pointer will point to the end of the last occuring
+ * If found, the return pointer will point to the end of the last occurring
  * needle within the haystack.
  */
 char const *_z_rstrstr(const char *haystack_start, const char *haystack_end, const char *needle);
@@ -39,7 +39,7 @@ char const *_z_rstrstr(const char *haystack_start, const char *haystack_end, con
  * A non-null-terminated haystack equivalent of libc's `strstr`.
  *
  * Returns NULL if the needle is not found.
- * If found, the return pointer will point to the start of the first occurence
+ * If found, the return pointer will point to the start of the first occurrence
  * of the needle within the haystack.
  */
 char const *_z_strstr(char const *haystack_start, char const *haystack_end, const char *needle_start);

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -192,7 +192,7 @@ size_t _z_locator_strlen(const _z_locator_t *l) {
         size_t md_len = _z_locator_metadata_strlen(&l->_metadata);
         if (md_len > (size_t)0) {
             ret = ret + (size_t)1;  // Locator metadata separator
-            ret = ret + md_len;     // Locator medatada content
+            ret = ret + md_len;     // Locator metadata content
         }
     }
     return ret;

--- a/src/link/unicast/tcp.c
+++ b/src/link/unicast/tcp.c
@@ -156,7 +156,7 @@ uint16_t _z_get_link_mtu_tcp(void) {
 int8_t _z_new_link_tcp(_z_link_t *zl, _z_endpoint_t *endpoint) {
     int8_t ret = _Z_RES_OK;
 
-    zl->_capabilities = Z_LINK_CAPABILITY_RELIEABLE | Z_LINK_CAPABILITY_STREAMED;
+    zl->_capabilities = Z_LINK_CAPABILITY_RELIABLE | Z_LINK_CAPABILITY_STREAMED;
     zl->_mtu = _z_get_link_mtu_tcp();
 
     zl->_endpoint = *endpoint;

--- a/src/link/unicast/ws.c
+++ b/src/link/unicast/ws.c
@@ -157,7 +157,7 @@ uint16_t _z_get_link_mtu_ws(void) {
 int8_t _z_new_link_ws(_z_link_t *zl, _z_endpoint_t *endpoint) {
     int8_t ret = _Z_RES_OK;
 
-    zl->_capabilities = Z_LINK_CAPABILITY_RELIEABLE;
+    zl->_capabilities = Z_LINK_CAPABILITY_RELIABLE;
     zl->_mtu = _z_get_link_mtu_ws();
 
     zl->_endpoint = *endpoint;

--- a/src/protocol/codec.c
+++ b/src/protocol/codec.c
@@ -319,7 +319,7 @@ int8_t _z_bytes_val_decode_na(_z_bytes_t *bs, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
 
     if (ret == _Z_RES_OK) {
-        if (_z_zbuf_len(zbf) >= bs->len) {                           // Check if we have enought bytes to read
+        if (_z_zbuf_len(zbf) >= bs->len) {                           // Check if we have enough bytes to read
             *bs = _z_bytes_wrap(_z_zbuf_get_rptr(zbf), bs->len);     // Decode without allocating
             _z_zbuf_set_rpos(zbf, _z_zbuf_get_rpos(zbf) + bs->len);  // Move the read position
         } else {

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -201,7 +201,7 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
                     // No need to store the whole reply in the monotonic mode.
                     _z_reply_t partial_reply;
                     (void)memset(&partial_reply, 0,
-                                 sizeof(_z_reply_t));  // Avoid warnings on uninitialised values on the reply
+                                 sizeof(_z_reply_t));  // Avoid warnings on uninitialized values on the reply
                     partial_reply.data.sample.keyexpr = _z_keyexpr_duplicate(reply.data.sample.keyexpr);
                     pen_rep->_reply = partial_reply;
                 } else {

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -98,7 +98,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
                                                                   //   or will release the suffix as well
     }
 
-    // Recursevely go through all the RIDs
+    // Recursively go through all the RIDs
     _z_zint_t id = keyexpr->_id;
     uint16_t mapping = _z_keyexpr_mapping_id(keyexpr);
     while (id != Z_RESOURCE_ID_NONE) {

--- a/src/system/arduino/opencr/network.cpp
+++ b/src/system/arduino/opencr/network.cpp
@@ -186,7 +186,7 @@ void _z_close_udp_unicast(_z_sys_net_socket_t *sock) {
 
 size_t _z_read_udp_unicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
     // Block until something to read
-    // FIXME: provide somekind of timeout functionality
+    // FIXME: provide some kind of timeout functionality
     ssize_t rb = 0;
     do {
         rb = sock._udp->parsePacket();
@@ -282,7 +282,7 @@ void _z_close_udp_multicast(_z_sys_net_socket_t *sockrecv, _z_sys_net_socket_t *
 size_t _z_read_udp_multicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len, const _z_sys_net_endpoint_t lep,
                              _z_bytes_t *addr) {
     // Block until something to read
-    // FIXME: provide somekind of timeout functionality
+    // FIXME: provide some kind of timeout functionality
     ssize_t rb = 0;
     do {
         rb = sock._udp->parsePacket();

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -88,7 +88,7 @@ int8_t _z_link_send_t_msg(const _z_link_t *zl, const _z_transport_message_t *t_m
     // Encode the session message
     ret = _z_transport_message_encode(&wbf, t_msg);
     if (ret == _Z_RES_OK) {
-        // Write the message legnth in the reserved space if needed
+        // Write the message length in the reserved space if needed
         if (_Z_LINK_IS_STREAMED(zl->_capabilities) == true) {
             size_t len = _z_wbuf_len(&wbf) - _Z_MSG_LEN_ENC_SIZE;
             for (uint8_t i = 0; i < _Z_MSG_LEN_ENC_SIZE; i++) {

--- a/src/transport/multicast/link/tx.c
+++ b/src/transport/multicast/link/tx.c
@@ -54,7 +54,7 @@ int8_t _z_multicast_send_t_msg(_z_transport_multicast_t *ztm, const _z_transport
     // Encode the session message
     ret = _z_transport_message_encode(&ztm->_wbuf, t_msg);
     if (ret == _Z_RES_OK) {
-        // Write the message legnth in the reserved space if needed
+        // Write the message length in the reserved space if needed
         __unsafe_z_finalize_wbuf(&ztm->_wbuf, _Z_LINK_IS_STREAMED(ztm->_link._capabilities));
         // Send the wbuf on the socket
         ret = _z_link_send_wbuf(&ztm->_link, &ztm->_wbuf);
@@ -105,7 +105,7 @@ int8_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_m
         if (ret == _Z_RES_OK) {
             ret = _z_network_message_encode(&ztm->_wbuf, n_msg);  // Encode the network message
             if (ret == _Z_RES_OK) {
-                // Write the message legnth in the reserved space if needed
+                // Write the message length in the reserved space if needed
                 __unsafe_z_finalize_wbuf(&ztm->_wbuf, _Z_LINK_IS_STREAMED(ztm->_link._capabilities));
 
                 ret = _z_link_send_wbuf(&ztm->_link, &ztm->_wbuf);  // Send the wbuf on the socket

--- a/src/transport/unicast/link/rx.c
+++ b/src/transport/unicast/link/rx.c
@@ -97,7 +97,7 @@ int8_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_trans
             // Check if the SN is correct
             if (_Z_HAS_FLAG(t_msg->_header, _Z_FLAG_T_FRAME_R) == true) {
                 // @TODO: amend once reliability is in place. For the time being only
-                //        monothonic SNs are ensured
+                //        monotonic SNs are ensured
                 if (_z_sn_precedes(ztu->_sn_res, ztu->_sn_rx_reliable, t_msg->_body._frame._sn) == true) {
                     ztu->_sn_rx_reliable = t_msg->_body._frame._sn;
                 } else {
@@ -133,7 +133,7 @@ int8_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_trans
 
             _Bool drop = false;
             if ((_z_wbuf_len(dbuf) + t_msg->_body._fragment._payload.len) > Z_FRAG_MAX_SIZE) {
-                // Filling the wbuf capacity as a way to signling the last fragment to reset the dbuf
+                // Filling the wbuf capacity as a way to signal the last fragment to reset the dbuf
                 // Otherwise, last (smaller) fragments can be understood as a complete message
                 _z_wbuf_write_bytes(dbuf, t_msg->_body._fragment._payload.start, 0, _z_wbuf_space_left(dbuf));
                 drop = true;

--- a/src/transport/unicast/link/tx.c
+++ b/src/transport/unicast/link/tx.c
@@ -57,7 +57,7 @@ int8_t _z_unicast_send_t_msg(_z_transport_unicast_t *ztu, const _z_transport_mes
     // Encode the session message
     ret = _z_transport_message_encode(&ztu->_wbuf, t_msg);
     if (ret == _Z_RES_OK) {
-        // Write the message legnth in the reserved space if needed
+        // Write the message length in the reserved space if needed
         __unsafe_z_finalize_wbuf(&ztu->_wbuf, _Z_LINK_IS_STREAMED(ztu->_link._capabilities));
         // Send the wbuf on the socket
         ret = _z_link_send_wbuf(&ztu->_link, &ztu->_wbuf);
@@ -108,7 +108,7 @@ int8_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_msg
         if (ret == _Z_RES_OK) {
             ret = _z_network_message_encode(&ztu->_wbuf, n_msg);  // Encode the network message
             if (ret == _Z_RES_OK) {
-                // Write the message legnth in the reserved space if needed
+                // Write the message length in the reserved space if needed
                 __unsafe_z_finalize_wbuf(&ztu->_wbuf, _Z_LINK_IS_STREAMED(ztu->_link._capabilities));
 
                 if (ztu->_wbuf._ioss._len == 1) {

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
 
     z_sleep_s(SLEEP);
 
-    // Write data from firt session
+    // Write data from first session
     size_t len = MSG_LEN;
     uint8_t *payload = (uint8_t *)z_malloc(len);
     memset(payload, 1, MSG_LEN);
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
         assert(queries >= expected);
     queries = 0;
 
-    // Wait to receive all the expectred replies
+    // Wait to receive all the expected replies
     now = z_clock_now();
     while (replies < expected) {
         assert(z_clock_elapsed_s(&now) < TIMEOUT);

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
         subs2 = _z_list_push(subs2, sub);
     }
 
-    // Write data from firt session
+    // Write data from first session
     size_t len = MSG_LEN;
     uint8_t *payload = (uint8_t *)z_malloc(len);
     memset(payload, 1, MSG_LEN);


### PR DESCRIPTION
Going through the repo, I noticed some typos in both comments and constants and decided to fix them.