### PR TITLE
removed using namespace std

### DIFF
--- a/include/zenoh-pico/collections/pointer.h
+++ b/include/zenoh-pico/collections/pointer.h
@@ -26,7 +26,6 @@
 #else
 #include <atomic>
 #define z_atomic(X) std::atomic<X>
-using namespace std;
 #endif
 
 /*------------------ Internal Array Macros ------------------*/


### PR DESCRIPTION
Headers should not leak global "using namespace" statements. This causes unexpected issues in the code which include such headers. See explanation here for example https://stackoverflow.com/questions/5849457/using-namespace-in-c-headers