### PR TITLE
Disable raweth testing

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -54,6 +54,19 @@ jobs:
           sudo apt install -y ninja-build
           FORCE_C99=ON CMAKE_GENERATOR=Ninja make
 
+  raweth_build:
+    name: Build raweth transport on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build raweth
+        run: |
+          sudo apt install -y ninja-build
+          Z_FEATURE_RAWETH_TRANSPORT=1 CMAKE_GENERATOR=Ninja make
+        
+
   zenoh_build:
     name: Build Zenoh from source
     runs-on: ubuntu-latest
@@ -114,25 +127,6 @@ jobs:
       - name: Kill Zenoh router
         if: always()
         run: kill ${{ steps.run-zenoh.outputs.zenohd-pid }}
-
-  raweth_build:
-    name: Build and test raweth transport on ubuntu-latest
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature_reth: [1, 0]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build project and run test
-        run: |
-          sudo apt install -y ninja-build
-          CMAKE_GENERATOR=Ninja make
-          python3 ./build/tests/raweth.py --reth $Z_FEATURE_RAWETH_TRANSPORT
-        timeout-minutes: 5
-        env:
-          Z_FEATURE_RAWETH_TRANSPORT: ${{ matrix.feature_reth }}
 
   st_build:
     needs: zenoh_build


### PR DESCRIPTION
The raweth test isn't stable when run on the CI and fails while it works locally. As this feature is not critical, the test will be deactivated for now.