### PR TITLE
Update query, reply and error messages format

### DIFF
--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -211,7 +211,8 @@ int8_t _z_undeclare_queryable(_z_queryable_t *qle);
  *     key: The resource key of this reply. The caller keeps the ownership.
  *     payload: The value of this reply, the caller keeps ownership.
  */
-int8_t _z_send_reply(const _z_query_t *query, const _z_keyexpr_t keyexpr, const _z_value_t payload);
+int8_t _z_send_reply(const _z_query_t *query, const _z_keyexpr_t keyexpr, const _z_value_t payload,
+                     const z_sample_kind_t kind);
 #endif
 
 #if Z_FEATURE_QUERY == 1

--- a/include/zenoh-pico/protocol/definitions/message.h
+++ b/include/zenoh-pico/protocol/definitions/message.h
@@ -166,20 +166,21 @@ void _z_msg_put_clear(_z_msg_put_t *);
 /*------------------ Query Message ------------------*/
 //   7 6 5 4 3 2 1 0
 //  +-+-+-+-+-+-+-+-+
-//  |Z|C|P|  QUERY  |
+//  |Z|P|C|  QUERY  |
 //  +-+-+-+---------+
-//  ~ params        ~  if P==1 -- <utf8;z32>
-//  +---------------+
 //  ~ consolidation ~  if C==1 -- u8
+//  +---------------+
+//  ~ params        ~  if P==1 -- <utf8;z16>
 //  +---------------+
 //  ~ [qry_exts]    ~  if Z==1
 //  +---------------+
