### PR TITLE
fix: open raweth socket on the correct network interface.

### DIFF
--- a/src/transport/raweth/link.c
+++ b/src/transport/raweth/link.c
@@ -104,7 +104,7 @@ static int8_t _z_f_link_open_raweth(_z_link_t *self) {
         self->_socket._raweth._interface = _ZP_RAWETH_CFG_INTERFACE;
     }
     // Open raweth link
-    return _z_open_raweth(&self->_socket._raweth._sock, _ZP_RAWETH_CFG_INTERFACE);
+    return _z_open_raweth(&self->_socket._raweth._sock, self->_socket._raweth._interface);
 }
 
 static int8_t _z_f_link_listen_raweth(_z_link_t *self) { return _z_f_link_open_raweth(self); }


### PR DESCRIPTION
Currently, the socket is always opened on the interface defined by _ZP_RAWETH_CFG_INTERFACE. This fix ensures that the raw Ethernet socket is opened on the interface specified by the iface component of the locator (if specified).

Fixes #340.