### PR TITLE
Move and rename macros for define owned/loaned/view types

### DIFF
--- a/include/zenoh-pico/api/olv_macros.h
+++ b/include/zenoh-pico/api/olv_macros.h
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#ifndef INCLUDE_ZENOH_PICO_API_OLV_MACROS_H
+#define INCLUDE_ZENOH_PICO_API_OLV_MACROS_H
+
+// Owned/Loaned/View type macros
+//
+// !!! FOR INTERNAL USAGE ONLY !!!
+
+// For pointer types
+#define _Z_OWNED_TYPE_PTR(type, name) \
+    typedef struct {                  \
+        type *_val;                   \
+    } z_owned_##name##_t;
+
+// For refcounted types
+#define _Z_OWNED_TYPE_RC(type, name) \
+    typedef struct {                 \
+        type _rc;                    \
+    } z_owned_##name##_t;
+
+#define _Z_LOANED_TYPE(type, name) typedef type z_loaned_##name##_t;
+
+#define _Z_VIEW_TYPE(type, name) \
+    typedef struct {             \
+        type _val;               \
+    } z_view_##name##_t;
+
+#define _Z_OWNED_FUNCTIONS_DEF(loanedtype, ownedtype, name)         \
+    _Bool z_##name##_check(const ownedtype *obj);                   \
+    const loanedtype *z_##name##_loan(const ownedtype *obj);        \
+    loanedtype *z_##name##_loan_mut(ownedtype *obj);                \
+    ownedtype *z_##name##_move(ownedtype *obj);                     \
+    int8_t z_##name##_clone(ownedtype *obj, const loanedtype *src); \
+    void z_##name##_drop(ownedtype *obj);                           \
+    void z_##name##_null(ownedtype *obj);
+
+#define _Z_VIEW_FUNCTIONS_DEF(loanedtype, viewtype, name)         \
+    const loanedtype *z_view_##name##_loan(const viewtype *name); \
+    loanedtype *z_view_##name##_loan_mut(viewtype *name);         \
+    void z_view_##name##_null(viewtype *name);
+
+#define _Z_OWNED_FUNCTIONS_PTR_IMPL(type, name, f_copy, f_free)                                     \
+    _Bool z_##name##_check(const z_owned_##name##_t *obj) { return obj->_val != NULL; }             \
+    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return obj->_val; } \
+    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return obj->_val; }         \
+    void z_##name##_null(z_owned_##name##_t *obj) { obj->_val = NULL; }                             \
+    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }                    \
+    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
+        int8_t ret = _Z_RES_OK;                                                                     \
+        obj->_val = (type *)z_malloc(sizeof(type));                                                 \
+        if (obj->_val != NULL) {                                                                    \
+            f_copy(obj->_val, src);                                                                 \
+        } else {                                                                                    \
+            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                      \
+        }                                                                                           \
+        return ret;                                                                                 \
+    }                                                                                               \
+    void z_##name##_drop(z_owned_##name##_t *obj) {                                                 \
+        if ((obj != NULL) && (obj->_val != NULL)) {                                                 \
+            f_free(&obj->_val);                                                                     \
+        }                                                                                           \
+    }
+
+#define _Z_OWNED_FUNCTIONS_RC_IMPL(name)                                                            \
+    _Bool z_##name##_check(const z_owned_##name##_t *val) { return val->_rc.in != NULL; }           \
+    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; } \
+    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }         \
+    void z_##name##_null(z_owned_##name##_t *val) { val->_rc.in = NULL; }                           \
+    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *val) { return val; }                    \
+    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
+        int8_t ret = _Z_RES_OK;                                                                     \
+        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                \
+        if (obj->_rc.in == NULL) {                                                                  \
+            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                      \
+        }                                                                                           \
+        return ret;                                                                                 \
+    }                                                                                               \
+    void z_##name##_drop(z_owned_##name##_t *val) {                                                 \
+        if (val->_rc.in != NULL) {                                                                  \
+            if (_z_##name##_rc_drop(&val->_rc)) {                                                   \
+                val->_rc.in = NULL;                                                                 \
+            }                                                                                       \
+        }                                                                                           \
+    }
+
+#define _Z_VIEW_FUNCTIONS_PTR_IMPL(type, name)                                                           \
+    const z_loaned_##name##_t *z_view_##name##_loan(const z_view_##name##_t *obj) { return &obj->_val; } \
+    z_loaned_##name##_t *z_view_##name##_loan_mut(z_view_##name##_t *obj) { return &obj->_val; }
+
+#define _Z_OWNED_FUNCTIONS_CLOSURE_DEF(ownedtype, name) \
+    _Bool z_##name##_check(const ownedtype *val);       \
+    ownedtype *z_##name##_move(ownedtype *val);         \
+    void z_##name##_drop(ownedtype *val);               \
+    void z_##name##_null(ownedtype *name);
+
+#define _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(ownedtype, name, f_call, f_drop)           \
+    _Bool z_##name##_check(const ownedtype *val) { return val->call != NULL; }     \
+    ownedtype *z_##name##_move(ownedtype *val) { return val; }                     \
+    void z_##name##_drop(ownedtype *val) {                                         \
+        if (val->drop != NULL) {                                                   \
+            (val->drop)(val->context);                                             \
+            val->drop = NULL;                                                      \
+        }                                                                          \
+        val->call = NULL;                                                          \
+        val->context = NULL;                                                       \
+    }                                                                              \
+    void z_##name##_null(ownedtype *val) {                                         \
+        val->call = NULL;                                                          \
+        val->drop = NULL;                                                          \
+        val->context = NULL;                                                       \
+    }                                                                              \
+    int8_t z_##name(ownedtype *closure, f_call call, f_drop drop, void *context) { \
+        closure->call = call;                                                      \
+        closure->drop = drop;                                                      \
+        closure->context = context;                                                \
+                                                                                   \
+        return _Z_RES_OK;                                                          \
+    }
+
+// Gets internal value from refcounted type (e.g. z_loaned_session_t, z_query_t)
+#define _Z_RC_IN_VAL(arg) ((arg)->in->val)
+
+// Gets internal value from refcounted owned type (e.g. z_owned_session_t, z_owned_query_t)
+#define _Z_OWNED_RC_IN_VAL(arg) ((arg)->_rc.in->val)
+
+#endif /* INCLUDE_ZENOH_PICO_API_OLV_MACROS_H */

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "olv_macros.h"
 #include "zenoh-pico/api/types.h"
 #include "zenoh-pico/net/query.h"
 #include "zenoh-pico/net/session.h"
