### PR TITLE
Fix/remove qos designated initializers

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -450,6 +450,7 @@ static inline z_qos_t z_qos_default(void) { return _Z_N_QOS_DEFAULT; }
  *   z_encoding_t encoding: The encoding of the value of this data sample.
  *   z_sample_kind_t kind: The kind of this data sample (PUT or DELETE).
  *   z_timestamp_t timestamp: The timestamp of this data sample.
+ *   z_qos_t qos: Quality of service settings used to deliver this sample.
  */
 typedef _z_sample_t z_sample_t;
 

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -60,10 +60,19 @@
 
 typedef _z_qos_t _z_n_qos_t;
 
-_z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority);
-z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos);
-z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos);
-_Bool _z_n_qos_get_express(_z_n_qos_t n_qos);
+static inline _z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority) {
+    _z_n_qos_t ret;
+    _Bool nodrop = congestion_control == Z_CONGESTION_CONTROL_DROP ? 0 : 1;
+    ret._val = (uint8_t)((express << 4) | (nodrop << 3) | priority);
+    return ret;
+}
+static inline z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos) {
+    return (z_priority_t)(n_qos._val & 0x07 /* 0b111 */);
+}
+static inline z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos) {
+    return (n_qos._val & 0x08 /* 0b1000 */) ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP;
+}
+static inline _Bool _z_n_qos_get_express(_z_n_qos_t n_qos) { return (_Bool)(n_qos._val & 0x10 /* 0b10000 */); }
 #define _z_n_qos_make(express, nodrop, priority)                                                     \
     _z_n_qos_create((_Bool)express, nodrop ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP, \
                     (z_priority_t)priority)

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -60,7 +60,8 @@
 
 typedef _z_qos_t _z_n_qos_t;
 
-static inline _z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority) {
+static inline _z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control,
+                                       z_priority_t priority) {
     _z_n_qos_t ret;
     _Bool nodrop = congestion_control == Z_CONGESTION_CONTROL_DROP ? 0 : 1;
     ret._val = (uint8_t)((express << 4) | (nodrop << 3) | priority);

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -60,19 +60,10 @@
 
 typedef _z_qos_t _z_n_qos_t;
 
-static inline _z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control,
-                                       z_priority_t priority) {
-    _Bool nodrop = congestion_control == Z_CONGESTION_CONTROL_DROP ? 0 : 1;
-    _z_n_qos_t ret = {._val = (uint8_t)((express << 4) | (nodrop << 3) | priority)};
-    return ret;
-}
-static inline z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos) {
-    return (z_priority_t)(n_qos._val & 0x07 /* 0b111 */);
-}
-static inline z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos) {
-    return (n_qos._val & 0x08 /* 0b1000 */) ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP;
-}
-static inline _Bool _z_n_qos_get_express(_z_n_qos_t n_qos) { return (_Bool)(n_qos._val & 0x10 /* 0b10000 */); }
+_z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority);
+z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos);
+z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos);
+_Bool _z_n_qos_get_express(_z_n_qos_t n_qos);
 #define _z_n_qos_make(express, nodrop, priority)                                                     \
     _z_n_qos_create((_Bool)express, nodrop ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP, \
                     (z_priority_t)priority)

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -276,12 +276,3 @@ void _z_msg_fix_mapping(_z_zenoh_message_t *msg, uint16_t mapping) {
             break;
     }
 }
-_z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority) {
-    _Bool nodrop = congestion_control == Z_CONGESTION_CONTROL_DROP ? 0 : 1;
-    _z_n_qos_t ret = {._val = (uint8_t)((express << 4) | (nodrop << 3) | priority)};
-    return ret;
-}
-z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos) { return (z_priority_t)(n_qos._val & 0x07 /* 0b111 */); }
-z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos) {
-    return (n_qos._val & 0x08 /* 0b1000 */) ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP;
-}

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -276,3 +276,12 @@ void _z_msg_fix_mapping(_z_zenoh_message_t *msg, uint16_t mapping) {
             break;
     }
 }
+_z_qos_t _z_n_qos_create(_Bool express, z_congestion_control_t congestion_control, z_priority_t priority) {
+    _Bool nodrop = congestion_control == Z_CONGESTION_CONTROL_DROP ? 0 : 1;
+    _z_n_qos_t ret = {._val = (uint8_t)((express << 4) | (nodrop << 3) | priority)};
+    return ret;
+}
+z_priority_t _z_n_qos_get_priority(_z_n_qos_t n_qos) { return (z_priority_t)(n_qos._val & 0x07 /* 0b111 */); }
+z_congestion_control_t _z_n_qos_get_congestion_control(_z_n_qos_t n_qos) {
+    return (n_qos._val & 0x08 /* 0b1000 */) ? Z_CONGESTION_CONTROL_BLOCK : Z_CONGESTION_CONTROL_DROP;
+}


### PR DESCRIPTION
move qos-related functions from header into .c to hide usage of designated initializers from c++ (closes #352)