### PR TITLE
Switch Windows z_clock to QueryPerformanceCounter

### DIFF
--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
         results[i] = z_clock_elapsed_us(&measure_start);
     }
     for (unsigned int i = 0; i < args.number_of_pings; i++) {
-        printf("%d bytes: seq=%d rtt=%luµs, lat=%luµs\n", args.size, i, results[i], results[i] / 2);
+        printf("%d bytes: seq=%d rtt=%luus, lat=%luus\n", args.size, i, results[i], results[i] / 2);
     }
     _z_mutex_unlock(&mutex);
     z_free(results);

--- a/include/zenoh-pico/system/platform/windows.h
+++ b/include/zenoh-pico/system/platform/windows.h
@@ -27,7 +27,7 @@ typedef SRWLOCK _z_mutex_t;
 typedef CONDITION_VARIABLE _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
-typedef struct timeb z_clock_t;
+typedef LARGE_INTEGER z_clock_t;
 typedef struct timeb z_time_t;
 
 typedef struct {

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -55,8 +55,8 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
                 // The receiving buffer
                 _z_zbuf_t zbf = _z_zbuf_make(Z_BATCH_UNICAST_SIZE);
 
-                z_time_t start = z_time_now();
-                while (z_time_elapsed_ms(&start) < period) {
+                z_clock_t start = z_clock_now();
+                while (z_clock_elapsed_ms(&start) < period) {
                     // Eventually read hello messages
                     _z_zbuf_reset(&zbf);
 

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -191,7 +191,7 @@ unsigned long z_clock_elapsed_us(z_clock_t *instant) {
     if (frequency.QuadPart == 0) {
         return 0;
     }
-    double elapsed = (double)(instant->QuadPart - now.QuadPart) * 1000000.0;
+    double elapsed = (double)(now.QuadPart - instant->QuadPart) * 1000000.0;
     elapsed /= frequency.QuadPart;
     return (unsigned long)elapsed;
 }
@@ -206,7 +206,7 @@ unsigned long z_clock_elapsed_ms(z_clock_t *instant) {
     if (frequency.QuadPart == 0) {
         return 0;
     }
-    double elapsed = (double)(instant->QuadPart - now.QuadPart) * 1000.0;
+    double elapsed = (double)(now.QuadPart - instant->QuadPart) * 1000.0;
     elapsed /= frequency.QuadPart;
     return (unsigned long)elapsed;
 }
@@ -221,7 +221,7 @@ unsigned long z_clock_elapsed_s(z_clock_t *instant) {
     if (frequency.QuadPart == 0) {
         return 0;
     }
-    double elapsed = (double)(instant->QuadPart - now.QuadPart) / frequency.QuadPart;
+    double elapsed = (double)(now.QuadPart - instant->QuadPart) / frequency.QuadPart;
     return (unsigned long)elapsed;
 }
 

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -177,26 +177,52 @@ int z_sleep_s(size_t time) {
 /*------------------ Instant ------------------*/
 z_clock_t z_clock_now(void) {
     z_clock_t now;
-    ftime(&now);
+    QueryPerformanceCounter(&now);
     return now;
 }
 
-unsigned long z_clock_elapsed_us(z_clock_t *instant) { return z_clock_elapsed_ms(instant) * 1000; }
+unsigned long z_clock_elapsed_us(z_clock_t *instant) {
+    z_clock_t now;
+    LARGE_INTEGER frequency;
+    QueryPerformanceCounter(&now);
+    QueryPerformanceFrequency(&frequency);  // ticks per second
+
+    // Hardware not supporting QueryPerformanceFrequency
+    if (frequency.QuadPart == 0) {
+        return 0;
+    }
+    double elapsed = (double)(instant->QuadPart - now.QuadPart) * 1000000.0;
+    elapsed /= frequency.QuadPart;
+    return (unsigned long)elapsed;
+}
 
 unsigned long z_clock_elapsed_ms(z_clock_t *instant) {
-    z_time_t now;
-    ftime(&now);
+    z_clock_t now;
+    LARGE_INTEGER frequency;
+    QueryPerformanceCounter(&now);
+    QueryPerformanceFrequency(&frequency);  // ticks per second
 
-    unsigned long elapsed = ((unsigned long)(now.time - instant->time) * 1000) + (now.millitm - instant->millitm);
-    return elapsed;
+    // Hardware not supporting QueryPerformanceFrequency
+    if (frequency.QuadPart == 0) {
+        return 0;
+    }
+    double elapsed = (double)(instant->QuadPart - now.QuadPart) * 1000.0;
+    elapsed /= frequency.QuadPart;
+    return (unsigned long)elapsed;
 }
 
 unsigned long z_clock_elapsed_s(z_clock_t *instant) {
-    z_time_t now;
-    ftime(&now);
+    z_clock_t now;
+    LARGE_INTEGER frequency;
+    QueryPerformanceCounter(&now);
+    QueryPerformanceFrequency(&frequency);  // ticks per second
 
-    unsigned long elapsed = (unsigned long)(now.time - instant->time);
-    return elapsed;
+    // Hardware not supporting QueryPerformanceFrequency
+    if (frequency.QuadPart == 0) {
+        return 0;
+    }
+    double elapsed = (double)(instant->QuadPart - now.QuadPart) / frequency.QuadPart;
+    return (unsigned long)elapsed;
 }
 
 /*------------------ Time ------------------*/


### PR DESCRIPTION
As stated in #272, the Windows `z_clock` implementation was the same as `z_time` which wasn't ideal.

 This PR aligns `z_clock` with the Rust clock implementation that uses Windows' QueryPerformanceCounter.
 
 As a bonus, it switches the scout timeout loop to `z_clock` instead of `z_time` which is more suited.