@@ -1029,60 +1030,34 @@ int8_t z_closure_hello(z_owned_closure_hello_t *closure, z_loaned_hello_handler_
 int8_t z_closure_zid(z_owned_closure_zid_t *closure, z_id_handler_t call, z_dropper_handler_t drop, void *context);
 
 /**************** Loans ****************/
-#define _OWNED_FUNCTIONS(loanedtype, ownedtype, name)               \
-    _Bool z_##name##_check(const ownedtype *obj);                   \
-    const loanedtype *z_##name##_loan(const ownedtype *obj);        \
-    loanedtype *z_##name##_loan_mut(ownedtype *obj);                \
-    ownedtype *z_##name##_move(ownedtype *obj);                     \
-    int8_t z_##name##_clone(ownedtype *obj, const loanedtype *src); \
-    void z_##name##_drop(ownedtype *obj);                           \
-    void z_##name##_null(ownedtype *obj);
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_string_t, z_owned_string_t, string)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_keyexpr_t, z_owned_keyexpr_t, keyexpr)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_config_t, z_owned_config_t, config)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_scouting_config_t, z_owned_scouting_config_t, scouting_config)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_session_t, z_owned_session_t, session)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_subscriber_t, z_owned_subscriber_t, subscriber)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_publisher_t, z_owned_publisher_t, publisher)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_queryable_t, z_owned_queryable_t, queryable)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_hello_t, z_owned_hello_t, hello)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_reply_t, z_owned_reply_t, reply)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_string_array_t, z_owned_string_array_t, string_array)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_sample_t, z_owned_sample_t, sample)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_query_t, z_owned_query_t, query)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_slice_t, z_owned_slice_t, slice)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_bytes_t, z_owned_bytes_t, bytes)
+_Z_OWNED_FUNCTIONS_DEF(z_loaned_value_t, z_owned_value_t, value)
 
