### PR TITLE
Fix bad value used to set reliability flag

### DIFF
--- a/include/zenoh-pico/protocol/definitions/transport.h
+++ b/include/zenoh-pico/protocol/definitions/transport.h
@@ -505,10 +505,12 @@ _z_transport_message_t _z_t_msg_make_open_syn(_z_zint_t lease, _z_zint_t initial
 _z_transport_message_t _z_t_msg_make_open_ack(_z_zint_t lease, _z_zint_t initial_sn);
 _z_transport_message_t _z_t_msg_make_close(uint8_t reason, _Bool link_only);
 _z_transport_message_t _z_t_msg_make_keep_alive(void);
-_z_transport_message_t _z_t_msg_make_frame(_z_zint_t sn, _z_network_message_vec_t messages, _Bool is_reliable);
-_z_transport_message_t _z_t_msg_make_frame_header(_z_zint_t sn, _Bool is_reliable);
-_z_transport_message_t _z_t_msg_make_fragment_header(_z_zint_t sn, _Bool is_reliable, _Bool is_last);
-_z_transport_message_t _z_t_msg_make_fragment(_z_zint_t sn, _z_bytes_t messages, _Bool is_reliable, _Bool is_last);
+_z_transport_message_t _z_t_msg_make_frame(_z_zint_t sn, _z_network_message_vec_t messages,
+                                           z_reliability_t reliability);
+_z_transport_message_t _z_t_msg_make_frame_header(_z_zint_t sn, z_reliability_t reliability);
+_z_transport_message_t _z_t_msg_make_fragment_header(_z_zint_t sn, z_reliability_t reliability, _Bool is_last);
+_z_transport_message_t _z_t_msg_make_fragment(_z_zint_t sn, _z_bytes_t messages, z_reliability_t reliability,
+                                              _Bool is_last);
 
 /*------------------ Copy ------------------*/
 void _z_t_msg_copy(_z_transport_message_t *clone, _z_transport_message_t *msg);

--- a/src/protocol/definitions/transport.c
+++ b/src/protocol/definitions/transport.c
@@ -203,12 +203,13 @@ _z_transport_message_t _z_t_msg_make_keep_alive(void) {
     return msg;
 }
 
-_z_transport_message_t _z_t_msg_make_frame(_z_zint_t sn, _z_network_message_vec_t messages, _Bool is_reliable) {
+_z_transport_message_t _z_t_msg_make_frame(_z_zint_t sn, _z_network_message_vec_t messages,
+                                           z_reliability_t reliability) {
     _z_transport_message_t msg;
     msg._header = _Z_MID_T_FRAME;
 
     msg._body._frame._sn = sn;
-    if (is_reliable == true) {
+    if (reliability == Z_RELIABILITY_RELIABLE) {
         _Z_SET_FLAG(msg._header, _Z_FLAG_T_FRAME_R);
     }
 
@@ -218,12 +219,12 @@ _z_transport_message_t _z_t_msg_make_frame(_z_zint_t sn, _z_network_message_vec_
 }
 
 /*------------------ Frame Message ------------------*/
-_z_transport_message_t _z_t_msg_make_frame_header(_z_zint_t sn, _Bool is_reliable) {
+_z_transport_message_t _z_t_msg_make_frame_header(_z_zint_t sn, z_reliability_t reliability) {
     _z_transport_message_t msg;
     msg._header = _Z_MID_T_FRAME;
 
     msg._body._frame._sn = sn;
-    if (is_reliable == true) {
+    if (reliability == Z_RELIABILITY_RELIABLE) {
         _Z_SET_FLAG(msg._header, _Z_FLAG_T_FRAME_R);
     }
 
@@ -233,16 +234,17 @@ _z_transport_message_t _z_t_msg_make_frame_header(_z_zint_t sn, _Bool is_reliabl
 }
 
 /*------------------ Fragment Message ------------------*/
-_z_transport_message_t _z_t_msg_make_fragment_header(_z_zint_t sn, _Bool is_reliable, _Bool is_last) {
-    return _z_t_msg_make_fragment(sn, _z_bytes_empty(), is_reliable, is_last);
+_z_transport_message_t _z_t_msg_make_fragment_header(_z_zint_t sn, z_reliability_t reliability, _Bool is_last) {
+    return _z_t_msg_make_fragment(sn, _z_bytes_empty(), reliability, is_last);
 }
-_z_transport_message_t _z_t_msg_make_fragment(_z_zint_t sn, _z_bytes_t payload, _Bool is_reliable, _Bool is_last) {
+_z_transport_message_t _z_t_msg_make_fragment(_z_zint_t sn, _z_bytes_t payload, z_reliability_t reliability,
+                                              _Bool is_last) {
     _z_transport_message_t msg;
     msg._header = _Z_MID_T_FRAGMENT;
     if (is_last == false) {
         _Z_SET_FLAG(msg._header, _Z_FLAG_T_FRAGMENT_M);
     }
-    if (is_reliable == true) {
+    if (reliability == Z_RELIABILITY_RELIABLE) {
         _Z_SET_FLAG(msg._header, _Z_FLAG_T_FRAGMENT_R);
     }
 


### PR DESCRIPTION
A reliability enum value was forced as a boolean and caused the reliability flag to no be set correctly. Could you review this @OlivierHecart?

This PR will close #412.