-#define _Z_FLAG_Z_Q_P 0x20  // 1 << 6 | Period            if P==1 then a period is present
+#define _Z_FLAG_Z_Q_C 0x20  // 1 << 5 | Consolidation if C==1 then consolidation is present
+#define _Z_FLAG_Z_Q_P 0x40  // 1 << 6 | Params        if P==1 then parameters are present
 typedef struct {
     _z_bytes_t _parameters;
     _z_source_info_t _ext_info;
     _z_value_t _ext_value;
-    z_consolidation_mode_t _ext_consolidation;
+    z_consolidation_mode_t _consolidation;
 #if Z_FEATURE_ATTACHMENT == 1
     _z_owned_encoded_attachment_t _ext_attachment;
 #endif
@@ -187,7 +188,6 @@ typedef struct {
 typedef struct {
     _Bool info;
     _Bool body;
-    _Bool consolidation;
     _Bool attachment;
 } _z_msg_query_reqexts_t;
 _z_msg_query_reqexts_t _z_msg_query_required_extensions(const _z_msg_query_t *msg);

--- a/include/zenoh-pico/protocol/definitions/message.h
+++ b/include/zenoh-pico/protocol/definitions/message.h
@@ -48,28 +48,25 @@
 #define _Z_FRAG_BUFF_BASE_SIZE 128  // Arbitrary base size of the buffer to encode a fragment message header
 
 // Flags:
-// - T: Timestamp      If T==1 then the timestamp if present
-// - I: Infrastructure If I==1 then the error is related to the infrastructure else to the user
+// - X: Reserved
+// - E: Encoding       If E==1 then the encoding is present
 // - Z: Extension      If Z==1 then at least one extension is present
 //
 //   7 6 5 4 3 2 1 0
 //  +-+-+-+-+-+-+-+-+
-//  |Z|I|T|   ERR   |
+//  |Z|E|X|   ERR   |
 //  +-+-+-+---------+
-//  %   code:z16    %
-//  +---------------+
-//  ~ ts: <u8;z16>  ~  if T==1
+//  %   encoding    %
 //  +---------------+
 //  ~  [err_exts]   ~  if Z==1
 //  +---------------+
-#define _Z_FLAG_Z_E_T 0x20
-#define _Z_FLAG_Z_E_I 0x40
+///  ~ pl: <u8;z32>  ~ Payload
+///  +---------------+
+#define _Z_FLAG_Z_E_E 0x40
 typedef struct {
-    uint16_t _code;
-    _Bool _is_infrastructure;
-    _z_timestamp_t _timestamp;
+    _z_encoding_t encoding;
     _z_source_info_t _ext_source_info;
-    _z_value_t _ext_value;
+    _z_bytes_t _payload;
 } _z_msg_err_t;
 void _z_msg_err_clear(_z_msg_err_t *err);
 

--- a/include/zenoh-pico/protocol/definitions/message.h
+++ b/include/zenoh-pico/protocol/definitions/message.h
@@ -49,36 +49,6 @@
 
 // Flags:
 // - T: Timestamp      If T==1 then the timestamp if present
-// - E: Encoding       If E==1 then the encoding is present
-// - Z: Extension      If Z==1 then at least one extension is present
-//
-//   7 6 5 4 3 2 1 0
-//  +-+-+-+-+-+-+-+-+
-//  |Z|E|T|  REPLY  |
-//  +-+-+-+---------+
-//  ~ ts: <u8;z16>  ~  if T==1
-//  +---------------+
-//  ~   encoding    ~  if E==1
-//  +---------------+
-//  ~  [repl_exts]  ~  if Z==1
-//  +---------------+
-//  ~ pl: <u8;z32>  ~  -- Payload
-//  +---------------+
-typedef struct {
-    _z_timestamp_t _timestamp;
-    _z_value_t _value;
-    _z_source_info_t _ext_source_info;
-    z_consolidation_mode_t _ext_consolidation;
-#if Z_FEATURE_ATTACHMENT == 1
-    _z_owned_encoded_attachment_t _ext_attachment;
-#endif
-} _z_msg_reply_t;
-void _z_msg_reply_clear(_z_msg_reply_t *msg);
-#define _Z_FLAG_Z_R_T 0x20
-#define _Z_FLAG_Z_R_E 0x40
-
-// Flags:
-// - T: Timestamp      If T==1 then the timestamp if present
 // - I: Infrastructure If I==1 then the error is related to the infrastructure else to the user
 // - Z: Extension      If Z==1 then at least one extension is present
 //
@@ -192,5 +162,34 @@ typedef struct {
 } _z_msg_query_reqexts_t;
 _z_msg_query_reqexts_t _z_msg_query_required_extensions(const _z_msg_query_t *msg);
 void _z_msg_query_clear(_z_msg_query_t *msg);
+
+typedef struct {
+    _Bool _is_put;
+    union {
+        _z_msg_del_t _del;
+        _z_msg_put_t _put;
+    } _body;
+} _z_reply_body_t;
+// Flags:
+// - C: Consolidation  If C==1 then consolidation is present
+// - X: Reserved
+// - Z: Extension      If Z==1 then at least one extension is present
+//
+//   7 6 5 4 3 2 1 0
+//  +-+-+-+-+-+-+-+-+
+//  |Z|X|C|  REPLY  |
+//  +-+-+-+---------+
+//  ~ consolidation ~  if C==1
+//  +---------------+
+//  ~  [repl_exts]  ~  if Z==1
+//  +---------------+
+//  ~  ReplyBody    ~  -- Payload
+//  +---------------+
+typedef struct {
+    z_consolidation_mode_t _consolidation;
+    _z_reply_body_t _body;
+} _z_msg_reply_t;
+void _z_msg_reply_clear(_z_msg_reply_t *msg);
+#define _Z_FLAG_Z_R_C 0x20
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_MESSAGE_H */

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -118,13 +118,7 @@ typedef struct {
 _z_n_msg_request_exts_t _z_n_msg_request_needed_exts(const _z_n_msg_request_t *msg);
 void _z_n_msg_request_clear(_z_n_msg_request_t *msg);
 
-typedef struct {
-    _Bool _is_put;
-    union {
-        _z_msg_del_t _del;
-        _z_msg_put_t _put;
-    } _body;
-} _z_push_body_t;
+typedef _z_reply_body_t _z_push_body_t;
 _z_push_body_t _z_push_body_null(void);
 _z_push_body_t _z_push_body_steal(_z_push_body_t *msg);
 void _z_push_body_clear(_z_push_body_t *msg);
@@ -236,7 +230,7 @@ _z_network_message_t _z_msg_make_query(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_byt
                                        z_attachment_t attachment
 #endif
 );
-_z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_value_t) value);
+_z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_push_body_t) body);
 _z_network_message_t _z_n_msg_make_ack(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key);
 _z_network_message_t _z_n_msg_make_response_final(_z_zint_t rid);
 _z_network_message_t _z_n_msg_make_declare(_z_declaration_t declaration);

