### PR TITLE
Clear buffer when done processing fragmented data to free the memory

### DIFF
--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -143,6 +143,9 @@ int8_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_m
                         }
                     }
                 }
+
+                // Clear the buffer as it's no longer required
+                _z_wbuf_clear (&fbf);
             }
         }
 

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -145,7 +145,7 @@ int8_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_m
                 }
 
                 // Clear the buffer as it's no longer required
-                _z_wbuf_clear (&fbf);
+                _z_wbuf_clear(&fbf);
             }
         }
 

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -152,6 +152,9 @@ int8_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_msg
                         }
                     }
                 }
+
+                // Clear the buffer as it's no longer required
+                _z_wbuf_clear (&fbf);
             }
         }
 

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -154,7 +154,7 @@ int8_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_msg
                 }
 
                 // Clear the buffer as it's no longer required
-                _z_wbuf_clear (&fbf);
+                _z_wbuf_clear(&fbf);
             }
         }
 


### PR DESCRIPTION
This PR attempts to fix #288 by clearing the contents of the _z_wbuf_t created when processing fragmented data. With this fix memory usage no longer increases over time.