-_OWNED_FUNCTIONS(z_loaned_string_t, z_owned_string_t, string)
-_OWNED_FUNCTIONS(z_loaned_keyexpr_t, z_owned_keyexpr_t, keyexpr)
-_OWNED_FUNCTIONS(z_loaned_config_t, z_owned_config_t, config)
-_OWNED_FUNCTIONS(z_loaned_scouting_config_t, z_owned_scouting_config_t, scouting_config)
-_OWNED_FUNCTIONS(z_loaned_session_t, z_owned_session_t, session)
-_OWNED_FUNCTIONS(z_loaned_subscriber_t, z_owned_subscriber_t, subscriber)
-_OWNED_FUNCTIONS(z_loaned_publisher_t, z_owned_publisher_t, publisher)
-_OWNED_FUNCTIONS(z_loaned_queryable_t, z_owned_queryable_t, queryable)
-_OWNED_FUNCTIONS(z_loaned_hello_t, z_owned_hello_t, hello)
-_OWNED_FUNCTIONS(z_loaned_reply_t, z_owned_reply_t, reply)
-_OWNED_FUNCTIONS(z_loaned_string_array_t, z_owned_string_array_t, string_array)
-_OWNED_FUNCTIONS(z_loaned_sample_t, z_owned_sample_t, sample)
-_OWNED_FUNCTIONS(z_loaned_query_t, z_owned_query_t, query)
-_OWNED_FUNCTIONS(z_loaned_slice_t, z_owned_slice_t, slice)
-_OWNED_FUNCTIONS(z_loaned_bytes_t, z_owned_bytes_t, bytes)
-_OWNED_FUNCTIONS(z_loaned_value_t, z_owned_value_t, value)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_sample_t, closure_sample)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_sample_t, closure_owned_sample)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_query_t, closure_query)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_query_t, closure_owned_query)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_reply_t, closure_reply)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_reply_t, closure_owned_reply)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_hello_t, closure_hello)
+_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_zid_t, closure_zid)
 
-#define _OWNED_FUNCTIONS_CLOSURE(ownedtype, name) \
-    _Bool z_##name##_check(const ownedtype *val); \
-    ownedtype *z_##name##_move(ownedtype *val);   \
-    void z_##name##_drop(ownedtype *val);         \
-    void z_##name##_null(ownedtype *name);
-
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_sample_t, closure_sample)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_reply_t, closure_owned_reply)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello)
-_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid)
-
-#define _VIEW_FUNCTIONS(loanedtype, viewtype, name)               \
-    const loanedtype *z_view_##name##_loan(const viewtype *name); \
-    loanedtype *z_view_##name##_loan_mut(viewtype *name);         \
-    void z_view_##name##_null(viewtype *name);
-
-_VIEW_FUNCTIONS(z_loaned_keyexpr_t, z_view_keyexpr_t, keyexpr)
-_VIEW_FUNCTIONS(z_loaned_string_t, z_view_string_t, string)
-
-// Gets internal value from refcounted type (e.g. z_loaned_session_t, z_query_t)
-#define _Z_RC_IN_VAL(arg) ((arg)->in->val)
-
-// Gets internal value from refcounted owned type (e.g. z_owned_session_t, z_owned_query_t)
-#define _Z_OWNED_RC_IN_VAL(arg) ((arg)->_rc.in->val)
+_Z_VIEW_FUNCTIONS_DEF(z_loaned_keyexpr_t, z_view_keyexpr_t, keyexpr)
+_Z_VIEW_FUNCTIONS_DEF(z_loaned_string_t, z_view_string_t, string)
 
 /**
  * Loans a :c:type:`z_owned_sample_t`.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -15,6 +15,7 @@
 #ifndef INCLUDE_ZENOH_PICO_API_TYPES_H
 #define INCLUDE_ZENOH_PICO_API_TYPES_H
 
+#include "olv_macros.h"
 #include "zenoh-pico/collections/element.h"
 #include "zenoh-pico/collections/list.h"
 #include "zenoh-pico/collections/slice.h"
@@ -31,27 +32,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Owned/Loaned types */
-
-// For pointer types
-#define _OWNED_TYPE_PTR(type, name) \
-    typedef struct {                \
-        type *_val;                 \
-    } z_owned_##name##_t;
-
-// For refcounted types
-#define _OWNED_TYPE_RC(type, name) \
-    typedef struct {               \
-        type _rc;                  \
-    } z_owned_##name##_t;
-
-#define _LOANED_TYPE(type, name) typedef type z_loaned_##name##_t;
-
-#define _VIEW_TYPE(type, name) \
-    typedef struct {           \
-        type _val;             \
-    } z_view_##name##_t;
 
 /**
  * Represents a variable-length encoding unsigned integer.
@@ -82,8 +62,8 @@ typedef _z_timestamp_t z_timestamp_t;
  *   size_t len: The length of the bytes array.
  *   uint8_t *start: A pointer to the bytes array.
  */