--- a/include/zenoh-pico/session/query.h
+++ b/include/zenoh-pico/session/query.h
@@ -26,8 +26,7 @@ _z_pending_query_t *_z_get_pending_query_by_id(_z_session_t *zn, const _z_zint_t
 
 int8_t _z_register_pending_query(_z_session_t *zn, _z_pending_query_t *pq);
 int8_t _z_trigger_query_reply_partial(_z_session_t *zn, _z_zint_t reply_context, const _z_keyexpr_t keyexpr,
-                                      const _z_bytes_t payload, const _z_encoding_t encoding, const _z_zint_t kind,
-                                      const _z_timestamp_t timestamp);
+                                      const _z_msg_put_t *msg);
 int8_t _z_trigger_query_reply_final(_z_session_t *zn, _z_zint_t id);
 void _z_unregister_pending_query(_z_session_t *zn, _z_pending_query_t *pq);
 void _z_flush_pending_queries(_z_session_t *zn);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -934,7 +934,7 @@ int8_t z_query_reply(const z_query_t *query, const z_keyexpr_t keyexpr, const ui
                                 .len = payload_len,
                             },
                         .encoding = {.prefix = opts.encoding.prefix, .suffix = opts.encoding.suffix}};
-    return _z_send_reply(&query->_val._rc.in->val, keyexpr, value);
+    return _z_send_reply(&query->_val._rc.in->val, keyexpr, value, Z_SAMPLE_KIND_PUT);
     return _Z_ERR_GENERIC;
 }
 #endif

--- a/src/protocol/codec/declarations.c
+++ b/src/protocol/codec/declarations.c
@@ -156,11 +156,11 @@ int8_t _z_decl_interest_encode(_z_wbuf_t *wbf, const _z_decl_interest_t *decl) {
             _Z_SET_FLAG(interest_flags, _Z_DECL_SUBSCRIBER_FLAG_M);
         }
         // Set decl flags & keyexpr
-        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, decl->interest_flags));
+        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, interest_flags));
         _Z_RETURN_IF_ERR(_z_keyexpr_encode(wbf, has_kesuffix, &decl->_keyexpr));
     } else {
         // Set decl flags
-        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, decl->interest_flags));
+        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, interest_flags));
     }
     return _Z_RES_OK;
 }

--- a/src/protocol/codec/declarations.c
+++ b/src/protocol/codec/declarations.c
@@ -133,34 +133,34 @@ int8_t _z_decl_interest_encode(_z_wbuf_t *wbf, const _z_decl_interest_t *decl) {
     // Set header
     uint8_t header = _Z_DECL_INTEREST_MID;
     if (_Z_HAS_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_CURRENT)) {
-        _Z_SET_FLAG(header, _Z_INTEREST_FLAG_CURRENT);
+        header |= _Z_INTEREST_FLAG_CURRENT;
     }
     if (_Z_HAS_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_FUTURE)) {
-        _Z_SET_FLAG(header, _Z_INTEREST_FLAG_FUTURE);
+        header |= _Z_INTEREST_FLAG_FUTURE;
     }
     _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, header));
     // Set id
     _Z_RETURN_IF_ERR(_z_zint_encode(wbf, decl->_id));
     // Copy flags but clear double use ones.
     uint8_t interest_flags = decl->interest_flags;
-    _Z_CLEAR_FLAG(interest_flags, _Z_INTEREST_FLAG_CURRENT);
-    _Z_CLEAR_FLAG(interest_flags, _Z_INTEREST_FLAG_FUTURE);
+    interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_N;
+    interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_M;
     // Process restricted flag
     if (_Z_HAS_FLAG(interest_flags, _Z_INTEREST_FLAG_RESTRICTED)) {
         // Set Named & Mapping flags
         _Bool has_kesuffix = _z_keyexpr_has_suffix(decl->_keyexpr);
         if (has_kesuffix) {
-            _Z_SET_FLAG(interest_flags, _Z_DECL_SUBSCRIBER_FLAG_N);
+            interest_flags |= _Z_DECL_SUBSCRIBER_FLAG_N;
         }
         if (_z_keyexpr_is_local(&decl->_keyexpr)) {
-            _Z_SET_FLAG(interest_flags, _Z_DECL_SUBSCRIBER_FLAG_M);
+            interest_flags |= _Z_DECL_SUBSCRIBER_FLAG_M;
         }
         // Set decl flags & keyexpr
-        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, interest_flags));
+        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, decl->interest_flags));
         _Z_RETURN_IF_ERR(_z_keyexpr_encode(wbf, has_kesuffix, &decl->_keyexpr));
     } else {
         // Set decl flags
-        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, interest_flags));
+        _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, decl->interest_flags));
     }
     return _Z_RES_OK;
 }
