### PR TITLE
add Z_FEATURE_ASSEMBLY_NOP

### DIFF
--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -225,6 +225,13 @@
 #define Z_FEATURE_RAWETH_TRANSPORT 0
 #endif
 
+/**
+ * Enable assembly nop.
+ */
+#ifndef Z_FEATURE_ASSEMBLY_NOP
+#define Z_FEATURE_ASSEMBLY_NOP 1
+#endif
+
 /*------------------ Compile-time configuration properties ------------------*/
 /**
  * Default length for Zenoh ID. Maximum size is 16 bytes.

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -361,7 +361,9 @@ size_t _z_endpoint_config_strlen(const _z_str_intmap_t *s, const char *proto) {
         if (_z_str_eq(proto, RAWETH_SCHEMA) == true) {
         len = _z_raweth_config_strlen(s);
     } else {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 
     return len;
@@ -399,7 +401,9 @@ char *_z_endpoint_config_to_str(const _z_str_intmap_t *s, const char *proto) {
         if (_z_str_eq(proto, RAWETH_SCHEMA) == true) {
         _z_raweth_config_to_str(s);
     } else {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 
     return res;

--- a/src/system/arduino/esp32/network.cpp
+++ b/src/system/arduino/esp32/network.cpp
@@ -558,7 +558,9 @@ int8_t _z_open_bt(_z_sys_net_socket_t *sock, const char *gname, uint8_t mode, ui
             uint8_t connected = sock->_bts->connect(gname);
             if (!connected) {
                 while (!sock->_bts->connected(tout)) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
                     __asm__("nop");
+#endif
                 }
             }
         } else {
@@ -584,7 +586,9 @@ int8_t _z_listen_bt(_z_sys_net_socket_t *sock, const char *gname, uint8_t mode, 
             uint8_t connected = sock->_bts->connect(gname);
             if (!connected) {
                 while (!sock->_bts->connected(tout)) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
                     __asm__("nop");
+#endif
                 }
             }
         } else {

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -32,7 +32,9 @@ uint8_t z_random_u8(void) {
     uint8_t ret = 0;
 #if defined(ZENOH_LINUX)
     while (getrandom(&ret, sizeof(uint8_t), 0) <= 0) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 #elif defined(ZENOH_MACOS) || defined(ZENOH_BSD)
     ret = z_random_u32();
@@ -45,7 +47,9 @@ uint16_t z_random_u16(void) {
     uint16_t ret = 0;
 #if defined(ZENOH_LINUX)
     while (getrandom(&ret, sizeof(uint16_t), 0) <= 0) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 #elif defined(ZENOH_MACOS) || defined(ZENOH_BSD)
     ret = z_random_u32();
@@ -58,7 +62,9 @@ uint32_t z_random_u32(void) {
     uint32_t ret = 0;
 #if defined(ZENOH_LINUX)
     while (getrandom(&ret, sizeof(uint32_t), 0) <= 0) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 #elif defined(ZENOH_MACOS) || defined(ZENOH_BSD)
     ret = arc4random();
@@ -71,7 +77,9 @@ uint64_t z_random_u64(void) {
     uint64_t ret = 0;
 #if defined(ZENOH_LINUX)
     while (getrandom(&ret, sizeof(uint64_t), 0) <= 0) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 #elif defined(ZENOH_MACOS) || defined(ZENOH_BSD)
     ret |= z_random_u32();
@@ -85,7 +93,9 @@ uint64_t z_random_u64(void) {
 void z_random_fill(void *buf, size_t len) {
 #if defined(ZENOH_LINUX)
     while (getrandom(buf, len, 0) <= 0) {
+#if Z_FEATURE_ASSEMBLY_NOP == 1
         __asm__("nop");
+#endif
     }
 #elif defined(ZENOH_MACOS) || defined(ZENOH_BSD)
     arc4random_buf(buf, len);


### PR DESCRIPTION
Add `Z_FEATURE_ASSEMBLY_NOP` to allow the user to disable assembly `nop` code as it raises the following build failure on some "exotic" architectures such as or1k:

```
/home/autobuild/autobuild/instance-1/output-1/build/libzenoh-pico-0.10.0-rc/src/link/endpoint.c: Assembler messages:
/home/autobuild/autobuild/instance-1/output-1/build/libzenoh-pico-0.10.0-rc/src/link/endpoint.c:358: Error: unrecognized instruction `nop'
```

Fixes:
 - http://autobuild.buildroot.org/results/fd0b2c666a1dc1537162d15b27743abd270243ed