-_OWNED_TYPE_PTR(_z_slice_t, slice)
-_LOANED_TYPE(_z_slice_t, slice)
+_Z_OWNED_TYPE_PTR(_z_slice_t, slice)
+_Z_LOANED_TYPE(_z_slice_t, slice)
 
 /**
  * Represents a container for slices.
@@ -91,8 +71,8 @@ _LOANED_TYPE(_z_slice_t, slice)
  * Members:
  *   _z_slice_t slice: content of the container.
  */
-_OWNED_TYPE_PTR(_z_bytes_t, bytes)
-_LOANED_TYPE(_z_bytes_t, bytes)
+_Z_OWNED_TYPE_PTR(_z_bytes_t, bytes)
+_Z_LOANED_TYPE(_z_bytes_t, bytes)
 
 /**
  * Represents a string without null-terminator.
@@ -101,9 +81,9 @@ _LOANED_TYPE(_z_bytes_t, bytes)
  *   size_t len: The length of the string.
  *   const char *val: A pointer to the string.
  */
-_OWNED_TYPE_PTR(_z_string_t, string)
-_LOANED_TYPE(_z_string_t, string)
-_VIEW_TYPE(_z_string_t, string)
+_Z_OWNED_TYPE_PTR(_z_string_t, string)
+_Z_LOANED_TYPE(_z_string_t, string)
+_Z_VIEW_TYPE(_z_string_t, string)
 
 /**
  * Represents a key expression in Zenoh.
@@ -115,9 +95,9 @@ _VIEW_TYPE(_z_string_t, string)
  *   - :c:func:`z_keyexpr_to_string`
  *   - :c:func:`zp_keyexpr_resolve`
  */
-_OWNED_TYPE_PTR(_z_keyexpr_t, keyexpr)
-_LOANED_TYPE(_z_keyexpr_t, keyexpr)
-_VIEW_TYPE(_z_keyexpr_t, keyexpr)
+_Z_OWNED_TYPE_PTR(_z_keyexpr_t, keyexpr)
+_Z_LOANED_TYPE(_z_keyexpr_t, keyexpr)
+_Z_VIEW_TYPE(_z_keyexpr_t, keyexpr)
 
 /**
  * Represents a Zenoh configuration, used to configure Zenoh sessions upon opening.
@@ -129,8 +109,8 @@ _VIEW_TYPE(_z_keyexpr_t, keyexpr)
  *   - :c:func:`zp_config_get`
  *   - :c:func:`zp_config_insert`
  */
-_OWNED_TYPE_PTR(_z_config_t, config)
-_LOANED_TYPE(_z_config_t, config)
+_Z_OWNED_TYPE_PTR(_z_config_t, config)
+_Z_LOANED_TYPE(_z_config_t, config)
 
 /**
  * Represents a scouting configuration, used to configure a scouting procedure.
@@ -142,14 +122,14 @@ _LOANED_TYPE(_z_config_t, config)
  *   - :c:func:`zp_scouting_config_get`
  *   - :c:func:`zp_scouting_config_insert`
  */