@@ -398,13 +398,13 @@ int8_t _z_decl_interest_decode(_z_decl_interest_t *decl, _z_zbuf_t *zbf, uint8_t
         }
     }
     // Replace named & mapping by current & future flags
-    _Z_CLEAR_FLAG(decl->interest_flags, _Z_DECL_SUBSCRIBER_FLAG_M);
-    _Z_CLEAR_FLAG(decl->interest_flags, _Z_DECL_SUBSCRIBER_FLAG_N);
+    decl->interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_M;
+    decl->interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_N;
     if (_Z_HAS_FLAG(header, _Z_INTEREST_FLAG_CURRENT)) {
-        _Z_SET_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_CURRENT);
+        decl->interest_flags |= _Z_INTEREST_FLAG_CURRENT;
     }
     if (_Z_HAS_FLAG(header, _Z_INTEREST_FLAG_FUTURE)) {
-        _Z_SET_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_FUTURE);
+        decl->interest_flags |= _Z_INTEREST_FLAG_FUTURE;
     }
     // Decode extention
     if (_Z_HAS_FLAG(header, _Z_FLAG_Z_Z)) {

--- a/src/protocol/codec/declarations.c
+++ b/src/protocol/codec/declarations.c
@@ -133,27 +133,27 @@ int8_t _z_decl_interest_encode(_z_wbuf_t *wbf, const _z_decl_interest_t *decl) {
     // Set header
     uint8_t header = _Z_DECL_INTEREST_MID;
     if (_Z_HAS_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_CURRENT)) {
-        header |= _Z_INTEREST_FLAG_CURRENT;
+        _Z_SET_FLAG(header, _Z_INTEREST_FLAG_CURRENT);
     }
     if (_Z_HAS_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_FUTURE)) {
-        header |= _Z_INTEREST_FLAG_FUTURE;
+        _Z_SET_FLAG(header, _Z_INTEREST_FLAG_FUTURE);
     }
     _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, header));
     // Set id
     _Z_RETURN_IF_ERR(_z_zint_encode(wbf, decl->_id));
     // Copy flags but clear double use ones.
     uint8_t interest_flags = decl->interest_flags;
-    interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_N;
-    interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_M;
+    _Z_CLEAR_FLAG(interest_flags, _Z_INTEREST_FLAG_CURRENT);
+    _Z_CLEAR_FLAG(interest_flags, _Z_INTEREST_FLAG_FUTURE);
     // Process restricted flag
     if (_Z_HAS_FLAG(interest_flags, _Z_INTEREST_FLAG_RESTRICTED)) {
         // Set Named & Mapping flags
         _Bool has_kesuffix = _z_keyexpr_has_suffix(decl->_keyexpr);
         if (has_kesuffix) {
-            interest_flags |= _Z_DECL_SUBSCRIBER_FLAG_N;
+            _Z_SET_FLAG(interest_flags, _Z_DECL_SUBSCRIBER_FLAG_N);
         }
         if (_z_keyexpr_is_local(&decl->_keyexpr)) {
-            interest_flags |= _Z_DECL_SUBSCRIBER_FLAG_M;
+            _Z_SET_FLAG(interest_flags, _Z_DECL_SUBSCRIBER_FLAG_M);
         }
         // Set decl flags & keyexpr
         _Z_RETURN_IF_ERR(_z_uint8_encode(wbf, decl->interest_flags));
@@ -398,13 +398,13 @@ int8_t _z_decl_interest_decode(_z_decl_interest_t *decl, _z_zbuf_t *zbf, uint8_t
         }
     }
     // Replace named & mapping by current & future flags
