### PR TITLE
Fix concurrency issue on task_running value

### DIFF
--- a/src/transport/multicast/lease.c
+++ b/src/transport/multicast/lease.c
@@ -184,13 +184,14 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
 int8_t _zp_multicast_start_lease_task(_z_transport_multicast_t *ztm, z_task_attr_t *attr, z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(z_task_t));
+    ztm->_lease_task_running = true;  // Init before z_task_init for concurrency issue
     // Init task
     if (z_task_init(task, attr, _zp_multicast_lease_task, ztm) != _Z_RES_OK) {
+        ztm->_lease_task_running = false;
         return _Z_ERR_SYSTEM_TASK_FAILED;
     }
     // Attach task
     ztm->_lease_task = task;
-    ztm->_lease_task_running = true;
     return _Z_RES_OK;
 }
 

--- a/src/transport/multicast/read.c
+++ b/src/transport/multicast/read.c
@@ -131,13 +131,14 @@ void *_zp_multicast_read_task(void *ztm_arg) {
 int8_t _zp_multicast_start_read_task(_z_transport_t *zt, z_task_attr_t *attr, z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(z_task_t));
+    zt->_transport._multicast._read_task_running = true;  // Init before z_task_init for concurrency issue
     // Init task
     if (z_task_init(task, attr, _zp_multicast_read_task, &zt->_transport._multicast) != _Z_RES_OK) {
+        zt->_transport._multicast._read_task_running = false;
         return _Z_ERR_SYSTEM_TASK_FAILED;
     }
     // Attach task
     zt->_transport._multicast._read_task = task;
-    zt->_transport._multicast._read_task_running = true;
     return _Z_RES_OK;
 }
 

--- a/src/transport/raweth/read.c
+++ b/src/transport/raweth/read.c
@@ -86,13 +86,14 @@ void *_zp_raweth_read_task(void *ztm_arg) {
 int8_t _zp_raweth_start_read_task(_z_transport_t *zt, z_task_attr_t *attr, z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(z_task_t));
+    zt->_transport._raweth._read_task_running = true;  // Init before z_task_init for concurrency issue
     // Init task
     if (z_task_init(task, attr, _zp_raweth_read_task, &zt->_transport._raweth) != _Z_RES_OK) {
+        zt->_transport._raweth._read_task_running = false;
         return _Z_ERR_SYSTEM_TASK_FAILED;
     }
     // Attach task
     zt->_transport._raweth._read_task = task;
-    zt->_transport._raweth._read_task_running = true;
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/lease.c
+++ b/src/transport/unicast/lease.c
@@ -98,13 +98,14 @@ void *_zp_unicast_lease_task(void *ztu_arg) {
 int8_t _zp_unicast_start_lease_task(_z_transport_t *zt, z_task_attr_t *attr, z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(z_task_t));
+    zt->_transport._unicast._lease_task_running = true;  // Init before z_task_init for concurrency issue
     // Init task
     if (z_task_init(task, attr, _zp_unicast_lease_task, &zt->_transport._unicast) != _Z_RES_OK) {
+        zt->_transport._unicast._lease_task_running = false;
         return _Z_ERR_SYSTEM_TASK_FAILED;
     }
     // Attach task
     zt->_transport._unicast._lease_task = task;
-    zt->_transport._unicast._lease_task_running = true;
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/read.c
+++ b/src/transport/unicast/read.c
@@ -124,13 +124,14 @@ void *_zp_unicast_read_task(void *ztu_arg) {
 int8_t _zp_unicast_start_read_task(_z_transport_t *zt, z_task_attr_t *attr, z_task_t *task) {
     // Init memory
     (void)memset(task, 0, sizeof(z_task_t));
+    zt->_transport._unicast._read_task_running = true;  // Init before z_task_init for concurrency issue
     // Init task
     if (z_task_init(task, attr, _zp_unicast_read_task, &zt->_transport._unicast) != _Z_RES_OK) {
+        zt->_transport._unicast._read_task_running = false;
         return _Z_ERR_SYSTEM_TASK_FAILED;
     }
     // Attach task
     zt->_transport._unicast._read_task = task;
-    zt->_transport._unicast._read_task_running = true;
     return _Z_RES_OK;
 }
 


### PR DESCRIPTION
#306 introduced a concurrency issue on `task_running` which caused some OS (espidf) to stop their read & lease tasks at startup. This PR revert this issue.

@oteffahi could you do the review?