### PR TITLE
Store declare information on te receiver side

### DIFF
--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -65,6 +65,7 @@ typedef struct _z_session_t {
     // Session interests
 #if Z_FEATURE_INTEREST == 1
     _z_session_interest_rc_list_t *_local_interests;
+    _z_declare_data_list_t *_remote_declares;
 #endif
 } _z_session_t;
 

--- a/include/zenoh-pico/session/interest.h
+++ b/include/zenoh-pico/session/interest.h
@@ -23,9 +23,9 @@
 _z_session_interest_rc_t *_z_get_interest_by_id(_z_session_t *zn, const _z_zint_t id);
 _z_session_interest_rc_t *_z_register_interest(_z_session_t *zn, _z_session_interest_t *intr);
 void _z_unregister_interest(_z_session_t *zn, _z_session_interest_rc_t *intr);
-void _z_flush_interest(_z_session_t *zn);
 #endif  // Z_FEATURE_INTEREST == 1
 
+void _z_flush_interest(_z_session_t *zn);
 int8_t _z_interest_process_declares(_z_session_t *zn, const _z_declaration_t *decl);
 int8_t _z_interest_process_undeclares(_z_session_t *zn, const _z_declaration_t *decl);
 int8_t _z_interest_process_final_interest(_z_session_t *zn, uint32_t id);

--- a/include/zenoh-pico/session/interest.h
+++ b/include/zenoh-pico/session/interest.h
@@ -27,6 +27,7 @@ void _z_flush_interest(_z_session_t *zn);
 #endif  // Z_FEATURE_INTEREST == 1
 
 int8_t _z_interest_process_declares(_z_session_t *zn, const _z_declaration_t *decl);
