### PR TITLE
Adapt to PlatformIO Zephyr update

### DIFF
--- a/.github/workflows/zephyr.yaml
+++ b/.github/workflows/zephyr.yaml
@@ -39,8 +39,6 @@ jobs:
         run: |
           curl -fsSL -o get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py
           python3 get-platformio.py
-          . $HOME/.platformio/penv/bin/activate
-          platformio update
 
       - name: Set up project
         run: |

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -17,7 +17,7 @@
 #if KERNEL_VERSION_MAJOR == 2
 #include <random/rand32.h>
 #else
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
Last week PlatformIO updated their Zephyr package to Zephyr 3.5, it created some issue (#285) that are now solved, and it soft deprecated some things. 

This PR updates the deprecated command/header.