### PR TITLE
Fix esp32 CI

### DIFF
--- a/.github/workflows/arduino_esp32.yaml
+++ b/.github/workflows/arduino_esp32.yaml
@@ -51,7 +51,7 @@ jobs:
 
           mkdir -p $ARDUINO_BASE
           cd $ARDUINO_BASE
-          platformio init -b esp32thing_plus --project-option="build_flags=-DZ_FEATURE_LINK_BLUETOOTH=1 -DZENOH_DEBUG=3 -DZENOH_COMPILER_GCC"
+          platformio init -b esp32thing_plus -O "build_flags=-DZ_FEATURE_LINK_BLUETOOTH=1 -DZENOH_DEBUG=3 -DZENOH_COMPILER_GCC" -O "lib_ldf_mode=deep+"
 
           cd $ARDUINO_BASE/lib
           ln -s $ZENOH_PICO_BASE

--- a/include/zenoh-pico/link/config/bt.h
+++ b/include/zenoh-pico/link/config/bt.h
@@ -32,14 +32,14 @@
 #define BT_CONFIG_TOUT_KEY 0x03
 #define BT_CONFIG_TOUT_STR "tout"
 
-#define BT_CONFIG_MAPPING_BUILD               \
-    _z_str_intmapping_t args[BT_CONFIG_ARGC]; \
-    args[0]._key = BT_CONFIG_MODE_KEY;        \
-    args[0]._str = BT_CONFIG_MODE_STR;        \
-    args[1]._key = BT_CONFIG_PROFILE_KEY;     \
-    args[1]._str = BT_CONFIG_PROFILE_STR;     \
-    args[2]._key = BT_CONFIG_TOUT_KEY;        \
-    args[2]._str = BT_CONFIG_TOUT_STR;
+#define BT_CONFIG_MAPPING_BUILD                   \
+    _z_str_intmapping_t args[BT_CONFIG_ARGC];     \
+    args[0]._key = BT_CONFIG_MODE_KEY;            \
+    args[0]._str = (char *)BT_CONFIG_MODE_STR;    \
+    args[1]._key = BT_CONFIG_PROFILE_KEY;         \
+    args[1]._str = (char *)BT_CONFIG_PROFILE_STR; \
+    args[2]._key = BT_CONFIG_TOUT_KEY;            \
+    args[2]._str = (char *)BT_CONFIG_TOUT_STR;
 
 size_t _z_bt_config_strlen(const _z_str_intmap_t *s);
 

--- a/include/zenoh-pico/link/config/serial.h
+++ b/include/zenoh-pico/link/config/serial.h
@@ -45,7 +45,7 @@
 #define SERIAL_CONFIG_MAPPING_BUILD               \
     _z_str_intmapping_t args[SERIAL_CONFIG_ARGC]; \
     args[0]._key = SERIAL_CONFIG_BAUDRATE_KEY;    \
-    args[0]._str = SERIAL_CONFIG_BAUDRATE_STR;
+    args[0]._str = (char *)SERIAL_CONFIG_BAUDRATE_STR;
 // args[1]._key = SERIAL_CONFIG_DATABITS_KEY;
 // args[1]._str = SERIAL_CONFIG_DATABITS_STR;
 // args[2]._key = SERIAL_CONFIG_FLOWCONTROL_KEY;

--- a/include/zenoh-pico/link/config/tcp.h
+++ b/include/zenoh-pico/link/config/tcp.h
@@ -29,7 +29,7 @@
 #define TCP_CONFIG_MAPPING_BUILD               \
     _z_str_intmapping_t args[TCP_CONFIG_ARGC]; \
     args[0]._key = TCP_CONFIG_TOUT_KEY;        \
-    args[0]._str = TCP_CONFIG_TOUT_STR;
+    args[0]._str = (char *)TCP_CONFIG_TOUT_STR;
 
 size_t _z_tcp_config_strlen(const _z_str_intmap_t *s);
 

--- a/include/zenoh-pico/link/config/udp.h
+++ b/include/zenoh-pico/link/config/udp.h
@@ -30,14 +30,14 @@
 #define UDP_CONFIG_JOIN_STR "join"
 
 #if Z_FEATURE_LINK_UDP_UNICAST == 1 || Z_FEATURE_LINK_UDP_MULTICAST == 1
