### PR TITLE
Remove invalid free of value pointer into argv array.

### DIFF
--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -113,9 +113,6 @@ int main(int argc, char **argv) {
 
     z_close(z_move(s));
 
-    if (value != default_value) {
-        free(value);
-    }
     return 0;
 }
 #else


### PR DESCRIPTION
Where the user has overridden the value to be sent the value pointer will point to memory within the argv array. As such the memory should not be freed. This PR removes the invalid free. Fixes #284.