### PR TITLE
Leave null pointer if task init failed & stop unicast read task when close message received

### DIFF
--- a/include/zenoh-pico/utils/result.h
+++ b/include/zenoh-pico/utils/result.h
@@ -65,6 +65,8 @@ typedef enum {
     _Z_ERR_SYSTEM_TASK_FAILED = -79,
     _Z_ERR_SYSTEM_OUT_OF_MEMORY = -78,
 
+    _Z_ERR_CONNECTION_CLOSED = -77,
+
     _Z_ERR_GENERIC = -128
 } _z_res_t;
 

--- a/src/transport/multicast/lease.c
+++ b/src/transport/multicast/lease.c
@@ -184,14 +184,13 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
 int8_t _zp_multicast_start_lease_task(_z_transport_multicast_t *ztm, _z_task_attr_t *attr, _z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(_z_task_t));
+    // Init task
+    if (_z_task_init(task, attr, _zp_multicast_lease_task, ztm) != _Z_RES_OK) {
+        return _Z_ERR_SYSTEM_TASK_FAILED;
+    }
     // Attach task
     ztm->_lease_task = task;
     ztm->_lease_task_running = true;
-    // Init task
-    if (_z_task_init(task, attr, _zp_multicast_lease_task, ztm) != _Z_RES_OK) {
-        ztm->_lease_task_running = false;
-        return _Z_ERR_SYSTEM_TASK_FAILED;
-    }
     return _Z_RES_OK;
 }
 

--- a/src/transport/multicast/read.c
+++ b/src/transport/multicast/read.c
@@ -131,14 +131,13 @@ void *_zp_multicast_read_task(void *ztm_arg) {
 int8_t _zp_multicast_start_read_task(_z_transport_t *zt, _z_task_attr_t *attr, _z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(_z_task_t));
+    // Init task
+    if (_z_task_init(task, attr, _zp_multicast_read_task, &zt->_transport._multicast) != _Z_RES_OK) {
+        return _Z_ERR_SYSTEM_TASK_FAILED;
+    }
     // Attach task
     zt->_transport._multicast._read_task = task;
     zt->_transport._multicast._read_task_running = true;
-    // Init task
-    if (_z_task_init(task, attr, _zp_multicast_read_task, &zt->_transport._multicast) != _Z_RES_OK) {
-        zt->_transport._multicast._read_task_running = false;
-        return _Z_ERR_SYSTEM_TASK_FAILED;
-    }
     return _Z_RES_OK;
 }
 

--- a/src/transport/raweth/read.c
+++ b/src/transport/raweth/read.c
@@ -86,14 +86,13 @@ void *_zp_raweth_read_task(void *ztm_arg) {
 int8_t _zp_raweth_start_read_task(_z_transport_t *zt, _z_task_attr_t *attr, _z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(_z_task_t));
+    // Init task
+    if (_z_task_init(task, attr, _zp_raweth_read_task, &zt->_transport._raweth) != _Z_RES_OK) {
+        return _Z_ERR_SYSTEM_TASK_FAILED;
+    }
     // Attach task
     zt->_transport._raweth._read_task = task;
     zt->_transport._raweth._read_task_running = true;
-    // Init task
-    if (_z_task_init(task, attr, _zp_raweth_read_task, &zt->_transport._raweth) != _Z_RES_OK) {
-        zt->_transport._raweth._read_task_running = false;
-        return _Z_ERR_SYSTEM_TASK_FAILED;
-    }
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/lease.c
+++ b/src/transport/unicast/lease.c
@@ -98,14 +98,13 @@ void *_zp_unicast_lease_task(void *ztu_arg) {
 int8_t _zp_unicast_start_lease_task(_z_transport_t *zt, _z_task_attr_t *attr, _z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(_z_task_t));
+    // Init task
+    if (_z_task_init(task, attr, _zp_unicast_lease_task, &zt->_transport._unicast) != _Z_RES_OK) {
+        return _Z_ERR_SYSTEM_TASK_FAILED;
+    }
     // Attach task
     zt->_transport._unicast._lease_task = task;
     zt->_transport._unicast._lease_task_running = true;
-    // Init task
-    if (_z_task_init(task, attr, _zp_unicast_lease_task, &zt->_transport._unicast) != _Z_RES_OK) {
-        zt->_transport._unicast._lease_task_running = false;
-        return _Z_ERR_SYSTEM_TASK_FAILED;
-    }
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/read.c
+++ b/src/transport/unicast/read.c
@@ -124,14 +124,13 @@ void *_zp_unicast_read_task(void *ztu_arg) {
 int8_t _zp_unicast_start_read_task(_z_transport_t *zt, _z_task_attr_t *attr, _z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(_z_task_t));
+    // Init task
+    if (_z_task_init(task, attr, _zp_unicast_read_task, &zt->_transport._unicast) != _Z_RES_OK) {
+        return _Z_ERR_SYSTEM_TASK_FAILED;
+    }
     // Attach task
     zt->_transport._unicast._read_task = task;
     zt->_transport._unicast._read_task_running = true;
-    // Init task
-    if (_z_task_init(task, attr, _zp_unicast_read_task, &zt->_transport._unicast) != _Z_RES_OK) {
-        zt->_transport._unicast._read_task_running = false;
-        return _Z_ERR_SYSTEM_TASK_FAILED;
-    }
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/rx.c
+++ b/src/transport/unicast/rx.c
@@ -96,6 +96,8 @@ int8_t _z_unicast_recv_t_msg(_z_transport_unicast_t *ztu, _z_transport_message_t
 }
 
 int8_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg) {
+    int8_t ret = _Z_RES_OK;
+
     switch (_Z_MID(t_msg->_header)) {
         case _Z_MID_T_FRAME: {
             _Z_INFO("Received Z_FRAME message\n");
@@ -190,6 +192,7 @@ int8_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_trans
 
         case _Z_MID_T_CLOSE: {
             _Z_INFO("Closing session as requested by the remote peer\n");
+            ret = _Z_ERR_CONNECTION_CLOSED;
             break;
         }
 
@@ -199,7 +202,7 @@ int8_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_trans
         }
     }
 
-    return _Z_RES_OK;
+    return ret;
 }
 #else
 int8_t _z_unicast_recv_t_msg(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg) {


### PR DESCRIPTION
This fixes #300, we don't register the task pointer in the transport structure if the task init failed. 

And also #299, when a unicast read task receives a close message, it stops running.