-_OWNED_TYPE_PTR(_z_scouting_config_t, scouting_config)
-_LOANED_TYPE(_z_scouting_config_t, scouting_config)
+_Z_OWNED_TYPE_PTR(_z_scouting_config_t, scouting_config)
+_Z_LOANED_TYPE(_z_scouting_config_t, scouting_config)
 
 /**
  * Represents a Zenoh Session.
  */
-_OWNED_TYPE_RC(_z_session_rc_t, session)
-_LOANED_TYPE(_z_session_rc_t, session)
+_Z_OWNED_TYPE_RC(_z_session_rc_t, session)
+_Z_LOANED_TYPE(_z_session_rc_t, session)
 
 /**
  * Represents a Zenoh Subscriber entity.
@@ -159,8 +139,8 @@ _LOANED_TYPE(_z_session_rc_t, session)
  *   - :c:func:`z_declare_subscriber`
  *   - :c:func:`z_undeclare_subscriber`
  */
-_OWNED_TYPE_PTR(_z_subscriber_t, subscriber)
-_LOANED_TYPE(_z_subscriber_t, subscriber)
+_Z_OWNED_TYPE_PTR(_z_subscriber_t, subscriber)
+_Z_LOANED_TYPE(_z_subscriber_t, subscriber)
 
 /**
  * Represents a Zenoh Publisher entity.
@@ -172,8 +152,8 @@ _LOANED_TYPE(_z_subscriber_t, subscriber)
  *   - :c:func:`z_publisher_put`
  *   - :c:func:`z_publisher_delete`
  */
-_OWNED_TYPE_PTR(_z_publisher_t, publisher)
-_LOANED_TYPE(_z_publisher_t, publisher)
+_Z_OWNED_TYPE_PTR(_z_publisher_t, publisher)
+_Z_LOANED_TYPE(_z_publisher_t, publisher)
 
 /**
  * Represents a Zenoh Queryable entity.
@@ -183,15 +163,15 @@ _LOANED_TYPE(_z_publisher_t, publisher)
  *   - :c:func:`z_declare_queryable`
  *   - :c:func:`z_undeclare_queryable`
  */
-_OWNED_TYPE_PTR(_z_queryable_t, queryable)
-_LOANED_TYPE(_z_queryable_t, queryable)
+_Z_OWNED_TYPE_PTR(_z_queryable_t, queryable)
+_Z_LOANED_TYPE(_z_queryable_t, queryable)
 
 /**
  * Represents a Zenoh Query entity, received by Zenoh Queryable entities.
  *
  */
-_OWNED_TYPE_RC(_z_query_rc_t, query)
-_LOANED_TYPE(_z_query_rc_t, query)
+_Z_OWNED_TYPE_RC(_z_query_rc_t, query)
+_Z_LOANED_TYPE(_z_query_rc_t, query)
 
 /**
  * Represents the encoding of a payload, in a MIME-like format.
@@ -200,8 +180,8 @@ _LOANED_TYPE(_z_query_rc_t, query)
  *   z_encoding_id_t prefix: The integer prefix of this encoding.
  *   z_loaned_slice_t* suffix: The suffix of this encoding. It MUST be a valid UTF-8 string.
  */
-_OWNED_TYPE_PTR(_z_encoding_t, encoding)
-_LOANED_TYPE(_z_encoding_t, encoding)
+_Z_OWNED_TYPE_PTR(_z_encoding_t, encoding)
+_Z_LOANED_TYPE(_z_encoding_t, encoding)
 
 /**
  * Represents a Zenoh value.
@@ -210,8 +190,8 @@ _LOANED_TYPE(_z_encoding_t, encoding)
  *   z_loaned_encoding_t encoding: The encoding of the `payload`.
  *   z_loaned_bytes_t* payload: The payload of this zenoh value.
  */
-_OWNED_TYPE_PTR(_z_value_t, value)
-_LOANED_TYPE(_z_value_t, value)
+_Z_OWNED_TYPE_PTR(_z_value_t, value)
+_Z_LOANED_TYPE(_z_value_t, value)
 
 /**
  * Represents the configuration used to configure a subscriber upon declaration :c:func:`z_declare_subscriber`.
@@ -422,8 +402,8 @@ static inline z_qos_t z_qos_default(void) { return _Z_N_QOS_DEFAULT; }
  *   z_timestamp_t timestamp: The timestamp of this data sample.
  *   z_qos_t qos: Quality of service settings used to deliver this sample.
  */
