### PR TITLE
Recopy key instead of steal when undeclaring

### DIFF
--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -129,16 +129,16 @@ _z_declaration_t _z_make_decl_keyexpr(uint16_t id, _Z_MOVE(_z_keyexpr_t) key);
 _z_declaration_t _z_make_undecl_keyexpr(uint16_t id);
 
 _z_declaration_t _z_make_decl_subscriber(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, _Bool reliable, _Bool pull_mode);
-_z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key);
+_z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
 _z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint32_t distance, uint8_t complete);
-_z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key);
+_z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
 _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id);
-_z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key);
+_z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
 _z_declaration_t _z_make_decl_interest(_Z_MOVE(_z_keyexpr_t) key, uint32_t id);
-_z_declaration_t _z_make_undecl_interest(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key);
+_z_declaration_t _z_make_undecl_interest(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 _z_declaration_t _z_make_final_decl(uint32_t id);
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_DECLARATIONS_H */

--- a/src/protocol/definitions/declarations.c
+++ b/src/protocol/definitions/declarations.c
@@ -16,7 +16,7 @@
 
 #include "zenoh-pico/protocol/keyexpr.h"
 
-void _z_declaration_clear(_z_declaration_t* decl) {
+void _z_declaration_clear(_z_declaration_t *decl) {
     switch (decl->_tag) {
         case _Z_DECL_KEXPR: {
             _z_keyexpr_clear(&decl->_body._decl_kexpr._keyexpr);
@@ -76,9 +76,9 @@ _z_declaration_t _z_make_decl_subscriber(_Z_MOVE(_z_keyexpr_t) key, uint32_t id,
                                        ._keyexpr = _z_keyexpr_steal(key),
                                        ._ext_subinfo = {._pull_mode = pull_mode, ._reliable = reliable}}}};
 }
-_z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key) {
+_z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t *key) {
     return (_z_declaration_t){._tag = _Z_UNDECL_SUBSCRIBER,
-                              ._body = {._undecl_subscriber = {._id = id, ._ext_keyexpr = _z_keyexpr_steal(key)}}};
+                              ._body = {._undecl_subscriber = {._id = id, ._ext_keyexpr = _z_keyexpr_duplicate(*key)}}};
 }
 _z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint32_t distance, uint8_t complete) {
     return (_z_declaration_t){
@@ -87,9 +87,9 @@ _z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, 
                                       ._keyexpr = _z_keyexpr_steal(key),
                                       ._ext_queryable_info = {._complete = complete, ._distance = distance}}}};
 }
-_z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key) {
+_z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t *key) {
     return (_z_declaration_t){._tag = _Z_UNDECL_QUERYABLE,
-                              ._body = {._undecl_queryable = {._id = id, ._ext_keyexpr = _z_keyexpr_steal(key)}}};
+                              ._body = {._undecl_queryable = {._id = id, ._ext_keyexpr = _z_keyexpr_duplicate(*key)}}};
 }
 _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id) {
     return (_z_declaration_t){._tag = _Z_DECL_TOKEN,
@@ -98,13 +98,13 @@ _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id) {
                                             ._keyexpr = _z_keyexpr_steal(key),
                                         }}};
 }
-_z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key) {
+_z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t *key) {
     return (_z_declaration_t){._tag = _Z_UNDECL_TOKEN,
-                              ._body = {._undecl_token = {._id = id, ._ext_keyexpr = _z_keyexpr_steal(key)}}};
+                              ._body = {._undecl_token = {._id = id, ._ext_keyexpr = _z_keyexpr_duplicate(*key)}}};
 }
-_z_declaration_t _z_make_undecl_interest(uint32_t id, _Z_OPTIONAL _Z_MOVE(_z_keyexpr_t) key) {
+_z_declaration_t _z_make_undecl_interest(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t *key) {
     return (_z_declaration_t){._tag = _Z_UNDECL_TOKEN,
-                              ._body = {._undecl_token = {._id = id, ._ext_keyexpr = _z_keyexpr_steal(key)}}};
+                              ._body = {._undecl_token = {._id = id, ._ext_keyexpr = _z_keyexpr_duplicate(*key)}}};
 }
 _z_declaration_t _z_make_decl_interest(_Z_MOVE(_z_keyexpr_t) key, uint32_t id) {
     return (_z_declaration_t){._tag = _Z_DECL_TOKEN,
@@ -127,7 +127,7 @@ _z_undecl_queryable_t _z_undecl_queryable_null(void) { return (_z_undecl_queryab
 _z_undecl_token_t _z_undecl_token_null(void) { return (_z_undecl_token_t){0}; }
 _z_undecl_interest_t _z_undecl_interest_null(void) { return (_z_undecl_interest_t){0}; }
 _z_final_interest_t _z_final_interest_null(void) { return (_z_final_interest_t){0}; }
-void _z_decl_fix_mapping(_z_declaration_t* msg, uint16_t mapping) {
+void _z_decl_fix_mapping(_z_declaration_t *msg, uint16_t mapping) {
     switch (msg->_tag) {
         case _Z_DECL_KEXPR: {
             _z_keyexpr_fix_mapping(&msg->_body._decl_kexpr._keyexpr, mapping);


### PR DESCRIPTION
This fixes #282, the undeclare process for queryable and subscription was:

    1) steal the keyexpr
    2) send the declare N message
    3) remove subscription/queryable from session
    
The delay between 1) and 3) was the source of the problem and stealing the keyepr was probably useful before the introduction of refcounting for subscriptions and queryables, but it is no longer necessary.
