### PR TITLE
Enable Z_FEATURE_ATTACHMENT feature functionality in installed headers by default

### DIFF
--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -232,6 +232,13 @@
 #define Z_FEATURE_FRAGMENTATION 1
 #endif
 
+/**
+ * Enable attachments.
+ */
+#ifndef Z_FEATURE_ATTACHMENT
+#define Z_FEATURE_ATTACHMENT 1
+#endif
+
 /*------------------ Compile-time configuration properties ------------------*/
 /**
  * Default length for Zenoh ID. Maximum size is 16 bytes.


### PR DESCRIPTION
Unlike other optional features that are enabled by default, the Z_FEATURE_ATTACHMENT feature is not listed in config.h. This leads to user applications using the installed header files failing to compile unless they define Z_FEATURE_ATTACHMENT and set its value to 1.

This PR fixes #328  by adding a block to the config.h file which defines Z_FEATURE_ATTACHMENT as 1 unless already defined.