-_OWNED_TYPE_RC(_z_sample_rc_t, sample)
-_LOANED_TYPE(_z_sample_rc_t, sample)
+_Z_OWNED_TYPE_RC(_z_sample_rc_t, sample)
+_Z_LOANED_TYPE(_z_sample_rc_t, sample)
 
 /**
  * Represents the content of a `hello` message returned by a zenoh entity as a reply to a `scout` message.
@@ -433,14 +413,14 @@ _LOANED_TYPE(_z_sample_rc_t, sample)
  *   z_loaned_slice_t* zid: The Zenoh ID of the scouted entity (empty if absent).
  *   z_loaned_string_array_t locators: The locators of the scouted entity.
  */
-_OWNED_TYPE_PTR(_z_hello_t, hello)
-_LOANED_TYPE(_z_hello_t, hello)
+_Z_OWNED_TYPE_PTR(_z_hello_t, hello)
+_Z_LOANED_TYPE(_z_hello_t, hello)
 
 /**
  * Represents the reply to a query.
  */
-_OWNED_TYPE_RC(_z_reply_rc_t, reply)
-_LOANED_TYPE(_z_reply_rc_t, reply)
+_Z_OWNED_TYPE_RC(_z_reply_rc_t, reply)
+_Z_LOANED_TYPE(_z_reply_rc_t, reply)
 
 /**
  * Represents an array of non null-terminated string.
@@ -451,9 +431,9 @@ _LOANED_TYPE(_z_reply_rc_t, reply)
  *   - :c:func:`z_string_array_len`
  *   - :c:func:`z_str_array_array_is_empty`
  */
-_OWNED_TYPE_PTR(_z_string_vec_t, string_array)
-_LOANED_TYPE(_z_string_vec_t, string_array)
-_VIEW_TYPE(_z_string_vec_t, string_array)
+_Z_OWNED_TYPE_PTR(_z_string_vec_t, string_array)
+_Z_LOANED_TYPE(_z_string_vec_t, string_array)
+_Z_VIEW_TYPE(_z_string_vec_t, string_array)
 
 const z_loaned_string_t *z_string_array_get(const z_loaned_string_array_t *a, size_t k);
 size_t z_string_array_len(const z_loaned_string_array_t *a);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "zenoh-pico/api/olv_macros.h"
 #include "zenoh-pico/api/primitives.h"
 #include "zenoh-pico/api/types.h"
 #include "zenoh-pico/collections/slice.h"
@@ -669,73 +670,25 @@ void z_closure_zid_call(const z_owned_closure_zid_t *closure, const z_id_t *id) 
     }
 }
 
-#define OWNED_FUNCTIONS_PTR(type, name, f_copy, f_free)                                             \
-    _Bool z_##name##_check(const z_owned_##name##_t *obj) { return obj->_val != NULL; }             \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return obj->_val; } \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return obj->_val; }         \
-    void z_##name##_null(z_owned_##name##_t *obj) { obj->_val = NULL; }                             \
-    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }                    \
-    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
-        int8_t ret = _Z_RES_OK;                                                                     \
-        obj->_val = (type *)z_malloc(sizeof(type));                                                 \
-        if (obj->_val != NULL) {                                                                    \
-            f_copy(obj->_val, src);                                                                 \
-        } else {                                                                                    \
-            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                      \
-        }                                                                                           \
-        return ret;                                                                                 \
-    }                                                                                               \
-    void z_##name##_drop(z_owned_##name##_t *obj) {                                                 \
-        if ((obj != NULL) && (obj->_val != NULL)) {                                                 \
-            f_free(&obj->_val);                                                                     \
-        }                                                                                           \
-    }
-
-#define OWNED_FUNCTIONS_RC(name)                                                                    \
-    _Bool z_##name##_check(const z_owned_##name##_t *val) { return val->_rc.in != NULL; }           \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; } \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }         \
-    void z_##name##_null(z_owned_##name##_t *val) { val->_rc.in = NULL; }                           \
-    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *val) { return val; }                    \
-    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
-        int8_t ret = _Z_RES_OK;                                                                     \
-        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                \
-        if (obj->_rc.in == NULL) {                                                                  \
-            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                      \
-        }                                                                                           \
-        return ret;                                                                                 \
-    }                                                                                               \
-    void z_##name##_drop(z_owned_##name##_t *val) {                                                 \
-        if (val->_rc.in != NULL) {                                                                  \
-            if (_z_##name##_rc_drop(&val->_rc)) {                                                   \
-                val->_rc.in = NULL;                                                                 \
-            }                                                                                       \
-        }                                                                                           \
-    }
-
-#define VIEW_FUNCTIONS_PTR(type, name)                                                                   \
-    const z_loaned_##name##_t *z_view_##name##_loan(const z_view_##name##_t *obj) { return &obj->_val; } \
-    z_loaned_##name##_t *z_view_##name##_loan_mut(z_view_##name##_t *obj) { return &obj->_val; }
-
 static inline void _z_owner_noop_copy(void *dst, const void *src) {
     (void)(dst);
     (void)(src);
 }
 