-    decl->interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_M;
-    decl->interest_flags &= ~_Z_DECL_SUBSCRIBER_FLAG_N;
+    _Z_CLEAR_FLAG(decl->interest_flags, _Z_DECL_SUBSCRIBER_FLAG_M);
+    _Z_CLEAR_FLAG(decl->interest_flags, _Z_DECL_SUBSCRIBER_FLAG_N);
     if (_Z_HAS_FLAG(header, _Z_INTEREST_FLAG_CURRENT)) {
-        decl->interest_flags |= _Z_INTEREST_FLAG_CURRENT;
+        _Z_SET_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_CURRENT);
     }
     if (_Z_HAS_FLAG(header, _Z_INTEREST_FLAG_FUTURE)) {
-        decl->interest_flags |= _Z_INTEREST_FLAG_FUTURE;
+        _Z_SET_FLAG(decl->interest_flags, _Z_INTEREST_FLAG_FUTURE);
     }
     // Decode extention
     if (_Z_HAS_FLAG(header, _Z_FLAG_Z_Z)) {

--- a/src/protocol/definitions/message.c
+++ b/src/protocol/definitions/message.c
@@ -18,8 +18,9 @@
 
 #include "zenoh-pico/collections/bytes.h"
 #include "zenoh-pico/protocol/core.h"
+#include "zenoh-pico/protocol/definitions/network.h"
 
-void _z_msg_reply_clear(_z_msg_reply_t *msg) { _z_value_clear(&msg->_value); }
+void _z_msg_reply_clear(_z_msg_reply_t *msg) { _z_push_body_clear(&msg->_body); }
 
 void _z_msg_put_clear(_z_msg_put_t *msg) {
     _z_bytes_clear(&msg->_encoding.suffix);

--- a/src/protocol/definitions/message.c
+++ b/src/protocol/definitions/message.c
@@ -49,6 +49,6 @@ void _z_msg_query_clear(_z_msg_query_t *msg) {
     _z_value_clear(&msg->_ext_value);
 }
 void _z_msg_err_clear(_z_msg_err_t *err) {
-    _z_timestamp_clear(&err->_timestamp);
-    _z_value_clear(&err->_ext_value);
+    _z_bytes_clear(&err->encoding.suffix);
+    _z_bytes_clear(&err->_payload);
 }

--- a/src/protocol/definitions/message.c
+++ b/src/protocol/definitions/message.c
@@ -35,7 +35,6 @@ _z_msg_query_reqexts_t _z_msg_query_required_extensions(const _z_msg_query_t *ms
         .body = msg->_ext_value.payload.start != NULL || msg->_ext_value.encoding.prefix != 0 ||
                 !_z_bytes_is_empty(&msg->_ext_value.encoding.suffix),
         .info = _z_id_check(msg->_ext_info._id) || msg->_ext_info._entity_id != 0 || msg->_ext_info._source_sn != 0,
-        .consolidation = msg->_ext_consolidation != Z_CONSOLIDATION_MODE_AUTO,
 #if Z_FEATURE_ATTACHMENT == 1
         .attachment = z_attachment_check(&att)
 #else

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -220,7 +220,7 @@ _z_network_message_t _z_n_msg_make_push(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_pu
         ._body._push = {._key = _z_keyexpr_steal(key), ._body = _z_push_body_steal(body)},
     };
 }
-_z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_value_t) value) {
+_z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_push_body_t) body) {
     return (_z_network_message_t){
         ._tag = _Z_N_RESPONSE,
         ._body._response =
@@ -230,10 +230,8 @@ _z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) ke
                 ._request_id = rid,
                 ._body._reply =
                     {
-                        ._timestamp = _z_timestamp_null(),
-                        ._value = _z_value_steal(value),
-                        ._ext_source_info = _z_source_info_null(),
-                        ._ext_consolidation = Z_CONSOLIDATION_MODE_AUTO,
+                        ._consolidation = Z_CONSOLIDATION_MODE_AUTO,
+                        ._body = _z_push_body_steal(body),
                     },
                 ._ext_qos = _Z_N_QOS_DEFAULT,
                 ._ext_timestamp = _z_timestamp_null(),

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -182,7 +182,7 @@ _z_zenoh_message_t _z_msg_make_query(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_bytes
                 ._key = _z_keyexpr_steal(key),
                 ._tag = _Z_REQUEST_QUERY,
                 ._body._query = {._parameters = _z_bytes_steal(parameters),
-                                 ._ext_consolidation = consolidation,
+                                 ._consolidation = consolidation,
                                  ._ext_value = _z_value_steal(value),
                                  ._ext_info = _z_source_info_null(),
 #if Z_FEATURE_ATTACHMENT == 1

--- a/src/session/reply.c
+++ b/src/session/reply.c
@@ -25,8 +25,11 @@ int8_t _z_trigger_reply_partial(_z_session_t *zn, _z_zint_t id, _z_keyexpr_t key
     // TODO check id to know where to dispatch
 
 #if Z_FEATURE_QUERY == 1
-    ret = _z_trigger_query_reply_partial(zn, id, key, reply->_value.payload, reply->_value.encoding, Z_SAMPLE_KIND_PUT,
-                                         reply->_timestamp);
+    if (reply->_body._is_put) {
+        ret = _z_trigger_query_reply_partial(zn, id, key, &reply->_body._body._put);
+    } else {
+        ret = _Z_ERR_GENERIC;
+    }
 #endif
     return ret;
 }

--- a/src/session/rx.c
+++ b/src/session/rx.c
@@ -153,10 +153,10 @@ int8_t _z_handle_network_message(_z_session_t *zn, _z_zenoh_message_t *msg, uint
                     ret = _z_trigger_reply_partial(zn, response._request_id, response._key, reply);
                 } break;
                 case _Z_RESPONSE_BODY_ERR: {
-                    // @TODO: expose errors to the user
+                    // @TODO: expose zenoh errors to the user
                     _z_msg_err_t error = response._body._err;
-                    _z_bytes_t payload = error._ext_value.payload;
-                    _Z_ERROR("Received Err for query %zu: code=%d, message=%.*s", response._request_id, error._code,
+                    _z_bytes_t payload = error._payload;
+                    _Z_ERROR("Received Err for query %zu: message=%.*s", response._request_id,
                              (int)payload.len, payload.start);
                 } break;
                 case _Z_RESPONSE_BODY_ACK: {

--- a/src/session/rx.c
+++ b/src/session/rx.c
@@ -156,8 +156,8 @@ int8_t _z_handle_network_message(_z_session_t *zn, _z_zenoh_message_t *msg, uint
                     // @TODO: expose zenoh errors to the user
                     _z_msg_err_t error = response._body._err;
                     _z_bytes_t payload = error._payload;
-                    _Z_ERROR("Received Err for query %zu: message=%.*s", response._request_id,
-                             (int)payload.len, payload.start);
+                    _Z_ERROR("Received Err for query %zu: message=%.*s", response._request_id, (int)payload.len,
+                             payload.start);
                 } break;
                 case _Z_RESPONSE_BODY_ACK: {
                     // @TODO: implement ACKs for puts/dels

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1226,18 +1226,14 @@ void ack_message(void) {
 
 _z_msg_reply_t gen_reply(void) {
     return (_z_msg_reply_t){
-        ._ext_source_info = gen_bool() ? gen_source_info() : _z_source_info_null(),
-        ._timestamp = gen_timestamp(),
-        ._ext_consolidation = (gen_uint8() % 4) - 1,
-        ._value = gen_value(),
+        ._consolidation = (gen_uint8() % 4) - 1,
+        ._body = gen_push_body(),
     };
 }
 
 void assert_eq_reply(const _z_msg_reply_t *left, const _z_msg_reply_t *right) {
-    assert_eq_timestamp(&left->_timestamp, &right->_timestamp);
-    assert_eq_source_info(&left->_ext_source_info, &right->_ext_source_info);
-    assert(left->_ext_consolidation == right->_ext_consolidation);
-    assert_eq_value(&left->_value, &right->_value);
+    assert(left->_consolidation == right->_consolidation);
+    assert_eq_push_body(&left->_body, &right->_body);
 }
 
 void reply_message(void) {

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1661,6 +1661,7 @@ _z_network_message_vec_t gen_net_msgs(size_t n) {
     _z_network_message_vec_t ret = _z_network_message_vec_make(n);
     for (size_t i = 0; i < n; i++) {
         _z_network_message_t *msg = (_z_network_message_t *)zp_malloc(sizeof(_z_network_message_t));
+        memset(msg, 0, sizeof(_z_network_message_t));
         *msg = gen_net_msg();
         _z_network_message_vec_append(&ret, msg);
     }
@@ -1833,7 +1834,7 @@ void scouting_message(void) {
 int main(void) {
     setvbuf(stdout, NULL, _IOLBF, 1024);
 
-    for (unsigned int i = 0; i < RUNS; i++) {
+    for (unsigned int i = 0; i < 1; i++) {
         printf("\n\n== RUN %u", i);
 
         // Message fields

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1384,7 +1384,7 @@ _z_n_msg_response_t gen_response(void) {
             ret._body._err = gen_err();
         } break;
         case 2: {
-            ret._tag = _Z_RESPONSE_BODY_ACK;
+            ret._tag = _Z_RESPONSE_BODY_REPLY;
             ret._body._reply = gen_reply();
         } break;
         default: {
@@ -1835,7 +1835,7 @@ void scouting_message(void) {
 int main(void) {
     setvbuf(stdout, NULL, _IOLBF, 1024);
 
-    for (unsigned int i = 0; i < 1; i++) {
+    for (unsigned int i = 0; i < RUNS; i++) {
         printf("\n\n== RUN %u", i);
 
         // Message fields

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1132,7 +1132,7 @@ void pull_message(void) {
 
 _z_msg_query_t gen_query(void) {
     return (_z_msg_query_t){
-        ._ext_consolidation = (gen_uint8() % 4) - 1,
+        ._consolidation = (gen_uint8() % 4) - 1,
         ._ext_info = gen_source_info(),
         ._parameters = gen_bytes(16),
         ._ext_value = gen_bool() ? gen_value() : _z_value_null(),
@@ -1140,7 +1140,7 @@ _z_msg_query_t gen_query(void) {
 }
 
 void assert_eq_query(const _z_msg_query_t *left, const _z_msg_query_t *right) {
-    assert(left->_ext_consolidation == right->_ext_consolidation);
+    assert(left->_consolidation == right->_consolidation);
     assert_eq_source_info(&left->_ext_info, &right->_ext_info);
     assert_eq_bytes(&left->_parameters, &right->_parameters);
     assert_eq_value(&left->_ext_value, &right->_ext_value);

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -518,8 +518,9 @@ void assert_eq_value(const _z_value_t *left, const _z_value_t *right) {
 _z_timestamp_t gen_timestamp(void) {
     _z_timestamp_t ts;
     ts.time = gen_uint64();
-    _z_bytes_t id = gen_bytes(16);
-    memcpy(ts.id.id, id.start, id.len);
+    for (size_t i = 0; i < 16; i++) {
+        ts.id.id[i] = gen_uint8() & 0x7f;  // 0b01111111
+    }
     return ts;
 }
 

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1165,21 +1165,18 @@ void query_message(void) {
 }
 
 _z_msg_err_t gen_err(void) {
+    size_t len = 1 + gen_uint8();
     return (_z_msg_err_t){
-        ._code = gen_uint16(),
-        ._is_infrastructure = gen_bool(),
-        ._timestamp = gen_timestamp(),
+        .encoding = gen_encoding(),
         ._ext_source_info = gen_bool() ? gen_source_info() : _z_source_info_null(),
-        ._ext_value = gen_bool() ? gen_value() : _z_value_null(),
+        ._payload = gen_payload(len), // Hangs if 0
     };
 }
 
 void assert_eq_err(const _z_msg_err_t *left, const _z_msg_err_t *right) {
-    assert(left->_code == right->_code);
-    assert(left->_is_infrastructure == right->_is_infrastructure);
-    assert_eq_timestamp(&left->_timestamp, &right->_timestamp);
+    assert_eq_encoding(&left->encoding, &right->encoding);
     assert_eq_source_info(&left->_ext_source_info, &right->_ext_source_info);
-    assert_eq_value(&left->_ext_value, &right->_ext_value);
+    assert_eq_bytes(&left->_payload, &right->_payload);
 }
 
 void err_message(void) {

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1169,7 +1169,7 @@ _z_msg_err_t gen_err(void) {
     return (_z_msg_err_t){
         .encoding = gen_encoding(),
         ._ext_source_info = gen_bool() ? gen_source_info() : _z_source_info_null(),
-        ._payload = gen_payload(len), // Hangs if 0
+        ._payload = gen_payload(len),  // Hangs if 0
     };
 }
 


### PR DESCRIPTION
Re-align reply, query and error message format with Zenoh changes.

Plus some bugfix on test_msgcodec.

Part of #344 