### PR TITLE
Decode fails when interest id flag is set

### DIFF
--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -95,6 +95,8 @@ typedef struct {
 } _z_undecl_interest_t;
 _z_undecl_interest_t _z_undecl_interest_null(void);
 
+#define _Z_FLAG_INTEREST_ID (1 << 5)
+
 typedef struct {
     enum {
         _Z_DECL_KEXPR,

--- a/src/protocol/codec/declarations.c
+++ b/src/protocol/codec/declarations.c
@@ -427,9 +427,13 @@ int8_t _z_undecl_interest_decode(_z_undecl_interest_t *decl, _z_zbuf_t *zbf, uin
     return _z_undecl_trivial_decode(zbf, &decl->_ext_keyexpr, &decl->_id, header);
 }
 int8_t _z_declaration_decode(_z_declaration_t *decl, _z_zbuf_t *zbf) {
-    int8_t ret;
     uint8_t header;
     _Z_RETURN_IF_ERR(_z_uint8_decode(&header, zbf));
+    if (_Z_HAS_FLAG(header, _Z_FLAG_INTEREST_ID)) {
+        return _Z_ERR_MESSAGE_FLAG_UNEXPECTED;
+    }
+
+    int8_t ret;
     switch (_Z_MID(header)) {
         case _Z_DECL_KEXPR_MID: {
             decl->_tag = _Z_DECL_KEXPR;


### PR DESCRIPTION
https://github.com/eclipse-zenoh/zenoh/pull/870 adds an interest id in the declare message to disambiguate wether the declaration is sent in a response of a declare interest with `future == false` or not.

However, zenoh-pico never sends an interest with `future == false`, so the interest id should never be set. If set, it means the protocol is misbehaving. Therefore, we return an error during decoding.