-OWNED_FUNCTIONS_PTR(_z_config_t, config, _z_owner_noop_copy, _z_config_free)
-OWNED_FUNCTIONS_PTR(_z_scouting_config_t, scouting_config, _z_owner_noop_copy, _z_scouting_config_free)
-OWNED_FUNCTIONS_PTR(_z_string_t, string, _z_string_copy, _z_string_free)
-OWNED_FUNCTIONS_PTR(_z_value_t, value, _z_value_copy, _z_value_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_config_t, config, _z_owner_noop_copy, _z_config_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_scouting_config_t, scouting_config, _z_owner_noop_copy, _z_scouting_config_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_string_t, string, _z_string_copy, _z_string_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_value_t, value, _z_value_copy, _z_value_free)
 
-OWNED_FUNCTIONS_PTR(_z_keyexpr_t, keyexpr, _z_keyexpr_copy, _z_keyexpr_free)
-VIEW_FUNCTIONS_PTR(_z_keyexpr_t, keyexpr)
-VIEW_FUNCTIONS_PTR(_z_string_t, string)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_keyexpr_t, keyexpr, _z_keyexpr_copy, _z_keyexpr_free)
+_Z_VIEW_FUNCTIONS_PTR_IMPL(_z_keyexpr_t, keyexpr)
+_Z_VIEW_FUNCTIONS_PTR_IMPL(_z_string_t, string)
 
