### PR TITLE
Renaming questionable

### DIFF
--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -589,7 +589,7 @@ z_owned_closure_sample_t z_closure_sample(_z_data_handler_t call, _z_dropper_han
  * Returns:
  *   Returns a new query closure.
  */
-z_owned_closure_query_t z_closure_query(_z_questionable_handler_t call, _z_dropper_handler_t drop, void *context);
+z_owned_closure_query_t z_closure_query(_z_queryable_handler_t call, _z_dropper_handler_t drop, void *context);
 
 /**
  * Return a new reply closure.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -498,14 +498,14 @@ void z_closure_sample_call(const z_owned_closure_sample_t *closure, const z_samp
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
- *   _z_questionable_handler_t call: `void (*_z_questionable_handler_t)(z_query_t *query, void *arg)` is the callback
- * function.
+ *   _z_queryable_handler_t call: `void (*_z_queryable_handler_t)(z_query_t *query, void *arg)` is the
+ * callback function.
  *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 typedef struct {
     void *context;
-    _z_questionable_handler_t call;
+    _z_queryable_handler_t call;
     _z_dropper_handler_t drop;
 } z_owned_closure_query_t;
 

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -185,7 +185,7 @@ int8_t _z_subscriber_pull(const _z_subscriber_t *sub);
  *    The created :c:type:`_z_queryable_t` or null if the declaration failed.
  */
 _z_queryable_t *_z_declare_queryable(_z_session_rc_t *zn, _z_keyexpr_t keyexpr, _Bool complete,
-                                     _z_questionable_handler_t callback, _z_drop_handler_t dropper, void *arg);
+                                     _z_queryable_handler_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_queryable_t`.

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -57,7 +57,7 @@ typedef struct _z_session_t {
 
     // Session queryables
 #if Z_FEATURE_QUERYABLE == 1
-    _z_questionable_rc_list_t *_local_questionable;
+    _z_session_queryable_rc_list_t *_local_queryable;
 #endif
 #if Z_FEATURE_QUERY == 1
     _z_pending_query_list_t *_pending_queries;

--- a/include/zenoh-pico/session/queryable.h
+++ b/include/zenoh-pico/session/queryable.h
@@ -24,13 +24,13 @@
 #define _Z_QUERYABLE_DISTANCE_DEFAULT 0
 
 /*------------------ Queryable ------------------*/
-_z_questionable_rc_t *_z_get_questionable_by_id(_z_session_t *zn, const _z_zint_t id);
-_z_questionable_rc_list_t *_z_get_questionable_by_key(_z_session_t *zn, const _z_keyexpr_t key);
+_z_session_queryable_rc_t *_z_get_session_queryable_by_id(_z_session_t *zn, const _z_zint_t id);
+_z_session_queryable_rc_list_t *_z_get_session_queryable_by_key(_z_session_t *zn, const _z_keyexpr_t key);
 
-_z_questionable_rc_t *_z_register_questionable(_z_session_t *zn, _z_questionable_t *q);
+_z_session_queryable_rc_t *_z_register_session_queryable(_z_session_t *zn, _z_session_queryable_t *q);
 int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *query, const _z_keyexpr_t q_key, uint32_t qid);
-void _z_unregister_questionable(_z_session_t *zn, _z_questionable_rc_t *q);
-void _z_flush_questionables(_z_session_t *zn);
+void _z_unregister_session_queryable(_z_session_t *zn, _z_session_queryable_rc_t *q);
+void _z_flush_session_queryable(_z_session_t *zn);
 #endif
 
 #endif /* ZENOH_PICO_SESSION_QUERYABLE_H */

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -114,24 +114,25 @@ typedef struct z_query_t z_query_t;  // Forward type declaration to avoid cyclic
 /**
  * The callback signature of the functions handling query messages.
  */
-typedef void (*_z_questionable_handler_t)(const z_query_t *query, void *arg);
+typedef void (*_z_queryable_handler_t)(const z_query_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     uint32_t _id;
-    _z_questionable_handler_t _callback;
+    _z_queryable_handler_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
     _Bool _complete;
-} _z_questionable_t;
+} _z_session_queryable_t;
 
-_Bool _z_questionable_eq(const _z_questionable_t *one, const _z_questionable_t *two);
-void _z_questionable_clear(_z_questionable_t *res);
+_Bool _z_session_queryable_eq(const _z_session_queryable_t *one, const _z_session_queryable_t *two);
+void _z_session_queryable_clear(_z_session_queryable_t *res);
 
-_Z_REFCOUNT_DEFINE(_z_questionable, _z_questionable)
-_Z_ELEM_DEFINE(_z_questionable, _z_questionable_t, _z_noop_size, _z_questionable_clear, _z_noop_copy)
-_Z_ELEM_DEFINE(_z_questionable_rc, _z_questionable_rc_t, _z_noop_size, _z_questionable_rc_drop, _z_noop_copy)
-_Z_LIST_DEFINE(_z_questionable_rc, _z_questionable_rc_t)
+_Z_REFCOUNT_DEFINE(_z_session_queryable, _z_session_queryable)
+_Z_ELEM_DEFINE(_z_session_queryable, _z_session_queryable_t, _z_noop_size, _z_session_queryable_clear, _z_noop_copy)
+_Z_ELEM_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t, _z_noop_size, _z_session_queryable_rc_drop,
+               _z_noop_copy)
+_Z_LIST_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
 
 typedef struct {
     _z_reply_t _reply;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -453,7 +453,7 @@ z_owned_closure_sample_t z_closure_sample(_z_data_handler_t call, _z_dropper_han
     return (z_owned_closure_sample_t){.call = call, .drop = drop, .context = context};
 }
 
-z_owned_closure_query_t z_closure_query(_z_questionable_handler_t call, _z_dropper_handler_t drop, void *context) {
+z_owned_closure_query_t z_closure_query(_z_queryable_handler_t call, _z_dropper_handler_t drop, void *context) {
     return (z_owned_closure_query_t){.call = call, .drop = drop, .context = context};
 }
 

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -66,7 +66,7 @@ int8_t _z_session_init(_z_session_t *zn, _z_id_t *zid) {
     zn->_remote_subscriptions = NULL;
 #endif
 #if Z_FEATURE_QUERYABLE == 1
-    zn->_local_questionable = NULL;
+    zn->_local_queryable = NULL;
 #endif
 #if Z_FEATURE_QUERY == 1
     zn->_pending_queries = NULL;
@@ -110,7 +110,7 @@ void _z_session_clear(_z_session_t *zn) {
     _z_flush_subscriptions(zn);
 #endif
 #if Z_FEATURE_QUERYABLE == 1
-    _z_flush_questionables(zn);
+    _z_flush_session_queryable(zn);
 #endif
 #if Z_FEATURE_QUERY == 1
     _z_flush_pending_queries(zn);


### PR DESCRIPTION
In zenoh-pico, for zenoh entities like `Queryable` or `Subscriber`, we need to distinguish between the object given to the user and the object we store in the zenoh session.

For `Subscriber` we have `_z_subscriber` and `_z_subscription` which is fine but for `Queryable` we had `_z_queryable` and `_z_questionable` which isn't great as the link between the two isn't clear.

As the problem may arise again for the yet-to-be-implemented `Interest` entity, `_z_questionable` should be renamed to `_z_session_queryable` to more accurately represent the link between those objects and this scheme is applicable to future entities.

As such this PR renames:
* `_z_questionable` -> `_z_session_queryable`
* `questionable_handler` -> `queryable_handler` (the callback type)
* `local_questionables` -> `local_queryable` (the session's list of entity)