+int8_t _z_interest_process_undeclares(_z_session_t *zn, const _z_declaration_t *decl);
 int8_t _z_interest_process_final_interest(_z_session_t *zn, uint32_t id);
 int8_t _z_interest_process_undeclare_interest(_z_session_t *zn, uint32_t id);
 int8_t _z_interest_process_declare_interest(_z_session_t *zn, _z_keyexpr_t key, uint32_t id, uint8_t flags);

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -190,12 +190,12 @@ int8_t _z_session_generate_zid(_z_id_t *bs, uint8_t size);
 
 typedef enum {
     _Z_INTEREST_MSG_TYPE_FINAL = 0,
-    _Z_INTEREST_MSG_TYPE_DECL_SUBSCRIBER,
-    _Z_INTEREST_MSG_TYPE_DECL_QUERYABLE,
-    _Z_INTEREST_MSG_TYPE_DECL_TOKEN,
-    _Z_INTEREST_MSG_TYPE_UNDECL_SUBSCRIBER,
-    _Z_INTEREST_MSG_TYPE_UNDECL_QUERYABLE,
-    _Z_INTEREST_MSG_TYPE_UNDECL_TOKEN,
+    _Z_INTEREST_MSG_TYPE_DECL_SUBSCRIBER = 1,
+    _Z_INTEREST_MSG_TYPE_DECL_QUERYABLE = 2,
+    _Z_INTEREST_MSG_TYPE_DECL_TOKEN = 3,
+    _Z_INTEREST_MSG_TYPE_UNDECL_SUBSCRIBER = 4,
+    _Z_INTEREST_MSG_TYPE_UNDECL_QUERYABLE = 5,
+    _Z_INTEREST_MSG_TYPE_UNDECL_TOKEN = 6,
 } _z_interest_msg_type_t;
 
 typedef struct _z_interest_msg_t {
@@ -224,5 +224,21 @@ _Z_ELEM_DEFINE(_z_session_interest, _z_session_interest_t, _z_noop_size, _z_sess
 _Z_ELEM_DEFINE(_z_session_interest_rc, _z_session_interest_rc_t, _z_noop_size, _z_session_interest_rc_drop,
                _z_noop_copy)
 _Z_LIST_DEFINE(_z_session_interest_rc, _z_session_interest_rc_t)
+
+typedef enum {
+    _Z_DECLARE_TYPE_SUBSCRIBER = 0,
+    _Z_DECLARE_TYPE_QUERYABLE = 1,
+    _Z_DECLARE_TYPE_TOKEN = 2,
+} _z_declare_type_t;
+
+typedef struct {
+    _z_keyexpr_t _key;
+    uint32_t _id;
+    uint8_t _type;
+} _z_declare_data_t;
+
+void _z_declare_data_clear(_z_declare_data_t * data);
+_Z_ELEM_DEFINE(_z_declare_data, _z_declare_data_t, _z_noop_size, _z_declare_data_clear, _z_noop_copy)
+_Z_LIST_DEFINE(_z_declare_data, _z_declare_data_t)
 
 #endif /* INCLUDE_ZENOH_PICO_SESSION_SESSION_H */

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -237,7 +237,7 @@ typedef struct {
     uint8_t _type;
 } _z_declare_data_t;
 
-void _z_declare_data_clear(_z_declare_data_t * data);
+void _z_declare_data_clear(_z_declare_data_t *data);
 _Z_ELEM_DEFINE(_z_declare_data, _z_declare_data_t, _z_noop_size, _z_declare_data_clear, _z_noop_copy)
 _Z_LIST_DEFINE(_z_declare_data, _z_declare_data_t)
 

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -351,6 +351,7 @@ void _z_unregister_interest(_z_session_t *zn, _z_session_interest_rc_t *intr) {
 void _z_flush_interest(_z_session_t *zn) {
     _zp_session_lock_mutex(zn);
     _z_session_interest_rc_list_free(&zn->_local_interests);
+    _z_declare_data_list_free(&zn->_remote_declares);
     _zp_session_unlock_mutex(zn);
 }
 
@@ -407,6 +408,8 @@ int8_t _z_interest_process_declare_interest(_z_session_t *zn, _z_keyexpr_t key, 
 }
 
 #else
+void _z_flush_interest(_z_session_t *zn) { _ZP_UNUSED(zn); }
+
 int8_t _z_interest_process_declares(_z_session_t *zn, const _z_declaration_t *decl) {
     _ZP_UNUSED(zn);
     _ZP_UNUSED(decl);

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -126,8 +126,7 @@ static int8_t _z_send_subscriber_interest(_z_session_t *zn) {
         // Build the declare message to send on the wire
         _z_keyexpr_t key = _z_keyexpr_alias(sub->in->val._key);
         _z_declaration_t declaration =
-            _z_make_decl_subscriber(&key, sub->in->val._id, sub->in->val._info.reliability == Z_RELIABILITY_RELIABLE,
-                                    sub->in->val._info.mode == Z_SUBMODE_PULL);
+            _z_make_decl_subscriber(&key, sub->in->val._id, sub->in->val._info.reliability == Z_RELIABILITY_RELIABLE);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
             return _Z_ERR_TRANSPORT_TX_FAILED;

--- a/src/session/queryable.c
+++ b/src/session/queryable.c
@@ -141,9 +141,7 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
     if (key._suffix != NULL) {
         _z_session_queryable_rc_list_t *qles = __unsafe_z_get_session_queryable_by_key(zn, key);
 
-#if Z_FEATURE_MULTI_THREAD == 1
-        zp_mutex_unlock(&zn->_mutex_inner);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
+        _zp_session_unlock_mutex(zn);
 
         // Build the z_query
         z_query_t query = {._val = {._rc = _z_query_rc_new()}};
@@ -160,10 +158,7 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
         _z_keyexpr_clear(&key);
         _z_session_queryable_rc_list_free(&qles);
     } else {
-#if Z_FEATURE_MULTI_THREAD == 1
-        zp_mutex_unlock(&zn->_mutex_inner);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+        _zp_session_unlock_mutex(zn);
         ret = _Z_ERR_KEYEXPR_UNKNOWN;
     }
 

--- a/src/session/rx.c
+++ b/src/session/rx.c
@@ -70,10 +70,10 @@ int8_t _z_handle_network_message(_z_session_t *zn, _z_zenoh_message_t *msg, uint
                     _z_interest_process_declares(zn, &decl._decl);
                 } break;
                 case _Z_UNDECL_SUBSCRIBER: {
-                    _z_interest_process_declares(zn, &decl._decl);
+                    _z_interest_process_undeclares(zn, &decl._decl);
                 } break;
                 case _Z_UNDECL_QUERYABLE: {
-                    _z_interest_process_declares(zn, &decl._decl);
+                    _z_interest_process_undeclares(zn, &decl._decl);
                 } break;
                 case _Z_DECL_TOKEN: {
                     // TODO: add support or explicitly discard

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -170,9 +170,7 @@ int8_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, co
     if (key._suffix != NULL) {
         _z_subscription_rc_list_t *subs = __unsafe_z_get_subscriptions_by_key(zn, _Z_RESOURCE_IS_LOCAL, key);
 
-#if Z_FEATURE_MULTI_THREAD == 1
-        zp_mutex_unlock(&zn->_mutex_inner);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
+        _zp_session_unlock_mutex(zn);
 
         // Build the sample
         _z_sample_t s;
@@ -195,9 +193,7 @@ int8_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, co
         _z_keyexpr_clear(&key);
         _z_subscription_rc_list_free(&subs);
     } else {
-#if Z_FEATURE_MULTI_THREAD == 1
-        zp_mutex_unlock(&zn->_mutex_inner);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
+        _zp_session_unlock_mutex(zn);
         ret = _Z_ERR_KEYEXPR_UNKNOWN;
     }
 

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -18,6 +18,7 @@
 
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/protocol/core.h"
+#include "zenoh-pico/session/interest.h"
 #include "zenoh-pico/session/query.h"
 #include "zenoh-pico/session/queryable.h"
 #include "zenoh-pico/session/resource.h"
@@ -115,6 +116,7 @@ void _z_session_clear(_z_session_t *zn) {
 #if Z_FEATURE_QUERY == 1
     _z_flush_pending_queries(zn);
 #endif
+    _z_flush_interest(zn);
 
 #if Z_FEATURE_MULTI_THREAD == 1
     zp_mutex_free(&zn->_mutex_inner);


### PR DESCRIPTION
With interest feature on, the receiver will store data from declares in order to retrieve the context simply from the undeclare id as they no longer contain key expressions.

Related to #331 