-OWNED_FUNCTIONS_PTR(_z_hello_t, hello, _z_owner_noop_copy, _z_hello_free)
-OWNED_FUNCTIONS_PTR(_z_string_vec_t, string_array, _z_owner_noop_copy, _z_string_vec_free)
-VIEW_FUNCTIONS_PTR(_z_string_vec_t, string_array)
-OWNED_FUNCTIONS_PTR(_z_slice_t, slice, _z_slice_copy, _z_slice_free)
-OWNED_FUNCTIONS_PTR(_z_bytes_t, bytes, _z_bytes_copy, _z_bytes_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_hello_t, hello, _z_owner_noop_copy, _z_hello_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_string_vec_t, string_array, _z_owner_noop_copy, _z_string_vec_free)
+_Z_VIEW_FUNCTIONS_PTR_IMPL(_z_string_vec_t, string_array)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_slice_t, slice, _z_slice_copy, _z_slice_free)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_bytes_t, bytes, _z_bytes_copy, _z_bytes_free)
 
 static _z_bytes_t _z_bytes_from_owned_bytes(z_owned_bytes_t *bytes) {
     _z_bytes_t b = _z_bytes_null();
@@ -745,44 +698,20 @@ static _z_bytes_t _z_bytes_from_owned_bytes(z_owned_bytes_t *bytes) {
     return b;
 }
 
-OWNED_FUNCTIONS_RC(sample)
-OWNED_FUNCTIONS_RC(session)
+_Z_OWNED_FUNCTIONS_RC_IMPL(sample)
+_Z_OWNED_FUNCTIONS_RC_IMPL(session)
 
-#define OWNED_FUNCTIONS_CLOSURE(ownedtype, name, f_call, f_drop)                   \
-    _Bool z_##name##_check(const ownedtype *val) { return val->call != NULL; }     \
-    ownedtype *z_##name##_move(ownedtype *val) { return val; }                     \
-    void z_##name##_drop(ownedtype *val) {                                         \
-        if (val->drop != NULL) {                                                   \
-            (val->drop)(val->context);                                             \
-            val->drop = NULL;                                                      \
-        }                                                                          \
-        val->call = NULL;                                                          \
-        val->context = NULL;                                                       \
-    }                                                                              \
-    void z_##name##_null(ownedtype *val) {                                         \
-        val->call = NULL;                                                          \
-        val->drop = NULL;                                                          \
-        val->context = NULL;                                                       \
-    }                                                                              \
-    int8_t z_##name(ownedtype *closure, f_call call, f_drop drop, void *context) { \
-        closure->call = call;                                                      \
-        closure->drop = drop;                                                      \
-        closure->context = context;                                                \
-                                                                                   \
-        return _Z_RES_OK;                                                          \
-    }
-
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_sample_t, closure_sample, _z_data_handler_t, z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample, z_owned_sample_handler_t,
-                        z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query, z_owned_query_handler_t,
-                        z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_reply_t, closure_owned_reply, z_owned_reply_handler_t,
-                        z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello, z_loaned_hello_handler_t, z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid, z_id_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_sample_t, closure_sample, _z_data_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_sample_t, closure_owned_sample, z_owned_sample_handler_t,
+                                z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_query_t, closure_owned_query, z_owned_query_handler_t,
+                                z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_reply_t, closure_owned_reply, z_owned_reply_handler_t,
+                                z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_hello_t, closure_hello, z_loaned_hello_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_zid_t, closure_zid, z_id_handler_t, z_dropper_handler_t)
 
 /************* Primitives **************/
 typedef struct __z_hello_handler_wrapper_t {
@@ -938,7 +867,7 @@ int8_t _z_publisher_drop(_z_publisher_t **pub) {
     return ret;
 }
 
-OWNED_FUNCTIONS_PTR(_z_publisher_t, publisher, _z_owner_noop_copy, _z_publisher_drop)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_publisher_t, publisher, _z_owner_noop_copy, _z_publisher_drop)
 
 void z_put_options_default(z_put_options_t *options) {
     options->congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
@@ -1092,7 +1021,7 @@ z_owned_keyexpr_t z_publisher_keyexpr(z_loaned_publisher_t *publisher) {
 #endif
 
 #if Z_FEATURE_QUERY == 1
-OWNED_FUNCTIONS_RC(reply)
+_Z_OWNED_FUNCTIONS_RC_IMPL(reply)
 
 void z_get_options_default(z_get_options_t *options) {
     options->target = z_query_target_default();
@@ -1167,8 +1096,8 @@ int8_t _z_queryable_drop(_z_queryable_t **queryable) {
     return ret;
 }
 
-OWNED_FUNCTIONS_RC(query)
-OWNED_FUNCTIONS_PTR(_z_queryable_t, queryable, _z_owner_noop_copy, _z_queryable_drop)
+_Z_OWNED_FUNCTIONS_RC_IMPL(query)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_queryable_t, queryable, _z_owner_noop_copy, _z_queryable_drop)
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
 
@@ -1279,7 +1208,7 @@ int8_t _z_subscriber_drop(_z_subscriber_t **sub) {
     return ret;
 }
 
-OWNED_FUNCTIONS_PTR(_z_subscriber_t, subscriber, _z_owner_noop_copy, _z_subscriber_drop)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_subscriber_t, subscriber, _z_owner_noop_copy, _z_subscriber_drop)
 
 void z_subscriber_options_default(z_subscriber_options_t *options) { options->reliability = Z_RELIABILITY_DEFAULT; }
 


### PR DESCRIPTION
This PR moves all macro for define and implement owned/loaned/view types to single file.
It will allows in future easy split `types.h`, `primitives.h` and `api.c` files.
And at this moment it needs for the channel rework implementation.