### PR TITLE
Add atomic fallback for CXX without std::atomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(FRAG_MAX_SIZE 0 CACHE STRING "Use this to override the maximum size for frag
 set(BATCH_UNICAST_SIZE 0 CACHE STRING "Use this to override the maximum unicast batch size")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
-  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES 
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
       ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 
@@ -61,6 +61,19 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 add_definition(ZENOH_C_STANDARD=${CMAKE_C_STANDARD})
+
+check_cxx_source_compiles("
+#include <atomic>
+
+int main() {
+  std::atomic<int> u{5};
+  return u;
+}" HAVE_CXX_STD_ATOMIC)
+
+if (NOT HAVE_CXX_STD_ATOMIC)
+  message(STATUS "Did not find std::atomic support, using fallback mechanism")
+  add_definition(ZENOH_CXX_ATOMIC_FALLBACK)
+endif()
 
 # while in development, use timestamp for patch version:
 string(TIMESTAMP PROJECT_VERSION_PATCH "%Y%m%ddev")

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -19,7 +19,7 @@
 
 #if ZENOH_C_STANDARD != 99
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) || ZENOH_CXX_ATOMIC_FALLBACK
 
 // clang-format off
 
@@ -322,7 +322,7 @@ inline bool z_check(const z_owned_reply_t& v) { return z_reply_check(&v); }
 inline bool z_check(const z_owned_hello_t& v) { return z_hello_check(&v); }
 inline bool z_check(const z_owned_str_t& v) { return z_str_check(&v); }
 
-inline void z_call(const z_owned_closure_sample_t &closure, const z_sample_t *sample) 
+inline void z_call(const z_owned_closure_sample_t &closure, const z_sample_t *sample)
     { z_closure_sample_call(&closure, sample); }
 inline void z_call(const z_owned_closure_query_t &closure, const z_query_t *query)
     { z_closure_query_call(&closure, query); }

--- a/include/zenoh-pico/collections/pointer.h
+++ b/include/zenoh-pico/collections/pointer.h
@@ -30,6 +30,37 @@
 #define _z_memory_order_release memory_order_release
 #define _z_memory_order_relaxed memory_order_relaxed
 #else
+
+#ifdef ZENOH_CXX_ATOMIC_FALLBACK /* Useful for CXX platforms that don't provide std::atomic */
+typedef enum
+  {
+    memory_order_relaxed = __ATOMIC_RELAXED,
+    memory_order_consume = __ATOMIC_CONSUME,
+    memory_order_acquire = __ATOMIC_ACQUIRE,
+    memory_order_release = __ATOMIC_RELEASE,
+    memory_order_acq_rel = __ATOMIC_ACQ_REL,
+    memory_order_seq_cst = __ATOMIC_SEQ_CST
+  } memory_order;
+
+extern void atomic_thread_fence (memory_order);
+#define atomic_thread_fence(MO)	__atomic_thread_fence (MO)
+#if ULONG_MAX == 4294967295UL
+#define _z_atomic(T)              unsigned int
+#define _z_atomic_store_explicit __atomic_store_4
+#define _z_atomic_fetch_add_explicit __atomic_fetch_add_4
+#define _z_atomic_fetch_sub_explicit __atomic_fetch_sub_4
+#elif ULONG_MAX == 18446744073709551615UL
+#define _z_atomic(T)              unsigned int
+#define _z_atomic_store_explicit __atomic_store_8
+#define _z_atomic_fetch_add_explicit __atomic_fetch_add_8
+#define _z_atomic_fetch_sub_explicit __atomic_fetch_sub_8
+#else
+#error "Can't determine size of unsigned int"
+#endif
+#define _z_memory_order_acquire memory_order_acquire
+#define _z_memory_order_release memory_order_release
+#define _z_memory_order_relaxed memory_order_relaxed
+#else
 #include <atomic>
 #define _z_atomic(X) std::atomic<X>
 #define _z_atomic_store_explicit std::atomic_store_explicit
@@ -38,6 +69,7 @@
 #define _z_memory_order_acquire std::memory_order_acquire
 #define _z_memory_order_release std::memory_order_release
 #define _z_memory_order_relaxed std::memory_order_relaxed
+#endif
 #endif  // __cplusplus
 
 /*------------------ Internal Array Macros ------------------*/


### PR DESCRIPTION
When compiling zenoh-pico on an embedded rtos without std::atomic you'll get `<atomic>` include errors. This patch provides a way to implement some of the c11 atomics used in `pointer.h` in CXX.

It's just an attempt maybe someone has an idea for a cleaner approach, also it's the question other parts of zenoh-pico are going to utilize c11 atomic.