-#define UDP_CONFIG_MAPPING_BUILD               \
-    _z_str_intmapping_t args[UDP_CONFIG_ARGC]; \
-    args[0]._key = UDP_CONFIG_IFACE_KEY;       \
-    args[0]._str = UDP_CONFIG_IFACE_STR;       \
-    args[1]._key = UDP_CONFIG_TOUT_KEY;        \
-    args[1]._str = UDP_CONFIG_TOUT_STR;        \
-    args[2]._key = UDP_CONFIG_JOIN_KEY;        \
-    args[2]._str = UDP_CONFIG_JOIN_STR;
+#define UDP_CONFIG_MAPPING_BUILD                 \
+    _z_str_intmapping_t args[UDP_CONFIG_ARGC];   \
+    args[0]._key = UDP_CONFIG_IFACE_KEY;         \
+    args[0]._str = (char *)UDP_CONFIG_IFACE_STR; \
+    args[1]._key = UDP_CONFIG_TOUT_KEY;          \
+    args[1]._str = (char *)UDP_CONFIG_TOUT_STR;  \
+    args[2]._key = UDP_CONFIG_JOIN_KEY;          \
+    args[2]._str = (char *)UDP_CONFIG_JOIN_STR;
 
 size_t _z_udp_config_strlen(const _z_str_intmap_t *s);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -502,19 +502,19 @@ int8_t z_scout(z_owned_scouting_config_t *config, z_owned_closure_hello_t *callb
 
         char *opt_as_str = _z_config_get(config->_value, Z_CONFIG_SCOUTING_WHAT_KEY);
         if (opt_as_str == NULL) {
-            opt_as_str = Z_CONFIG_SCOUTING_WHAT_DEFAULT;
+            opt_as_str = (char *)Z_CONFIG_SCOUTING_WHAT_DEFAULT;
         }
         z_what_t what = strtol(opt_as_str, NULL, 10);
 
         opt_as_str = _z_config_get(config->_value, Z_CONFIG_MULTICAST_LOCATOR_KEY);
         if (opt_as_str == NULL) {
-            opt_as_str = Z_CONFIG_MULTICAST_LOCATOR_DEFAULT;
+            opt_as_str = (char *)Z_CONFIG_MULTICAST_LOCATOR_DEFAULT;
         }
         char *mcast_locator = opt_as_str;
 
         opt_as_str = _z_config_get(config->_value, Z_CONFIG_SCOUTING_TIMEOUT_KEY);
         if (opt_as_str == NULL) {
-            opt_as_str = Z_CONFIG_SCOUTING_TIMEOUT_DEFAULT;
+            opt_as_str = (char *)Z_CONFIG_SCOUTING_TIMEOUT_DEFAULT;
         }
         uint32_t timeout = strtoul(opt_as_str, NULL, 10);
 

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -71,19 +71,19 @@ int8_t _z_open(_z_session_t *zn, _z_config_t *config) {
         if (connect == NULL && listen == NULL) {  // Scout if peer is not configured
             opt_as_str = _z_config_get(config, Z_CONFIG_SCOUTING_WHAT_KEY);
             if (opt_as_str == NULL) {
-                opt_as_str = Z_CONFIG_SCOUTING_WHAT_DEFAULT;
+                opt_as_str = (char *)Z_CONFIG_SCOUTING_WHAT_DEFAULT;
             }
             z_what_t what = strtol(opt_as_str, NULL, 10);
 
             opt_as_str = _z_config_get(config, Z_CONFIG_MULTICAST_LOCATOR_KEY);
             if (opt_as_str == NULL) {
-                opt_as_str = Z_CONFIG_MULTICAST_LOCATOR_DEFAULT;
+                opt_as_str = (char *)Z_CONFIG_MULTICAST_LOCATOR_DEFAULT;
             }
             char *mcast_locator = opt_as_str;
 
             opt_as_str = _z_config_get(config, Z_CONFIG_SCOUTING_TIMEOUT_KEY);
             if (opt_as_str == NULL) {
-                opt_as_str = Z_CONFIG_SCOUTING_TIMEOUT_DEFAULT;
+                opt_as_str = (char *)Z_CONFIG_SCOUTING_TIMEOUT_DEFAULT;
             }
             uint32_t timeout = strtoul(opt_as_str, NULL, 10);
 


### PR DESCRIPTION
The new version of platformIO (6.1.14) changed the way it handles dependency (potentially a bug on their side) which made the CI fail as platformIO couldn't find the esp32 lib `BluetoothSerial`.

This PR:
* Adds an option for platformio dependency check
* Correct discard const warnings

