### PR TITLE
Remove refcounting from reply/sample.

### DIFF
--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -105,8 +105,11 @@ void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
         z_keyexpr_to_string(z_sample_keyexpr(sample), &keystr);
         z_owned_string_t replystr;
         z_bytes_deserialize_into_string(z_sample_payload(sample), &replystr);
+        z_owned_string_t encoding;
+        z_encoding_to_string(z_sample_encoding(sample), &encoding);
 
         printf(">> Received ('%s': '%s')\n", z_string_data(z_loan(keystr)), z_string_data(z_loan(replystr)));
+        printf("    with encoding: %s\n", z_string_data(z_loan(encoding)));
 
         // Check attachment
         kv_pairs_rx_t kvp = {
@@ -119,6 +122,7 @@ void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
 
         z_drop(z_move(keystr));
         z_drop(z_move(replystr));
+        z_drop(z_move(encoding));
     } else {
         printf(">> Received an error\n");
     }
@@ -212,6 +216,11 @@ int main(int argc, char **argv) {
     z_owned_bytes_t attachment;
     z_bytes_serialize_from_iter(&attachment, create_attachment_iter, (void *)&ctx);
     opts.attachment = z_move(attachment);
+
+    // Add encoding value
+    z_owned_encoding_t encoding;
+    z_encoding_from_str(&encoding, "zenoh/string;utf8");
+    opts.encoding = z_move(encoding);
 
     z_owned_closure_reply_t callback;
     z_closure(&callback, reply_handler, reply_dropper);

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -70,6 +70,7 @@ void parse_attachment(kv_pairs_rx_t *kvp, const z_loaned_bytes_t *attachment) {
         z_bytes_deserialize_into_string(z_loan(second), &kvp->data[kvp->current_idx].value);
         z_bytes_drop(&first);
         z_bytes_drop(&second);
+        z_bytes_drop(&kv);
         kvp->current_idx++;
     }
 }

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -75,7 +75,7 @@ void parse_attachment(kv_pairs_rx_t *kvp, const z_loaned_bytes_t *attachment) {
 }
 
 void print_attachment(kv_pairs_rx_t *kvp) {
-    printf("   with attachment:\n");
+    printf("    with attachment:\n");
     for (uint32_t i = 0; i < kvp->current_idx; i++) {
         printf("     %d: %s, %s\n", i, z_string_data(z_loan(kvp->data[i].key)),
                z_string_data(z_loan(kvp->data[i].value)));

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
         options.attachment = z_move(attachment);
 
         // Add encoding value
-        z_encoding_from_str(&encoding, "text/plain;utf8");
+        z_encoding_from_str(&encoding, "zenoh/string;utf8");
         options.encoding = z_move(encoding);
 
         z_publisher_put(z_loan(pub), z_move(payload), &options);

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -82,6 +82,7 @@ void parse_attachment(kv_pairs_rx_t *kvp, const z_loaned_bytes_t *attachment) {
         z_bytes_deserialize_into_string(z_loan(second), &kvp->data[kvp->current_idx].value);
         z_bytes_drop(&first);
         z_bytes_drop(&second);
+        z_bytes_drop(&kv);
         kvp->current_idx++;
     }
 }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -87,7 +87,7 @@ void parse_attachment(kv_pairs_rx_t *kvp, const z_loaned_bytes_t *attachment) {
 }
 
 void print_attachment(kv_pairs_rx_t *kvp) {
-    printf("   with attachment:\n");
+    printf("    with attachment:\n");
     for (uint32_t i = 0; i < kvp->current_idx; i++) {
         printf("     %d: %s, %s\n", i, z_string_data(z_loan(kvp->data[i].key)),
                z_string_data(z_loan(kvp->data[i].value)));
@@ -119,7 +119,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
     z_owned_string_t payload_string;
     z_bytes_deserialize_into_string(z_query_payload(query), &payload_string);
     if (z_string_len(z_loan(payload_string)) > 1) {
-        printf("   with value '%s'\n", z_string_data(z_loan(payload_string)));
+        printf("    with value '%s'\n", z_string_data(z_loan(payload_string)));
     }
     // Check attachment
     kv_pairs_rx_t kvp = {

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -53,7 +53,7 @@ void parse_attachment(kv_pairs_t *kvp, const z_loaned_bytes_t *attachment) {
 }
 
 void print_attachment(kv_pairs_t *kvp) {
-    printf("   with attachment:\n");
+    printf("    with attachment:\n");
     for (uint32_t i = 0; i < kvp->current_idx; i++) {
         printf("     %d: %s, %s\n", i, z_string_data(z_loan(kvp->data[i].key)),
                z_string_data(z_loan(kvp->data[i].value)));

--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -51,9 +51,15 @@
             return;                                                                                                  \
         }                                                                                                            \
         if (elem == NULL) {                                                                                          \
-            internal_elem->_rc.in = NULL;                                                                            \
+            internal_elem->_val = NULL;                                                                              \
         } else {                                                                                                     \
-            elem_copy_f(&internal_elem->_rc, elem);                                                                  \
+            internal_elem->_val = (elem_loaned_type *)z_malloc(sizeof(elem_loaned_type));                            \
+            if (internal_elem->_val == NULL) {                                                                       \
+                z_free(internal_elem);                                                                               \
+                _Z_ERROR("Out of memory");                                                                           \
+                return;                                                                                              \
+            }                                                                                                        \
+            elem_copy_f(internal_elem->_val, (elem_loaned_type *)elem);                                              \
         }                                                                                                            \
         int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                       \
         if (ret != _Z_RES_OK) {                                                                                      \
@@ -112,7 +118,7 @@
                            /* collection_try_pull_f           */ _z_##kind_name##_mt_try_pull,              \
                            /* elem_owned_type                 */ z_owned_##item_name##_t,                   \
                            /* elem_loaned_type                */ z_loaned_##item_name##_t,                  \
-                           /* elem_copy_f                     */ _z_##item_name##_rc_copy,                  \
+                           /* elem_copy_f                     */ _z_##item_name##_copy,                     \
                            /* elem_drop_f                     */ z_##item_name##_drop)
 
 #define _Z_CHANNEL_DEFINE_DUMMY(item_name, kind_name)       \

--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -27,7 +27,7 @@
 #define _Z_CHANNEL_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,        \
                                collection_type, collection_new_f, collection_free_f, collection_push_f,              \
                                collection_pull_f, collection_try_pull_f, elem_owned_type, elem_loaned_type,          \
-                               elem_copy_f, elem_drop_f)                                                             \
+                               elem_clone_f, elem_drop_f)                                                            \
     typedef struct {                                                                                                 \
         collection_type *collection;                                                                                 \
     } handler_type;                                                                                                  \
@@ -50,17 +50,8 @@
             _Z_ERROR("Out of memory");                                                                               \
             return;                                                                                                  \
         }                                                                                                            \
-        if (elem == NULL) {                                                                                          \
-            internal_elem->_val = NULL;                                                                              \
-        } else {                                                                                                     \
-            internal_elem->_val = (elem_loaned_type *)z_malloc(sizeof(elem_loaned_type));                            \
-            if (internal_elem->_val == NULL) {                                                                       \
-                z_free(internal_elem);                                                                               \
-                _Z_ERROR("Out of memory");                                                                           \
-                return;                                                                                              \
-            }                                                                                                        \
-            elem_copy_f(internal_elem->_val, (elem_loaned_type *)elem);                                              \
-        }                                                                                                            \
+        elem_clone_f(internal_elem, elem);                                                                           \
+                                                                                                                     \
         int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                       \
         if (ret != _Z_RES_OK) {                                                                                      \
             _Z_ERROR("%s failed: %i", #collection_push_f, ret);                                                      \
@@ -118,99 +109,8 @@
                            /* collection_try_pull_f           */ _z_##kind_name##_mt_try_pull,              \
                            /* elem_owned_type                 */ z_owned_##item_name##_t,                   \
                            /* elem_loaned_type                */ z_loaned_##item_name##_t,                  \
-                           /* elem_copy_f                     */ _z_##item_name##_copy,                     \
+                           /* elem_clone_f                     */ z_##item_name##_clone,                    \
                            /* elem_drop_f                     */ z_##item_name##_drop)
-
-#define _Z_CHANNEL_RC_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,     \
-                                  collection_type, collection_new_f, collection_free_f, collection_push_f,           \
-                                  collection_pull_f, collection_try_pull_f, elem_owned_type, elem_loaned_type,       \
-                                  elem_copy_f, elem_drop_f)                                                          \
-    typedef struct {                                                                                                 \
-        collection_type *collection;                                                                                 \
-    } handler_type;                                                                                                  \
-                                                                                                                     \
-    _Z_OWNED_TYPE_PTR(handler_type, handler_name)                                                                    \
-    _Z_LOANED_TYPE(handler_type, handler_name)                                                                       \
-                                                                                                                     \
-    static inline void _z_##handler_name##_elem_free(void **elem) {                                                  \
-        elem_drop_f((elem_owned_type *)*elem);                                                                       \
-        z_free(*elem);                                                                                               \
-        *elem = NULL;                                                                                                \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_elem_move(void *dst, void *src) {                                         \
-        memcpy(dst, src, sizeof(elem_owned_type));                                                                   \
-        z_free(src);                                                                                                 \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_send(const elem_loaned_type *elem, void *context) {                       \
-        elem_owned_type *internal_elem = (elem_owned_type *)z_malloc(sizeof(elem_owned_type));                       \
-        if (internal_elem == NULL) {                                                                                 \
-            _Z_ERROR("Out of memory");                                                                               \
-            return;                                                                                                  \
-        }                                                                                                            \
-        if (elem == NULL) {                                                                                          \
-            internal_elem->_rc.in = NULL;                                                                            \
-        } else {                                                                                                     \
-            elem_copy_f(&internal_elem->_rc, elem);                                                                  \
-        }                                                                                                            \
-        int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                       \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_push_f, ret);                                                      \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void z_##handler_name##_recv(const z_loaned_##handler_name##_t *handler, elem_owned_type *elem) {  \
-        int8_t ret = collection_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move); \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_pull_f, ret);                                                      \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void z_##handler_name##_try_recv(const z_loaned_##handler_name##_t *handler,                       \
-                                                   elem_owned_type *elem) {                                          \
-        int8_t ret =                                                                                                 \
-            collection_try_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move);      \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_try_pull_f, ret);                                                  \
-        }                                                                                                            \
-    }                                                                                                                \
-                                                                                                                     \
-    static inline void _z_##handler_name##_free(handler_type **handler) {                                            \
-        handler_type *ptr = *handler;                                                                                \
-        if (ptr != NULL) {                                                                                           \
-            collection_free_f(ptr->collection, _z_##handler_name##_elem_free);                                       \
-            z_free(ptr);                                                                                             \
-            *handler = NULL;                                                                                         \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_copy(void *dst, const void *src) {                                        \
-        (void)(dst);                                                                                                 \
-        (void)(src);                                                                                                 \
-    }                                                                                                                \
-                                                                                                                     \
-    _Z_OWNED_FUNCTIONS_PTR_IMPL(handler_type, handler_name, _z_##handler_name##_copy, _z_##handler_name##_free)      \
-                                                                                                                     \
-    static inline int8_t handler_new_f_name(callback_type *callback, z_owned_##handler_name##_t *handler,            \
-                                            size_t capacity) {                                                       \
-        handler->_val = (handler_type *)z_malloc(sizeof(handler_type));                                              \
-        handler->_val->collection = collection_new_f(capacity);                                                      \
-        callback_new_f(callback, _z_##handler_name##_send, NULL, handler->_val->collection);                         \
-        return _Z_RES_OK;                                                                                            \
-    }
-
-#define _Z_CHANNEL_RC_DEFINE(item_name, kind_name)                                                             \
-    _Z_CHANNEL_RC_DEFINE_IMPL(/* handler_type                    */ _z_##kind_name##_handler_##item_name##_t,  \
-                              /* handler_name                    */ kind_name##_handler_##item_name,           \
-                              /* handler_new_f_name              */ z_##kind_name##_channel_##item_name##_new, \
-                              /* callback_type                   */ z_owned_closure_##item_name##_t,           \
-                              /* callback_new_f                  */ z_closure_##item_name,                     \
-                              /* collection_type                 */ _z_##kind_name##_mt_t,                     \
-                              /* collection_new_f                */ _z_##kind_name##_mt_new,                   \
-                              /* collection_free_f               */ _z_##kind_name##_mt_free,                  \
-                              /* collection_push_f               */ _z_##kind_name##_mt_push,                  \
-                              /* collection_pull_f               */ _z_##kind_name##_mt_pull,                  \
-                              /* collection_try_pull_f           */ _z_##kind_name##_mt_try_pull,              \
-                              /* elem_owned_type                 */ z_owned_##item_name##_t,                   \
-                              /* elem_loaned_type                */ z_loaned_##item_name##_t,                  \
-                              /* elem_copy_f                     */ _z_##item_name##_rc_copy,                  \
-                              /* elem_drop_f                     */ z_##item_name##_drop)
 
 #define _Z_CHANNEL_DEFINE_DUMMY(item_name, kind_name)       \
     typedef struct {                                        \
@@ -239,12 +139,12 @@ _Z_CHANNEL_DEFINE(sample, fifo)
 // This macro defines:
 //   z_ring_channel_query_new()
 //   z_owned_ring_handler_query_t/z_loaned_ring_handler_query_t
-_Z_CHANNEL_RC_DEFINE(query, ring)
+_Z_CHANNEL_DEFINE(query, ring)
 
 // This macro defines:
 //   z_fifo_channel_query_new()
 //   z_owned_fifo_handler_query_t/z_loaned_fifo_handler_query_t
-_Z_CHANNEL_RC_DEFINE(query, fifo)
+_Z_CHANNEL_DEFINE(query, fifo)
 #else   // Z_FEATURE_QUERYABLE
 _Z_CHANNEL_DEFINE_DUMMY(query, ring)
 _Z_CHANNEL_DEFINE_DUMMY(query, fifo)

--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -121,6 +121,97 @@
                            /* elem_copy_f                     */ _z_##item_name##_copy,                     \
                            /* elem_drop_f                     */ z_##item_name##_drop)
 
+#define _Z_CHANNEL_RC_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,     \
+                                  collection_type, collection_new_f, collection_free_f, collection_push_f,           \
+                                  collection_pull_f, collection_try_pull_f, elem_owned_type, elem_loaned_type,       \
+                                  elem_copy_f, elem_drop_f)                                                          \
+    typedef struct {                                                                                                 \
+        collection_type *collection;                                                                                 \
+    } handler_type;                                                                                                  \
+                                                                                                                     \
+    _Z_OWNED_TYPE_PTR(handler_type, handler_name)                                                                    \
+    _Z_LOANED_TYPE(handler_type, handler_name)                                                                       \
+                                                                                                                     \
+    static inline void _z_##handler_name##_elem_free(void **elem) {                                                  \
+        elem_drop_f((elem_owned_type *)*elem);                                                                       \
+        z_free(*elem);                                                                                               \
+        *elem = NULL;                                                                                                \
+    }                                                                                                                \
+    static inline void _z_##handler_name##_elem_move(void *dst, void *src) {                                         \
+        memcpy(dst, src, sizeof(elem_owned_type));                                                                   \
+        z_free(src);                                                                                                 \
+    }                                                                                                                \
+    static inline void _z_##handler_name##_send(const elem_loaned_type *elem, void *context) {                       \
+        elem_owned_type *internal_elem = (elem_owned_type *)z_malloc(sizeof(elem_owned_type));                       \
+        if (internal_elem == NULL) {                                                                                 \
+            _Z_ERROR("Out of memory");                                                                               \
+            return;                                                                                                  \
+        }                                                                                                            \
+        if (elem == NULL) {                                                                                          \
+            internal_elem->_rc.in = NULL;                                                                            \
+        } else {                                                                                                     \
+            elem_copy_f(&internal_elem->_rc, elem);                                                                  \
+        }                                                                                                            \
+        int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                       \
+        if (ret != _Z_RES_OK) {                                                                                      \
+            _Z_ERROR("%s failed: %i", #collection_push_f, ret);                                                      \
+        }                                                                                                            \
+    }                                                                                                                \
+    static inline void z_##handler_name##_recv(const z_loaned_##handler_name##_t *handler, elem_owned_type *elem) {  \
+        int8_t ret = collection_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move); \
+        if (ret != _Z_RES_OK) {                                                                                      \
+            _Z_ERROR("%s failed: %i", #collection_pull_f, ret);                                                      \
+        }                                                                                                            \
+    }                                                                                                                \
+    static inline void z_##handler_name##_try_recv(const z_loaned_##handler_name##_t *handler,                       \
+                                                   elem_owned_type *elem) {                                          \
+        int8_t ret =                                                                                                 \
+            collection_try_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move);      \
+        if (ret != _Z_RES_OK) {                                                                                      \
+            _Z_ERROR("%s failed: %i", #collection_try_pull_f, ret);                                                  \
+        }                                                                                                            \
+    }                                                                                                                \
+                                                                                                                     \
+    static inline void _z_##handler_name##_free(handler_type **handler) {                                            \
+        handler_type *ptr = *handler;                                                                                \
+        if (ptr != NULL) {                                                                                           \
+            collection_free_f(ptr->collection, _z_##handler_name##_elem_free);                                       \
+            z_free(ptr);                                                                                             \
+            *handler = NULL;                                                                                         \
+        }                                                                                                            \
+    }                                                                                                                \
+    static inline void _z_##handler_name##_copy(void *dst, const void *src) {                                        \
+        (void)(dst);                                                                                                 \
+        (void)(src);                                                                                                 \
+    }                                                                                                                \
+                                                                                                                     \
+    _Z_OWNED_FUNCTIONS_PTR_IMPL(handler_type, handler_name, _z_##handler_name##_copy, _z_##handler_name##_free)      \
+                                                                                                                     \
+    static inline int8_t handler_new_f_name(callback_type *callback, z_owned_##handler_name##_t *handler,            \
+                                            size_t capacity) {                                                       \
+        handler->_val = (handler_type *)z_malloc(sizeof(handler_type));                                              \
+        handler->_val->collection = collection_new_f(capacity);                                                      \
+        callback_new_f(callback, _z_##handler_name##_send, NULL, handler->_val->collection);                         \
+        return _Z_RES_OK;                                                                                            \
+    }
+
+#define _Z_CHANNEL_RC_DEFINE(item_name, kind_name)                                                             \
+    _Z_CHANNEL_RC_DEFINE_IMPL(/* handler_type                    */ _z_##kind_name##_handler_##item_name##_t,  \
+                              /* handler_name                    */ kind_name##_handler_##item_name,           \
+                              /* handler_new_f_name              */ z_##kind_name##_channel_##item_name##_new, \
+                              /* callback_type                   */ z_owned_closure_##item_name##_t,           \
+                              /* callback_new_f                  */ z_closure_##item_name,                     \
+                              /* collection_type                 */ _z_##kind_name##_mt_t,                     \
+                              /* collection_new_f                */ _z_##kind_name##_mt_new,                   \
+                              /* collection_free_f               */ _z_##kind_name##_mt_free,                  \
+                              /* collection_push_f               */ _z_##kind_name##_mt_push,                  \
+                              /* collection_pull_f               */ _z_##kind_name##_mt_pull,                  \
+                              /* collection_try_pull_f           */ _z_##kind_name##_mt_try_pull,              \
+                              /* elem_owned_type                 */ z_owned_##item_name##_t,                   \
+                              /* elem_loaned_type                */ z_loaned_##item_name##_t,                  \
+                              /* elem_copy_f                     */ _z_##item_name##_rc_copy,                  \
+                              /* elem_drop_f                     */ z_##item_name##_drop)
+
 #define _Z_CHANNEL_DEFINE_DUMMY(item_name, kind_name)       \
     typedef struct {                                        \
         uint8_t _foo;                                       \
@@ -148,12 +239,12 @@ _Z_CHANNEL_DEFINE(sample, fifo)
 // This macro defines:
 //   z_ring_channel_query_new()
 //   z_owned_ring_handler_query_t/z_loaned_ring_handler_query_t
-_Z_CHANNEL_DEFINE(query, ring)
+_Z_CHANNEL_RC_DEFINE(query, ring)
 
 // This macro defines:
 //   z_fifo_channel_query_new()
 //   z_owned_fifo_handler_query_t/z_loaned_fifo_handler_query_t
-_Z_CHANNEL_DEFINE(query, fifo)
+_Z_CHANNEL_RC_DEFINE(query, fifo)
 #else   // Z_FEATURE_QUERYABLE
 _Z_CHANNEL_DEFINE_DUMMY(query, ring)
 _Z_CHANNEL_DEFINE_DUMMY(query, fifo)

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1249,83 +1249,6 @@ z_qos_t z_sample_qos(const z_loaned_sample_t *sample);
  */
 const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample);
 
-/**
- * Gets the keyexpr from a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the keyexpr from.
- *
- * Return:
- *   The keyexpr wrapped as a :c:type:`z_loaned_keyexpr_t`.
- */
-const z_loaned_keyexpr_t *zp_reply_sample_keyexpr(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the payload of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the payload from.
- *
- * Return:
- *   The payload wrapped as a :c:type:`z_loaned_bytes_t`.
- */
-const z_loaned_bytes_t *zp_reply_sample_payload(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the timestamp of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the timestamp from.
- *
- * Return:
- *   The timestamp wrapped as a :c:type:`z_timestamp_t`.
- */
-z_timestamp_t zp_reply_sample_timestamp(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the encoding of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the encoding from.
- *
- * Return:
- *   The encoding wrapped as a :c:type:`z_loaned_encoding_t*`.
- */
-const z_loaned_encoding_t *zp_reply_sample_encoding(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the kind of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the kind from.
- *
- * Return:
- *   The sample kind wrapped as a :c:type:`z_sample_kind_t`.
- */
-z_sample_kind_t zp_reply_sample_kind(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the qos value of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the qos from.
- *
- * Return:
- *   The qos wrapped as a :c:type:`z_qos_t`.
- */
-z_qos_t zp_reply_sample_qos(const zp_loaned_reply_sample_t *sample);
-
-/**
- * Gets the attachment of a reply sample by aliasing it.
- *
- * Parameters:
- *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the attachment from.
- *
- * Return:
- *   Pointer to the attachment as a :c:type:`z_loaned_bytes_t`.
- */
-const z_loaned_bytes_t *zp_reply_sample_attachment(const zp_loaned_reply_sample_t *sample);
-
 #if Z_FEATURE_PUBLICATION == 1
 /**
  * Builds a :c:type:`z_put_options_t` with default values.
@@ -1489,7 +1412,7 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
 _Bool z_reply_is_ok(const z_loaned_reply_t *reply);
 
 /**
- * Gets the content of an OK reply refcounted.
+ * Gets the content of an OK reply.
  *
  * You should always make sure that :c:func:`z_reply_is_ok` returns ``true`` before calling this function.
  *
@@ -1500,19 +1423,6 @@ _Bool z_reply_is_ok(const z_loaned_reply_t *reply);
  *   The OK reply content wrapped as a :c:type:`z_loaned_sample_t`.
  */
 const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply);
-
-/**
- * Gets the content of an OK reply.
- *
- * You should always make sure that :c:func:`z_reply_is_ok` returns ``true`` before calling this function.
- *
- * Parameters:
- *   reply: Pointer to a :c:type:`z_loaned_reply_t` to get content from.
- *
- * Return:
- *   The OK reply content wrapped as a :c:type:`zp_loaned_reply_sample_t`.
- */
-const zp_loaned_reply_sample_t *zp_reply_ok(const z_loaned_reply_t *reply);
 
 /**
  * Gets the contents of an error reply.

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1239,7 +1239,7 @@ z_sample_kind_t z_sample_kind(const z_loaned_sample_t *sample);
 z_qos_t z_sample_qos(const z_loaned_sample_t *sample);
 
 /**
- * Gets the attachment of a value by aliasing it.
+ * Gets the attachment of a sample by aliasing it.
  *
  * Parameters:
  *   sample: Pointer to a :c:type:`z_loaned_sample_t` to get the attachment from.
@@ -1248,6 +1248,83 @@ z_qos_t z_sample_qos(const z_loaned_sample_t *sample);
  *   Pointer to the attachment as a :c:type:`z_loaned_bytes_t`.
  */
 const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample);
+
+/**
+ * Gets the keyexpr from a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the keyexpr from.
+ *
+ * Return:
+ *   The keyexpr wrapped as a :c:type:`z_loaned_keyexpr_t`.
+ */
+const z_loaned_keyexpr_t *zp_reply_sample_keyexpr(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the payload of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the payload from.
+ *
+ * Return:
+ *   The payload wrapped as a :c:type:`z_loaned_bytes_t`.
+ */
+const z_loaned_bytes_t *zp_reply_sample_payload(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the timestamp of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the timestamp from.
+ *
+ * Return:
+ *   The timestamp wrapped as a :c:type:`z_timestamp_t`.
+ */
+z_timestamp_t zp_reply_sample_timestamp(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the encoding of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the encoding from.
+ *
+ * Return:
+ *   The encoding wrapped as a :c:type:`z_loaned_encoding_t*`.
+ */
+const z_loaned_encoding_t *zp_reply_sample_encoding(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the kind of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the kind from.
+ *
+ * Return:
+ *   The sample kind wrapped as a :c:type:`z_sample_kind_t`.
+ */
+z_sample_kind_t zp_reply_sample_kind(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the qos value of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the qos from.
+ *
+ * Return:
+ *   The qos wrapped as a :c:type:`z_qos_t`.
+ */
+z_qos_t zp_reply_sample_qos(const zp_loaned_reply_sample_t *sample);
+
+/**
+ * Gets the attachment of a reply sample by aliasing it.
+ *
+ * Parameters:
+ *   sample: Pointer to a :c:type:`zp_loaned_reply_sample_t` to get the attachment from.
+ *
+ * Return:
+ *   Pointer to the attachment as a :c:type:`z_loaned_bytes_t`.
+ */
+const z_loaned_bytes_t *zp_reply_sample_attachment(const zp_loaned_reply_sample_t *sample);
 
 #if Z_FEATURE_PUBLICATION == 1
 /**
@@ -1412,7 +1489,7 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
 _Bool z_reply_is_ok(const z_loaned_reply_t *reply);
 
 /**
- * Gets the content of an OK reply.
+ * Gets the content of an OK reply refcounted.
  *
  * You should always make sure that :c:func:`z_reply_is_ok` returns ``true`` before calling this function.
  *
@@ -1423,6 +1500,19 @@ _Bool z_reply_is_ok(const z_loaned_reply_t *reply);
  *   The OK reply content wrapped as a :c:type:`z_loaned_sample_t`.
  */
 const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply);
+
+/**
+ * Gets the content of an OK reply.
+ *
+ * You should always make sure that :c:func:`z_reply_is_ok` returns ``true`` before calling this function.
+ *
+ * Parameters:
+ *   reply: Pointer to a :c:type:`z_loaned_reply_t` to get content from.
+ *
+ * Return:
+ *   The OK reply content wrapped as a :c:type:`zp_loaned_reply_sample_t`.
+ */
+const zp_loaned_reply_sample_t *zp_reply_ok(const z_loaned_reply_t *reply);
 
 /**
  * Gets the contents of an error reply.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -171,8 +171,8 @@ _Z_LOANED_TYPE(_z_queryable_t, queryable)
  * Represents a Zenoh Query entity, received by Zenoh Queryable entities.
  *
  */
-_Z_OWNED_TYPE_PTR(_z_query_t, query)
-_Z_LOANED_TYPE(_z_query_t, query)
+_Z_OWNED_TYPE_RC(_z_query_rc_t, query)
+_Z_LOANED_TYPE(_z_query_rc_t, query)
 
 /**
  * Represents the encoding of a payload, in a MIME-like format.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -171,8 +171,8 @@ _Z_LOANED_TYPE(_z_queryable_t, queryable)
  * Represents a Zenoh Query entity, received by Zenoh Queryable entities.
  *
  */
-_Z_OWNED_TYPE_RC(_z_query_rc_t, query)
-_Z_LOANED_TYPE(_z_query_rc_t, query)
+_Z_OWNED_TYPE_PTR(_z_query_t, query)
+_Z_LOANED_TYPE(_z_query_t, query)
 
 /**
  * Represents the encoding of a payload, in a MIME-like format.
@@ -403,8 +403,8 @@ static inline z_qos_t z_qos_default(void) { return _Z_N_QOS_DEFAULT; }
  *   z_timestamp_t timestamp: The timestamp of this data sample.
  *   z_qos_t qos: Quality of service settings used to deliver this sample.
  */
-_Z_OWNED_TYPE_RC(_z_sample_rc_t, sample)
-_Z_LOANED_TYPE(_z_sample_rc_t, sample)
+_Z_OWNED_TYPE_PTR(_z_sample_t, sample)
+_Z_LOANED_TYPE(_z_sample_t, sample)
 
 /**
  * Represents the content of a `hello` message returned by a zenoh entity as a reply to a `scout` message.
@@ -420,8 +420,8 @@ _Z_LOANED_TYPE(_z_hello_t, hello)
 /**
  * Represents the reply to a query.
  */
-_Z_OWNED_TYPE_RC(_z_reply_rc_t, reply)
-_Z_LOANED_TYPE(_z_reply_rc_t, reply)
+_Z_OWNED_TYPE_PTR(_z_reply_t, reply)
+_Z_LOANED_TYPE(_z_reply_t, reply)
 
 /**
  * Represents an array of non null-terminated string.

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -78,6 +78,7 @@ _z_string_t *_z_string_make_as_ptr(const char *value);
 size_t _z_string_size(const _z_string_t *s);
 int8_t _z_string_copy(_z_string_t *dst, const _z_string_t *src);
 void _z_string_move(_z_string_t *dst, _z_string_t *src);
+_z_string_t _z_string_steal(_z_string_t *str);
 void _z_string_move_str(_z_string_t *dst, char *src);
 void _z_string_clear(_z_string_t *s);
 void _z_string_free(_z_string_t **s);

--- a/include/zenoh-pico/net/encoding.h
+++ b/include/zenoh-pico/net/encoding.h
@@ -34,5 +34,6 @@ void _z_encoding_clear(_z_encoding_t *encoding);
 _Bool _z_encoding_check(const _z_encoding_t *encoding);
 int8_t _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src);
 void _z_encoding_move(_z_encoding_t *dst, _z_encoding_t *src);
+_z_encoding_t _z_encoding_steal(_z_encoding_t *val);
 
 #endif /* ZENOH_PICO_ENCODING_NETAPI_H */

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -118,7 +118,7 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub);
  * Returns:
  *     ``0`` in case of success, ``-1`` in case of failure.
  */
-int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload, const _z_encoding_t encoding,
+int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload, _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
                 const _z_bytes_t attachment);
 #endif

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -118,7 +118,7 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub);
  * Returns:
  *     ``0`` in case of success, ``-1`` in case of failure.
  */
-int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload, _z_encoding_t encoding,
+int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload, const _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
                 const _z_bytes_t attachment);
 #endif

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -28,7 +28,7 @@ typedef struct _z_query_t {
     _z_value_t _value;
     _z_keyexpr_t _key;
     uint32_t _request_id;
-    _z_session_t *_zn;  // FIXME: Switch to session rc, Issue #476
+    _z_session_t *_zn;  // FIXME: Potential UB source, Issue #476
     _z_bytes_t attachment;
     char *_parameters;
     _Bool _anyke;
@@ -38,6 +38,8 @@ _z_query_t _z_query_null(void);
 void _z_query_clear(_z_query_t *q);
 void _z_query_copy(_z_query_t *dst, const _z_query_t *src);
 void _z_query_free(_z_query_t **query);
+
+_Z_REFCOUNT_DEFINE(_z_query, _z_query)
 
 /**
  * Return type when declaring a queryable.

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -49,7 +49,7 @@ typedef struct {
 
 #if Z_FEATURE_QUERYABLE == 1
 _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_t *zn,
-                           uint32_t request_id, _z_bytes_t attachment);
+                           uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
 #endif

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -49,7 +49,7 @@ typedef struct {
 
 #if Z_FEATURE_QUERYABLE == 1
 _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_t *zn,
-                           uint32_t request_id, const _z_bytes_t attachment);
+                           uint32_t request_id, _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
 #endif

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -28,7 +28,7 @@ typedef struct _z_query_t {
     _z_value_t _value;
     _z_keyexpr_t _key;
     uint32_t _request_id;
-    _z_session_t *_zn;
+    _z_session_t *_zn;  // FIXME: Switch to session rc, Issue #476
     _z_bytes_t attachment;
     char *_parameters;
     _Bool _anyke;
@@ -36,7 +36,8 @@ typedef struct _z_query_t {
 
 _z_query_t _z_query_null(void);
 void _z_query_clear(_z_query_t *q);
-_Z_REFCOUNT_DEFINE(_z_query, _z_query)
+void _z_query_copy(_z_query_t *dst, const _z_query_t *src);
+void _z_query_free(_z_query_t **query);
 
 /**
  * Return type when declaring a queryable.
@@ -47,8 +48,8 @@ typedef struct {
 } _z_queryable_t;
 
 #if Z_FEATURE_QUERYABLE == 1
-_z_query_t _z_query_create(const _z_value_t *value, const _z_keyexpr_t *key, const _z_slice_t *parameters,
-                           _z_session_t *zn, uint32_t request_id, const _z_bytes_t attachment);
+_z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_t *zn,
+                           uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
 #endif

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -63,7 +63,7 @@ void _z_reply_free(_z_reply_t **hello);
 void _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           _z_bytes_t attachment);
+                           const _z_bytes_t attachment);
 
 typedef struct _z_pending_reply_t {
     _z_reply_t _reply;

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -32,8 +32,12 @@
  *
  */
 typedef struct _z_reply_data_t {
-    _z_sample_rc_t sample;
+    union {
+        _z_sample_t base;
+        _z_sample_rc_t rc;
+    } sample;
     _z_id_t replier_id;
+    _Bool has_sample_as_rc;
 } _z_reply_data_t;
 
 void _z_reply_data_clear(_z_reply_data_t *rd);

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -32,16 +32,12 @@
  *
  */
 typedef struct _z_reply_data_t {
-    union {
-        _z_sample_t base;
-        _z_sample_rc_t rc;
-    } sample;
+    _z_sample_t sample;
     _z_id_t replier_id;
-    _Bool has_sample_as_rc;
 } _z_reply_data_t;
 
 void _z_reply_data_clear(_z_reply_data_t *rd);
-void _z_reply_data_copy(_z_reply_data_t *dst, _z_reply_data_t *src);
+void _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
 _z_reply_t _z_reply_move(_z_reply_t *src_reply);
 
 _Z_ELEM_DEFINE(_z_reply_data, _z_reply_data_t, _z_noop_size, _z_reply_data_clear, _z_noop_copy)
@@ -64,12 +60,10 @@ typedef struct _z_reply_t {
 _z_reply_t _z_reply_null(void);
 void _z_reply_clear(_z_reply_t *src);
 void _z_reply_free(_z_reply_t **hello);
-void _z_reply_copy(_z_reply_t *dst, _z_reply_t *src);
+void _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
                            const _z_bytes_t attachment);
-
-_Z_REFCOUNT_DEFINE(_z_reply, _z_reply)
 
 typedef struct _z_pending_reply_t {
     _z_reply_t _reply;

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -63,7 +63,7 @@ void _z_reply_free(_z_reply_t **hello);
 void _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           const _z_bytes_t attachment);
+                           _z_bytes_t attachment);
 
 typedef struct _z_pending_reply_t {
     _z_reply_t _reply;

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -56,6 +56,6 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src);
 
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             const _z_bytes_t attachment);
+                             _z_bytes_t attachment);
 
 #endif /* ZENOH_PICO_SAMPLE_NETAPI_H */

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -39,8 +39,6 @@ typedef struct _z_sample_t {
 } _z_sample_t;
 void _z_sample_clear(_z_sample_t *sample);
 
-_Z_REFCOUNT_DEFINE(_z_sample, _z_sample)
-
 _z_sample_t _z_sample_null(void);
 _Bool _z_sample_check(const _z_sample_t *sample);
 void _z_sample_move(_z_sample_t *dst, _z_sample_t *src);
@@ -56,7 +54,7 @@ void _z_sample_free(_z_sample_t **sample);
 void _z_sample_copy(_z_sample_t *dst, const _z_sample_t *src);
 _z_sample_t _z_sample_duplicate(const _z_sample_t *src);
 
-_z_sample_t _z_sample_create(const _z_keyexpr_t *key, const _z_bytes_t payload, _z_timestamp_t timestamp,
+_z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              const _z_bytes_t attachment);
 

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -56,6 +56,6 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src);
 
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, _z_timestamp_t timestamp,
                              _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             _z_bytes_t attachment);
+                             const _z_bytes_t attachment);
 
 #endif /* ZENOH_PICO_SAMPLE_NETAPI_H */

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -55,7 +55,7 @@ void _z_sample_copy(_z_sample_t *dst, const _z_sample_t *src);
 _z_sample_t _z_sample_duplicate(const _z_sample_t *src);
 
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, _z_timestamp_t timestamp,
-                             const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
+                             _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              _z_bytes_t attachment);
 
 #endif /* ZENOH_PICO_SAMPLE_NETAPI_H */

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -49,13 +49,12 @@ _Z_ELEM_DEFINE(_z_resource, _z_resource_t, _z_noop_size, _z_resource_clear, _z_r
 _Z_LIST_DEFINE(_z_resource, _z_resource_t)
 
 // Forward declaration to avoid cyclical include
-typedef struct _z_sample_rc_t z_loaned_sample_t;
-typedef struct _z_sample_t zp_loaned_reply_sample_t;
+typedef struct _z_sample_t _z_sample_t;
 
 /**
  * The callback signature of the functions handling data messages.
  */
-typedef void (*_z_data_handler_t)(const z_loaned_sample_t *sample, void *arg);
+typedef void (*_z_data_handler_t)(const _z_sample_t *sample, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
@@ -82,12 +81,12 @@ typedef struct {
 } _z_publication_t;
 
 // Forward type declaration to avoid cyclical include
-typedef struct _z_query_rc_t z_loaned_query_t;
+typedef struct _z_query_t _z_query_t;
 
 /**
  * The callback signature of the functions handling query messages.
  */
-typedef void (*_z_queryable_handler_t)(const z_loaned_query_t *query, void *arg);
+typedef void (*_z_queryable_handler_t)(const _z_query_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
@@ -111,12 +110,12 @@ _Z_LIST_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
 typedef struct _z_reply_t _z_reply_t;
 typedef _z_list_t _z_reply_data_list_t;
 typedef _z_list_t _z_pending_reply_list_t;
-typedef struct _z_reply_rc_t _z_reply_rc_t;
-typedef _z_reply_rc_t z_loaned_reply_t;
+typedef struct _z_reply_t _z_reply_t;
+
 /**
  * The callback signature of the functions handling query replies.
  */
-typedef void (*_z_reply_handler_t)(const z_loaned_reply_t *reply, void *arg);
+typedef void (*_z_reply_handler_t)(const _z_reply_t *reply, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -81,12 +81,12 @@ typedef struct {
 } _z_publication_t;
 
 // Forward type declaration to avoid cyclical include
-typedef struct _z_query_t _z_query_t;
+typedef struct _z_query_rc_t _z_query_rc_t;
 
 /**
  * The callback signature of the functions handling query messages.
  */
-typedef void (*_z_queryable_handler_t)(const _z_query_t *query, void *arg);
+typedef void (*_z_queryable_handler_t)(const _z_query_rc_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -50,6 +50,7 @@ _Z_LIST_DEFINE(_z_resource, _z_resource_t)
 
 // Forward declaration to avoid cyclical include
 typedef struct _z_sample_rc_t z_loaned_sample_t;
+typedef struct _z_sample_t zp_loaned_reply_sample_t;
 
 /**
  * The callback signature of the functions handling data messages.

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -865,12 +865,13 @@ int8_t z_put(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, z_
         _z_write(&_Z_RC_IN_VAL(zs), *keyexpr, _z_bytes_from_owned_bytes(payload), _z_encoding_from_owned(opt.encoding),
                  Z_SAMPLE_KIND_PUT, opt.congestion_control, opt.priority, _z_bytes_from_owned_bytes(opt.attachment));
 
-    // Trigger local subscriptions (consumes attachment)
+    // Trigger local subscriptions
     _z_trigger_local_subscriptions(&_Z_RC_IN_VAL(zs), *keyexpr, _z_bytes_from_owned_bytes(payload),
                                    _z_n_qos_make(0, opt.congestion_control == Z_CONGESTION_CONTROL_BLOCK, opt.priority),
                                    _z_bytes_from_owned_bytes(opt.attachment));
     // Clean-up
     z_encoding_drop(opt.encoding);
+    z_bytes_drop(opt.attachment);
     z_bytes_drop(payload);
     return ret;
 }
@@ -963,11 +964,12 @@ int8_t z_publisher_put(const z_loaned_publisher_t *pub, z_owned_bytes_t *payload
                        _z_encoding_from_owned(opt.encoding), Z_SAMPLE_KIND_PUT, pub->_congestion_control,
                        pub->_priority, _z_bytes_from_owned_bytes(opt.attachment));
     }
-    // Trigger local subscriptions (consumes attachment)
+    // Trigger local subscriptions
     _z_trigger_local_subscriptions(&pub->_zn.in->val, pub->_key, _z_bytes_from_owned_bytes(payload), _Z_N_QOS_DEFAULT,
                                    _z_bytes_from_owned_bytes(opt.attachment));
     // Clean-up
     z_encoding_drop(opt.encoding);
+    z_bytes_drop(opt.attachment);
     z_bytes_drop(payload);
     return ret;
 }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -559,16 +559,16 @@ z_query_consolidation_t z_query_consolidation_none(void) {
 z_query_consolidation_t z_query_consolidation_default(void) { return z_query_consolidation_auto(); }
 
 void z_query_parameters(const z_loaned_query_t *query, z_view_string_t *parameters) {
-    parameters->_val.val = query->_parameters;
-    parameters->_val.len = strlen(query->_parameters);
+    parameters->_val.val = query->in->val._parameters;
+    parameters->_val.len = strlen(query->in->val._parameters);
 }
 
-const z_loaned_bytes_t *z_query_attachment(const z_loaned_query_t *query) { return &query->attachment; }
+const z_loaned_bytes_t *z_query_attachment(const z_loaned_query_t *query) { return &query->in->val.attachment; }
 
-const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query) { return &query->_key; }
+const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query) { return &query->in->val._key; }
 
-const z_loaned_bytes_t *z_query_payload(const z_loaned_query_t *query) { return &query->_value.payload; }
-const z_loaned_encoding_t *z_query_encoding(const z_loaned_query_t *query) { return &query->_value.encoding; }
+const z_loaned_bytes_t *z_query_payload(const z_loaned_query_t *query) { return &query->in->val._value.payload; }
+const z_loaned_encoding_t *z_query_encoding(const z_loaned_query_t *query) { return &query->in->val._value.encoding; }
 
 void z_closure_sample_call(const z_loaned_closure_sample_t *closure, const z_loaned_sample_t *sample) {
     if (closure->call != NULL) {
@@ -1065,7 +1065,7 @@ int8_t _z_queryable_drop(_z_queryable_t **queryable) {
     return ret;
 }
 
-_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_query_t, query, _z_query_copy, _z_query_free)
+_Z_OWNED_FUNCTIONS_RC_IMPL(query)
 _Z_OWNED_FUNCTIONS_PTR_IMPL(_z_queryable_t, queryable, _z_owner_noop_copy, _z_queryable_drop)
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
@@ -1120,7 +1120,8 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
     _z_value_t value = {.payload = _z_bytes_from_owned_bytes(payload),
                         .encoding = _z_encoding_from_owned(opts.encoding)};
 
-    int8_t ret = _z_send_reply(query, *keyexpr, value, Z_SAMPLE_KIND_PUT, _z_bytes_from_owned_bytes(opts.attachment));
+    int8_t ret =
+        _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, _z_bytes_from_owned_bytes(opts.attachment));
     if (payload != NULL) {
         z_bytes_drop(payload);
     }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -558,16 +558,16 @@ z_query_consolidation_t z_query_consolidation_none(void) {
 z_query_consolidation_t z_query_consolidation_default(void) { return z_query_consolidation_auto(); }
 
 void z_query_parameters(const z_loaned_query_t *query, z_view_string_t *parameters) {
-    parameters->_val.val = query->in->val._parameters;
-    parameters->_val.len = strlen(query->in->val._parameters);
+    parameters->_val.val = query->_parameters;
+    parameters->_val.len = strlen(query->_parameters);
 }
 
-const z_loaned_bytes_t *z_query_attachment(const z_loaned_query_t *query) { return &query->in->val.attachment; }
+const z_loaned_bytes_t *z_query_attachment(const z_loaned_query_t *query) { return &query->attachment; }
 
-const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query) { return &query->in->val._key; }
+const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query) { return &query->_key; }
 
-const z_loaned_bytes_t *z_query_payload(const z_loaned_query_t *query) { return &query->in->val._value.payload; }
-const z_loaned_encoding_t *z_query_encoding(const z_loaned_query_t *query) { return &query->in->val._value.encoding; }
+const z_loaned_bytes_t *z_query_payload(const z_loaned_query_t *query) { return &query->_value.payload; }
+const z_loaned_encoding_t *z_query_encoding(const z_loaned_query_t *query) { return &query->_value.encoding; }
 
 void z_closure_sample_call(const z_loaned_closure_sample_t *closure, const z_loaned_sample_t *sample) {
     if (closure->call != NULL) {
@@ -666,7 +666,7 @@ static _z_encoding_t _z_encoding_from_owned(const z_owned_encoding_t *encoding) 
 }
 #endif
 
-_Z_OWNED_FUNCTIONS_RC_IMPL(sample)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_sample_t, sample, _z_sample_copy, _z_sample_free)
 _Z_OWNED_FUNCTIONS_RC_IMPL(session)
 
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_sample, _z_data_handler_t, z_dropper_handler_t)
@@ -809,27 +809,13 @@ int8_t z_info_routers_zid(const z_loaned_session_t *zs, z_owned_closure_zid_t *c
 
 z_id_t z_info_zid(const z_loaned_session_t *zs) { return _Z_RC_IN_VAL(zs)._local_zid; }
 
-const z_loaned_keyexpr_t *z_sample_keyexpr(const z_loaned_sample_t *sample) { return &_Z_RC_IN_VAL(sample).keyexpr; }
-z_sample_kind_t z_sample_kind(const z_loaned_sample_t *sample) { return _Z_RC_IN_VAL(sample).kind; }
-const z_loaned_bytes_t *z_sample_payload(const z_loaned_sample_t *sample) { return &_Z_RC_IN_VAL(sample).payload; }
-z_timestamp_t z_sample_timestamp(const z_loaned_sample_t *sample) { return _Z_RC_IN_VAL(sample).timestamp; }
-const z_loaned_encoding_t *z_sample_encoding(const z_loaned_sample_t *sample) { return &_Z_RC_IN_VAL(sample).encoding; }
-z_qos_t z_sample_qos(const z_loaned_sample_t *sample) { return _Z_RC_IN_VAL(sample).qos; }
-const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample) {
-    return &_Z_RC_IN_VAL(sample).attachment;
-}
-
-const z_loaned_keyexpr_t *zp_reply_sample_keyexpr(const zp_loaned_reply_sample_t *sample) { return &sample->keyexpr; }
-z_sample_kind_t zp_reply_sample_kind(const zp_loaned_reply_sample_t *sample) { return sample->kind; }
-const z_loaned_bytes_t *zp_reply_sample_payload(const zp_loaned_reply_sample_t *sample) { return &sample->payload; }
-z_timestamp_t zp_reply_sample_timestamp(const zp_loaned_reply_sample_t *sample) { return sample->timestamp; }
-const z_loaned_encoding_t *zp_reply_sample_encoding(const zp_loaned_reply_sample_t *sample) {
-    return &sample->encoding;
-}
-z_qos_t zp_reply_sample_qos(const zp_loaned_reply_sample_t *sample) { return sample->qos; }
-const z_loaned_bytes_t *zp_reply_sample_attachment(const zp_loaned_reply_sample_t *sample) {
-    return &sample->attachment;
-}
+const z_loaned_keyexpr_t *z_sample_keyexpr(const z_loaned_sample_t *sample) { return &sample->keyexpr; }
+z_sample_kind_t z_sample_kind(const z_loaned_sample_t *sample) { return sample->kind; }
+const z_loaned_bytes_t *z_sample_payload(const z_loaned_sample_t *sample) { return &sample->payload; }
+z_timestamp_t z_sample_timestamp(const z_loaned_sample_t *sample) { return sample->timestamp; }
+const z_loaned_encoding_t *z_sample_encoding(const z_loaned_sample_t *sample) { return &sample->encoding; }
+z_qos_t z_sample_qos(const z_loaned_sample_t *sample) { return sample->qos; }
+const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample) { return &sample->attachment; }
 
 const z_loaned_bytes_t *z_reply_err_payload(const z_loaned_reply_err_t *reply_err) { return &reply_err->payload; }
 const z_loaned_encoding_t *z_reply_err_encoding(const z_loaned_reply_err_t *reply_err) { return &reply_err->encoding; }
@@ -1001,7 +987,7 @@ z_owned_keyexpr_t z_publisher_keyexpr(z_loaned_publisher_t *publisher) {
 #endif
 
 #if Z_FEATURE_QUERY == 1
-_Z_OWNED_FUNCTIONS_RC_IMPL(reply)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_reply_t, reply, _z_reply_copy, _z_reply_free)
 
 void z_get_options_default(z_get_options_t *options) {
     options->target = z_query_target_default();
@@ -1061,21 +1047,7 @@ _Bool z_reply_is_ok(const z_loaned_reply_t *reply) {
     return true;
 }
 
-const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) {
-    // Convert sample to sample_rc if needed
-    if (!reply->in->val.data.has_sample_as_rc) {
-        reply->in->val.data.sample.rc = _z_sample_rc_new_from_val(reply->in->val.data.sample.base);
-        reply->in->val.data.has_sample_as_rc = true;
-    }
-    return &reply->in->val.data.sample.rc;
-}
-
-const zp_loaned_reply_sample_t *zp_reply_ok(const z_loaned_reply_t *reply) {
-    if (reply->in->val.data.has_sample_as_rc) {
-        return NULL;
-    }
-    return &reply->in->val.data.sample.base;
-}
+const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) { return &reply->data.sample; }
 
 const z_loaned_reply_err_t *z_reply_err(const z_loaned_reply_t *reply) {
     _ZP_UNUSED(reply);
@@ -1092,7 +1064,7 @@ int8_t _z_queryable_drop(_z_queryable_t **queryable) {
     return ret;
 }
 
-_Z_OWNED_FUNCTIONS_RC_IMPL(query)
+_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_query_t, query, _z_query_copy, _z_query_free)
 _Z_OWNED_FUNCTIONS_PTR_IMPL(_z_queryable_t, queryable, _z_owner_noop_copy, _z_queryable_drop)
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
@@ -1147,8 +1119,7 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
     _z_value_t value = {.payload = _z_bytes_from_owned_bytes(payload),
                         .encoding = _z_encoding_from_owned(opts.encoding)};
 
-    int8_t ret =
-        _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, _z_bytes_from_owned_bytes(opts.attachment));
+    int8_t ret = _z_send_reply(query, *keyexpr, value, Z_SAMPLE_KIND_PUT, _z_bytes_from_owned_bytes(opts.attachment));
     if (payload != NULL) {
         z_bytes_drop(payload);
     }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -865,13 +865,12 @@ int8_t z_put(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, z_
         _z_write(&_Z_RC_IN_VAL(zs), *keyexpr, _z_bytes_from_owned_bytes(payload), _z_encoding_from_owned(opt.encoding),
                  Z_SAMPLE_KIND_PUT, opt.congestion_control, opt.priority, _z_bytes_from_owned_bytes(opt.attachment));
 
-    // Trigger local subscriptions
+    // Trigger local subscriptions (consumes attachment)
     _z_trigger_local_subscriptions(&_Z_RC_IN_VAL(zs), *keyexpr, _z_bytes_from_owned_bytes(payload),
                                    _z_n_qos_make(0, opt.congestion_control == Z_CONGESTION_CONTROL_BLOCK, opt.priority),
                                    _z_bytes_from_owned_bytes(opt.attachment));
     // Clean-up
     z_encoding_drop(opt.encoding);
-    z_bytes_drop(opt.attachment);
     z_bytes_drop(payload);
     return ret;
 }
@@ -964,12 +963,11 @@ int8_t z_publisher_put(const z_loaned_publisher_t *pub, z_owned_bytes_t *payload
                        _z_encoding_from_owned(opt.encoding), Z_SAMPLE_KIND_PUT, pub->_congestion_control,
                        pub->_priority, _z_bytes_from_owned_bytes(opt.attachment));
     }
-    // Trigger local subscriptions
+    // Trigger local subscriptions (consumes attachment)
     _z_trigger_local_subscriptions(&pub->_zn.in->val, pub->_key, _z_bytes_from_owned_bytes(payload), _Z_N_QOS_DEFAULT,
                                    _z_bytes_from_owned_bytes(opt.attachment));
     // Clean-up
     z_encoding_drop(opt.encoding);
-    z_bytes_drop(opt.attachment);
     z_bytes_drop(payload);
     return ret;
 }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -291,6 +291,7 @@ static int8_t _z_encoding_convert_into_string(const z_loaned_encoding_t *encodin
     }
     // Allocate string
     char *value = (char *)z_malloc(sizeof(char) * total_len);
+    memset(value, 0, total_len);
     if (value == NULL) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -819,6 +819,18 @@ const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample) {
     return &_Z_RC_IN_VAL(sample).attachment;
 }
 
+const z_loaned_keyexpr_t *zp_reply_sample_keyexpr(const zp_loaned_reply_sample_t *sample) { return &sample->keyexpr; }
+z_sample_kind_t zp_reply_sample_kind(const zp_loaned_reply_sample_t *sample) { return sample->kind; }
+const z_loaned_bytes_t *zp_reply_sample_payload(const zp_loaned_reply_sample_t *sample) { return &sample->payload; }
+z_timestamp_t zp_reply_sample_timestamp(const zp_loaned_reply_sample_t *sample) { return sample->timestamp; }
+const z_loaned_encoding_t *zp_reply_sample_encoding(const zp_loaned_reply_sample_t *sample) {
+    return &sample->encoding;
+}
+z_qos_t zp_reply_sample_qos(const zp_loaned_reply_sample_t *sample) { return sample->qos; }
+const z_loaned_bytes_t *zp_reply_sample_attachment(const zp_loaned_reply_sample_t *sample) {
+    return &sample->attachment;
+}
+
 const z_loaned_bytes_t *z_reply_err_payload(const z_loaned_reply_err_t *reply_err) { return &reply_err->payload; }
 const z_loaned_encoding_t *z_reply_err_encoding(const z_loaned_reply_err_t *reply_err) { return &reply_err->encoding; }
 
@@ -1045,11 +1057,25 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
 _Bool z_reply_is_ok(const z_loaned_reply_t *reply) {
     _ZP_UNUSED(reply);
     // For the moment always return TRUE.
-    // The support for reply errors will come in the next release.
+    // FIXME: The support for reply errors will come in the next release.
     return true;
 }
 
-const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) { return &reply->in->val.data.sample; }
+const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) {
+    // Convert sample to sample_rc if needed
+    if (!reply->in->val.data.has_sample_as_rc) {
+        reply->in->val.data.sample.rc = _z_sample_rc_new_from_val(reply->in->val.data.sample.base);
+        reply->in->val.data.has_sample_as_rc = true;
+    }
+    return &reply->in->val.data.sample.rc;
+}
+
+const zp_loaned_reply_sample_t *zp_reply_ok(const z_loaned_reply_t *reply) {
+    if (reply->in->val.data.has_sample_as_rc) {
+        return NULL;
+    }
+    return &reply->in->val.data.sample.base;
+}
 
 const z_loaned_reply_err_t *z_reply_err(const z_loaned_reply_t *reply) {
     _ZP_UNUSED(reply);

--- a/src/collections/bytes.c
+++ b/src/collections/bytes.c
@@ -316,13 +316,13 @@ int8_t _z_bytes_reader_seek(_z_bytes_reader_t *reader, int64_t offset, int origi
             reader->in_slice_idx = 0;
             reader->slice_idx = 0;
             if (offset < 0) return _Z_ERR_DID_NOT_READ;
-            return _z_bytes_reader_seek_forward(reader, offset);
+            return _z_bytes_reader_seek_forward(reader, (size_t)offset);
         }
         case SEEK_CUR: {
             if (offset >= 0)
-                return _z_bytes_reader_seek_forward(reader, offset);
+                return _z_bytes_reader_seek_forward(reader, (size_t)offset);
             else
-                return _z_bytes_reader_seek_backward(reader, -offset);
+                return _z_bytes_reader_seek_backward(reader, (size_t)(-offset));
         }
         case SEEK_END: {
             reader->byte_idx = _z_bytes_len(reader->bytes);
@@ -331,14 +331,14 @@ int8_t _z_bytes_reader_seek(_z_bytes_reader_t *reader, int64_t offset, int origi
             if (offset > 0)
                 return _Z_ERR_DID_NOT_READ;
             else
-                return _z_bytes_reader_seek_backward(reader, -offset);
+                return _z_bytes_reader_seek_backward(reader, (size_t)(-offset));
         }
         default:
             return _Z_ERR_GENERIC;
     }
 }
 
-int64_t _z_bytes_reader_tell(const _z_bytes_reader_t *reader) { return reader->byte_idx; }
+int64_t _z_bytes_reader_tell(const _z_bytes_reader_t *reader) { return (int64_t)reader->byte_idx; }
 
 size_t _z_bytes_reader_read(_z_bytes_reader_t *reader, uint8_t *buf, size_t len) {
     uint8_t *buf_start = buf;

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -74,6 +74,16 @@ void _z_string_move(_z_string_t *dst, _z_string_t *src) {
     src->len = 0;
 }
 
+_z_string_t _z_string_steal(_z_string_t *str) {
+    _z_string_t ret = {
+        .val = str->val,
+        .len = str->len,
+    };
+    str->val = NULL;
+    str->len = 0;
+    return ret;
+}
+
 void _z_string_move_str(_z_string_t *dst, char *src) {
     dst->val = src;
     dst->len = strlen(src);

--- a/src/net/encoding.c
+++ b/src/net/encoding.c
@@ -57,3 +57,12 @@ void _z_encoding_move(_z_encoding_t *dst, _z_encoding_t *src) {
     src->id = _Z_ENCODING_ID_DEFAULT;
     _z_string_move(&dst->schema, &src->schema);
 }
+
+_z_encoding_t _z_encoding_steal(_z_encoding_t *val) {
+    _z_encoding_t ret = {
+        .id = val->id,
+        .schema = _z_string_steal(&val->schema),
+    };
+    val->id = _Z_ENCODING_ID_DEFAULT;
+    return ret;
+}

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -148,12 +148,14 @@ int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t p
                         ._body._body._put =
                             {
                                 ._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()},
-                                ._payload = payload,
-                                ._encoding = encoding,
-                                ._attachment = attachment,
+                                ._payload = _z_bytes_null(),
+                                ._encoding = _z_encoding_steal(&encoding),
+                                ._attachment = _z_bytes_null(),
                             },
                     },
             };
+            _z_bytes_copy(&msg._body._push._body._body._put._payload, &payload);
+            _z_bytes_copy(&msg._body._push._body._body._put._attachment, &attachment);
             break;
         case Z_SAMPLE_KIND_DELETE:
             msg = (_z_network_message_t){

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -130,7 +130,7 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub) {
 }
 
 /*------------------ Write ------------------*/
-int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload, const _z_encoding_t encoding,
+int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload, _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
                 const _z_bytes_t attachment) {
     int8_t ret = _Z_RES_OK;

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -130,7 +130,7 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub) {
 }
 
 /*------------------ Write ------------------*/
-int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload, _z_encoding_t encoding,
+int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload, const _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
                 const _z_bytes_t attachment) {
     int8_t ret = _Z_RES_OK;
@@ -148,14 +148,12 @@ int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t p
                         ._body._body._put =
                             {
                                 ._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()},
-                                ._payload = _z_bytes_null(),
-                                ._encoding = _z_encoding_steal(&encoding),
-                                ._attachment = _z_bytes_null(),
+                                ._payload = payload,
+                                ._encoding = encoding,
+                                ._attachment = attachment,
                             },
                     },
             };
-            _z_bytes_copy(&msg._body._push._body._body._put._payload, &payload);
-            _z_bytes_copy(&msg._body._push._body._body._put._attachment, &attachment);
             break;
         case Z_SAMPLE_KIND_DELETE:
             msg = (_z_network_message_t){

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -61,7 +61,7 @@ void _z_query_free(_z_query_t **query) {
 
 #if Z_FEATURE_QUERYABLE == 1
 _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_t *zn,
-                           uint32_t request_id, _z_bytes_t attachment) {
+                           uint32_t request_id, const _z_bytes_t attachment) {
     _z_query_t q = _z_query_null();
     q._request_id = request_id;
     q._zn = zn;

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -66,12 +66,12 @@ _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_
     q._request_id = request_id;
     q._zn = zn;
     q._parameters = (char *)z_malloc(parameters->len + 1);
-    memcpy(q._parameters, parameters->start, parameters->len);
+    memcpy(q._parameters, parameters->start, parameters->len); // TODO: Might be movable, Issue #482
     q._parameters[parameters->len] = 0;
     q._anyke = (strstr(q._parameters, Z_SELECTOR_QUERY_MATCH) == NULL) ? false : true;
     q._key = _z_keyexpr_steal(key);
-    _z_value_copy(&q._value, value);
-    _z_bytes_move(&q.attachment, &attachment);
+    _z_bytes_copy(&q.attachment, &attachment);
+    _z_value_copy(&q._value, value); // FIXME: Move encoding, Issue #482
     return q;
 }
 

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -66,12 +66,12 @@ _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_
     q._request_id = request_id;
     q._zn = zn;
     q._parameters = (char *)z_malloc(parameters->len + 1);
-    memcpy(q._parameters, parameters->start, parameters->len); // TODO: Might be movable, Issue #482
+    memcpy(q._parameters, parameters->start, parameters->len);  // TODO: Might be movable, Issue #482
     q._parameters[parameters->len] = 0;
     q._anyke = (strstr(q._parameters, Z_SELECTOR_QUERY_MATCH) == NULL) ? false : true;
     q._key = _z_keyexpr_steal(key);
     _z_bytes_copy(&q.attachment, &attachment);
-    _z_value_copy(&q._value, value); // FIXME: Move encoding, Issue #482
+    _z_value_copy(&q._value, value);  // FIXME: Move encoding, Issue #482
     return q;
 }
 

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -61,7 +61,7 @@ void _z_query_free(_z_query_t **query) {
 
 #if Z_FEATURE_QUERYABLE == 1
 _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_t *zn,
-                           uint32_t request_id, const _z_bytes_t attachment) {
+                           uint32_t request_id, _z_bytes_t attachment) {
     _z_query_t q = _z_query_null();
     q._request_id = request_id;
     q._zn = zn;
@@ -69,9 +69,9 @@ _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_
     memcpy(q._parameters, parameters->start, parameters->len);
     q._parameters[parameters->len] = 0;
     q._anyke = (strstr(q._parameters, Z_SELECTOR_QUERY_MATCH) == NULL) ? false : true;
-    _z_bytes_copy(&q.attachment, &attachment);
     q._key = _z_keyexpr_steal(key);
     _z_value_copy(&q._value, value);
+    _z_bytes_move(&q.attachment, &attachment);
     return q;
 }
 

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -21,19 +21,14 @@ _z_reply_t _z_reply_null(void) {
     _z_reply_t r = {._tag = Z_REPLY_TAG_DATA,
                     .data = {
                         .replier_id = {.id = {0}},
-                        .has_sample_as_rc = false,
-                        .sample.base = _z_sample_null(),
+                        .sample = _z_sample_null(),
                     }};
     return r;
 }
 
 #if Z_FEATURE_QUERY == 1
 void _z_reply_data_clear(_z_reply_data_t *reply_data) {
-    if (reply_data->has_sample_as_rc) {
-        _z_sample_rc_drop(&reply_data->sample.rc);
-    } else {
-        _z_sample_clear(&reply_data->sample.base);
-    }
+    _z_sample_clear(&reply_data->sample);
     reply_data->replier_id = _z_id_empty();
 }
 
@@ -47,15 +42,9 @@ void _z_reply_data_free(_z_reply_data_t **reply_data) {
     }
 }
 
-void _z_reply_data_copy(_z_reply_data_t *dst, _z_reply_data_t *src) {
+void _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src) {
     dst->replier_id = src->replier_id;
-    dst->has_sample_as_rc = src->has_sample_as_rc;
-
-    if (src->has_sample_as_rc) {
-        _z_sample_rc_copy(&dst->sample.rc, &src->sample.rc);
-    } else {
-        _z_sample_copy(&dst->sample.base, &src->sample.base);
-    }
+    _z_sample_copy(&dst->sample, &src->sample);
 }
 
 _z_reply_t _z_reply_move(_z_reply_t *src_reply) {
@@ -77,7 +66,7 @@ void _z_reply_free(_z_reply_t **reply) {
     }
 }
 
-void _z_reply_copy(_z_reply_t *dst, _z_reply_t *src) {
+void _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src) {
     _z_reply_data_copy(&dst->data, &src->data);
     dst->_tag = src->_tag;
 }
@@ -102,12 +91,12 @@ _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, 
     if (tag == Z_REPLY_TAG_DATA) {
         reply.data.replier_id = id;
         // Create reply sample
-        reply.data.sample.base.keyexpr = keyexpr;    // FIXME: call z_keyexpr_move or copy
-        reply.data.sample.base.encoding = encoding;  // FIXME: call z_encoding_move or copy
-        _z_bytes_copy(&sample.payload, &payload);
-        reply.data.sample.base.kind = kind;
-        reply.data.sample.base.timestamp = _z_timestamp_duplicate(timestamp);
-        reply.data.sample.base.attachment._slice = _z_slice_steal((_z_slice_t *)&att._slice);
+        reply.data.sample.keyexpr = keyexpr;    // FIXME: call z_keyexpr_move or copy
+        reply.data.sample.encoding = encoding;  // FIXME: call z_encoding_move or copy
+        _z_bytes_copy(&reply.data.sample.payload, &payload);
+        reply.data.sample.kind = kind;
+        reply.data.sample.timestamp = _z_timestamp_duplicate(timestamp);
+        _z_bytes_copy(&reply.data.sample.attachment, &attachment);  // FIXME: Steal slices
     }
     return reply;
 }

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -92,11 +92,11 @@ _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, 
         reply.data.replier_id = id;
         // Create reply sample
         reply.data.sample.keyexpr = _z_keyexpr_steal(&keyexpr);
-        _z_encoding_copy(&reply.data.sample.encoding, &encoding);
-        _z_bytes_copy(&reply.data.sample.payload, &payload);
         reply.data.sample.kind = kind;
         reply.data.sample.timestamp = _z_timestamp_duplicate(timestamp);
-        _z_bytes_move(&reply.data.sample.attachment, &attachment);
+        _z_bytes_copy(&reply.data.sample.payload, &payload);
+        _z_bytes_copy(&reply.data.sample.attachment, &attachment);
+        _z_encoding_copy(&reply.data.sample.encoding, &encoding); // FIXME: Move encoding, Issue #482
     }
     return reply;
 }

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -96,7 +96,7 @@ _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, 
         reply.data.sample.timestamp = _z_timestamp_duplicate(timestamp);
         _z_bytes_copy(&reply.data.sample.payload, &payload);
         _z_bytes_copy(&reply.data.sample.attachment, &attachment);
-        _z_encoding_copy(&reply.data.sample.encoding, &encoding); // FIXME: Move encoding, Issue #482
+        _z_encoding_copy(&reply.data.sample.encoding, &encoding);  // FIXME: Move encoding, Issue #482
     }
     return reply;
 }

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -85,7 +85,7 @@ void _z_pending_reply_clear(_z_pending_reply_t *pr) {
 
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           _z_bytes_t attachment) {
+                           const _z_bytes_t attachment) {
     _z_reply_t reply = _z_reply_null();
     reply._tag = tag;
     if (tag == Z_REPLY_TAG_DATA) {
@@ -103,7 +103,7 @@ _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, 
 #else
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           _z_bytes_t attachment) {
+                           const _z_bytes_t attachment) {
     _ZP_UNUSED(keyexpr);
     _ZP_UNUSED(tag);
     _ZP_UNUSED(id);

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -85,25 +85,25 @@ void _z_pending_reply_clear(_z_pending_reply_t *pr) {
 
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           const _z_bytes_t attachment) {
+                           _z_bytes_t attachment) {
     _z_reply_t reply = _z_reply_null();
     reply._tag = tag;
     if (tag == Z_REPLY_TAG_DATA) {
         reply.data.replier_id = id;
         // Create reply sample
-        reply.data.sample.keyexpr = keyexpr;    // FIXME: call z_keyexpr_move or copy
-        reply.data.sample.encoding = encoding;  // FIXME: call z_encoding_move or copy
+        reply.data.sample.keyexpr = _z_keyexpr_steal(&keyexpr);
+        _z_encoding_copy(&reply.data.sample.encoding, &encoding);
         _z_bytes_copy(&reply.data.sample.payload, &payload);
         reply.data.sample.kind = kind;
         reply.data.sample.timestamp = _z_timestamp_duplicate(timestamp);
-        _z_bytes_copy(&reply.data.sample.attachment, &attachment);  // FIXME: Steal slices
+        _z_bytes_move(&reply.data.sample.attachment, &attachment);
     }
     return reply;
 }
 #else
 _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t payload,
                            const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
-                           const _z_bytes_t attachment) {
+                           _z_bytes_t attachment) {
     _ZP_UNUSED(keyexpr);
     _ZP_UNUSED(tag);
     _ZP_UNUSED(id);

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -82,13 +82,13 @@ _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const 
                              _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              _z_bytes_t attachment) {
     _z_sample_t s = _z_sample_null();
-    _z_bytes_copy(&s.payload, &payload);
-    _z_encoding_copy(&s.encoding, &encoding);
     s.keyexpr = _z_keyexpr_steal(key);
     s.kind = kind;
     s.timestamp = timestamp;
     s.qos = qos;
-    _z_bytes_move(&s.attachment, &attachment);
+    _z_bytes_copy(&s.payload, &payload);
+    _z_bytes_copy(&s.attachment, &attachment);
+    _z_encoding_copy(&s.encoding, &encoding); // FIXME: Move encoding, Issue #482
     return s;
 }
 #else

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -80,7 +80,7 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src) {
 #if Z_FEATURE_SUBSCRIPTION == 1
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             const _z_bytes_t attachment) {
+                             _z_bytes_t attachment) {
     _z_sample_t s = _z_sample_null();
     _z_bytes_copy(&s.payload, &payload);
     _z_encoding_copy(&s.encoding, &encoding);
@@ -88,13 +88,13 @@ _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const 
     s.kind = kind;
     s.timestamp = timestamp;
     s.qos = qos;
-    _z_bytes_copy(&s.attachment, &attachment);
+    _z_bytes_move(&s.attachment, &attachment);
     return s;
 }
 #else
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             const _z_bytes_t attachment) {
+                             _z_bytes_t attachment) {
     _ZP_UNUSED(key);
     _ZP_UNUSED(payload);
     _ZP_UNUSED(timestamp);

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -78,13 +78,13 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src) {
 }
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-_z_sample_t _z_sample_create(const _z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
+_z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              const _z_bytes_t attachment) {
     _z_sample_t s = _z_sample_null();
-    _z_keyexpr_copy(&s.keyexpr, key);
     _z_bytes_copy(&s.payload, &payload);
     _z_encoding_copy(&s.encoding, &encoding);
+    s.keyexpr = _z_keyexpr_steal(key);
     s.kind = kind;
     s.timestamp = timestamp;
     s.qos = qos;
@@ -92,7 +92,7 @@ _z_sample_t _z_sample_create(const _z_keyexpr_t *key, const _z_bytes_t payload, 
     return s;
 }
 #else
-_z_sample_t _z_sample_create(const _z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
+_z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
                              const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              const _z_bytes_t attachment) {
     _ZP_UNUSED(key);

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -88,7 +88,7 @@ _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const 
     s.qos = qos;
     _z_bytes_copy(&s.payload, &payload);
     _z_bytes_copy(&s.attachment, &attachment);
-    _z_encoding_copy(&s.encoding, &encoding); // FIXME: Move encoding, Issue #482
+    _z_encoding_copy(&s.encoding, &encoding);  // FIXME: Move encoding, Issue #482
     return s;
 }
 #else

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -80,7 +80,7 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src) {
 #if Z_FEATURE_SUBSCRIPTION == 1
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
                              _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             _z_bytes_t attachment) {
+                             const _z_bytes_t attachment) {
     _z_sample_t s = _z_sample_null();
     s.keyexpr = _z_keyexpr_steal(key);
     s.kind = kind;
@@ -93,8 +93,8 @@ _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const 
 }
 #else
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
-                             const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
-                             _z_bytes_t attachment) {
+                             _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
+                             const _z_bytes_t attachment) {
     _ZP_UNUSED(key);
     _ZP_UNUSED(payload);
     _ZP_UNUSED(timestamp);

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -79,7 +79,7 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src) {
 
 #if Z_FEATURE_SUBSCRIPTION == 1
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t timestamp,
-                             const _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
+                             _z_encoding_t encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              _z_bytes_t attachment) {
     _z_sample_t s = _z_sample_null();
     _z_bytes_copy(&s.payload, &payload);

--- a/src/protocol/definitions/message.c
+++ b/src/protocol/definitions/message.c
@@ -23,8 +23,9 @@
 void _z_msg_reply_clear(_z_msg_reply_t *msg) { _z_push_body_clear(&msg->_body); }
 
 void _z_msg_put_clear(_z_msg_put_t *msg) {
-    _z_encoding_clear(&msg->_encoding);
     _z_bytes_drop(&msg->_payload);
+    _z_bytes_drop(&msg->_attachment);
+    _z_encoding_clear(&msg->_encoding);  // FIXME: Remove when possible, Issue #482
     _z_timestamp_clear(&msg->_commons._timestamp);
 }
 
@@ -38,6 +39,7 @@ _z_msg_query_reqexts_t _z_msg_query_required_extensions(const _z_msg_query_t *ms
 
 void _z_msg_query_clear(_z_msg_query_t *msg) {
     _z_slice_clear(&msg->_parameters);
+    _z_bytes_drop(&msg->_ext_attachment);
     _z_value_clear(&msg->_ext_value);
 }
 void _z_msg_err_clear(_z_msg_err_t *err) {

--- a/src/protocol/keyexpr.c
+++ b/src/protocol/keyexpr.c
@@ -39,7 +39,6 @@ int8_t _z_keyexpr_copy(_z_keyexpr_t *dst, const _z_keyexpr_t *src) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }
     dst->_id = src->_id;
-    dst->_suffix = src->_suffix ? _z_str_clone(src->_suffix) : NULL;
     dst->_mapping = src->_mapping;
     _z_keyexpr_set_owns_suffix(dst, true);
     return _Z_RES_OK;

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -127,8 +127,8 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
             pen_rep = _z_pending_reply_list_head(pen_rps);
 
             // Check if this is the same resource key
-            if (_z_str_eq(pen_rep->_reply.data.sample.in->val.keyexpr._suffix,
-                          reply.data.sample.in->val.keyexpr._suffix) == true) {
+            if (_z_str_eq(pen_rep->_reply.data.sample.base.keyexpr._suffix, reply.data.sample.base.keyexpr._suffix) ==
+                true) {
                 if (msg->_commons._timestamp.time <= pen_rep->_tstamp.time) {
                     drop = true;
                 } else {
@@ -149,7 +149,7 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
                     _z_reply_t partial_reply;
                     (void)memset(&partial_reply, 0,
                                  sizeof(_z_reply_t));  // Avoid warnings on uninitialized values on the reply
-                    partial_reply.data.sample.in->val.keyexpr = _z_keyexpr_duplicate(reply.data.sample.in->val.keyexpr);
+                    partial_reply.data.sample.base.keyexpr = _z_keyexpr_duplicate(reply.data.sample.base.keyexpr);
                     pen_rep->_reply = partial_reply;
                 } else {
                     pen_rep->_reply = reply;  // Store the whole reply in the latest mode

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -127,8 +127,7 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
             pen_rep = _z_pending_reply_list_head(pen_rps);
 
             // Check if this is the same resource key
-            if (_z_str_eq(pen_rep->_reply.data.sample.base.keyexpr._suffix, reply.data.sample.base.keyexpr._suffix) ==
-                true) {
+            if (_z_str_eq(pen_rep->_reply.data.sample.keyexpr._suffix, reply.data.sample.keyexpr._suffix) == true) {
                 if (msg->_commons._timestamp.time <= pen_rep->_tstamp.time) {
                     drop = true;
                 } else {
@@ -149,7 +148,7 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
                     _z_reply_t partial_reply;
                     (void)memset(&partial_reply, 0,
                                  sizeof(_z_reply_t));  // Avoid warnings on uninitialized values on the reply
-                    partial_reply.data.sample.base.keyexpr = _z_keyexpr_duplicate(reply.data.sample.base.keyexpr);
+                    partial_reply.data.sample.keyexpr = _z_keyexpr_duplicate(reply.data.sample.keyexpr);
                     pen_rep->_reply = partial_reply;
                 } else {
                     pen_rep->_reply = reply;  // Store the whole reply in the latest mode
@@ -166,10 +165,10 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
 
     // Trigger the user callback
     if ((ret == _Z_RES_OK) && (pen_qry->_consolidation != Z_CONSOLIDATION_MODE_LATEST)) {
-        _z_reply_rc_t cb_reply = _z_reply_rc_new();
-        cb_reply.in->val = _z_reply_move(&reply);
+        _z_reply_t cb_reply = _z_reply_null();
+        cb_reply = _z_reply_move(&reply);
         pen_qry->_callback(&cb_reply, pen_qry->_arg);
-        _z_reply_rc_drop(&cb_reply);
+        _z_reply_clear(&cb_reply);
     }
 
     if (ret != _Z_RES_OK) {
@@ -189,18 +188,17 @@ int8_t _z_trigger_query_reply_final(_z_session_t *zn, _z_zint_t id) {
     if ((ret == _Z_RES_OK) && (pen_qry == NULL)) {
         ret = _Z_ERR_ENTITY_UNKNOWN;
     }
-
     // The reply is the final one, apply consolidation if needed
     if ((ret == _Z_RES_OK) && (pen_qry->_consolidation == Z_CONSOLIDATION_MODE_LATEST)) {
         while (pen_qry->_pending_replies != NULL) {
             _z_pending_reply_t *pen_rep = _z_pending_reply_list_head(pen_qry->_pending_replies);
 
             // Trigger the query handler
-            _z_reply_rc_t cb_reply = _z_reply_rc_new();
-            cb_reply.in->val = _z_reply_move(&pen_rep->_reply);
+            _z_reply_t cb_reply = _z_reply_null();
+            cb_reply = _z_reply_move(&pen_rep->_reply);
             pen_qry->_callback(&cb_reply, pen_qry->_arg);
             pen_qry->_pending_replies = _z_pending_reply_list_pop(pen_qry->_pending_replies, NULL);
-            _z_reply_rc_drop(&cb_reply);
+            _z_reply_clear(&cb_reply);
         }
     }
 

--- a/src/session/queryable.c
+++ b/src/session/queryable.c
@@ -145,8 +145,8 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
         _zp_session_unlock_mutex(zn);
 
         // Build the z_query
-        _z_query_rc_t query = _z_query_rc_new();
-        query.in->val = _z_query_create(&msgq->_ext_value, &key, &msgq->_parameters, zn, qid, attachment);
+        _z_query_t query = _z_query_null();
+        query = _z_query_create(&msgq->_ext_value, &key, &msgq->_parameters, zn, qid, attachment);
         // Parse session_queryable list
         _z_session_queryable_rc_list_t *xs = qles;
         while (xs != NULL) {
@@ -155,8 +155,7 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
             xs = _z_session_queryable_rc_list_tail(xs);
         }
         // Clean up
-        _z_query_rc_drop(&query);
-        _z_keyexpr_clear(&key);
+        _z_query_clear(&query);
         _z_session_queryable_rc_list_free(&qles);
     } else {
         _zp_session_unlock_mutex(zn);

--- a/src/session/queryable.c
+++ b/src/session/queryable.c
@@ -145,8 +145,8 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
         _zp_session_unlock_mutex(zn);
 
         // Build the z_query
-        _z_query_t query = _z_query_null();
-        query = _z_query_create(&msgq->_ext_value, &key, &msgq->_parameters, zn, qid, attachment);
+        _z_query_rc_t query = _z_query_rc_new();
+        query.in->val = _z_query_create(&msgq->_ext_value, &key, &msgq->_parameters, zn, qid, attachment);
         // Parse session_queryable list
         _z_session_queryable_rc_list_t *xs = qles;
         while (xs != NULL) {
@@ -155,7 +155,7 @@ int8_t _z_trigger_queryables(_z_session_t *zn, const _z_msg_query_t *msgq, const
             xs = _z_session_queryable_rc_list_tail(xs);
         }
         // Clean up
-        _z_query_clear(&query);
+        _z_query_rc_drop(&query);
         _z_session_queryable_rc_list_free(&qles);
     } else {
         _zp_session_unlock_mutex(zn);

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -162,8 +162,8 @@ int8_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, co
         _zp_session_unlock_mutex(zn);
 
         // Build the sample
-        _z_sample_rc_t sample = _z_sample_rc_new();
-        sample.in->val = _z_sample_create(&key, payload, timestamp, encoding, kind, qos, attachment);
+        _z_sample_t sample = _z_sample_null();
+        sample = _z_sample_create(&key, payload, timestamp, encoding, kind, qos, attachment);
         // Parse subscription list
         _z_subscription_rc_list_t *xs = subs;
         _Z_DEBUG("Triggering %ju subs", (uintmax_t)_z_subscription_rc_list_len(xs));
@@ -173,8 +173,7 @@ int8_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, co
             xs = _z_subscription_rc_list_tail(xs);
         }
         // Clean up
-        _z_sample_rc_drop(&sample);
-        _z_keyexpr_clear(&key);
+        _z_sample_clear(&sample);
         _z_subscription_rc_list_free(&subs);
     } else {
         _zp_session_unlock_mutex(zn);

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -162,8 +162,7 @@ int8_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, co
         _zp_session_unlock_mutex(zn);
 
         // Build the sample
-        _z_sample_t sample = _z_sample_null();
-        sample = _z_sample_create(&key, payload, timestamp, encoding, kind, qos, attachment);
+        _z_sample_t sample = _z_sample_create(&key, payload, timestamp, encoding, kind, qos, attachment);
         // Parse subscription list
         _z_subscription_rc_list_t *xs = subs;
         _Z_DEBUG("Triggering %ju subs", (uintmax_t)_z_subscription_rc_list_len(xs));

--- a/tests/attachment.py
+++ b/tests/attachment.py
@@ -30,28 +30,28 @@ Putting Data ('demo/example/zenoh-pico-pub': '[   4] Pub from Pico!')...'''
 Declaring Subscriber on 'demo/example/**'...
 Press CTRL-C to quit...
 >> [Subscriber] Received ('demo/example/zenoh-pico-pub': '[   0] Pub from Pico!')
-    with encoding: text/plain;utf8
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: source, C
      1: index, 0
 >> [Subscriber] Received ('demo/example/zenoh-pico-pub': '[   1] Pub from Pico!')
-    with encoding: text/plain;utf8
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: source, C
      1: index, 1
 >> [Subscriber] Received ('demo/example/zenoh-pico-pub': '[   2] Pub from Pico!')
-    with encoding: text/plain;utf8
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: source, C
      1: index, 2
 >> [Subscriber] Received ('demo/example/zenoh-pico-pub': '[   3] Pub from Pico!')
-    with encoding: text/plain;utf8
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: source, C
      1: index, 3
 >> [Subscriber] Received ('demo/example/zenoh-pico-pub': '[   4] Pub from Pico!')
-    with encoding: text/plain;utf8
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: source, C
      1: index, 4'''
 
@@ -137,7 +137,8 @@ def query_and_queryable():
     z_query_expected_output = """Opening session...
 Sending Query 'demo/example/**'...
 >> Received ('demo/example/**': 'Queryable from Pico!')
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: reply_key, reply_value
 >> Received query final notification"""
 
@@ -147,7 +148,8 @@ Sending Query 'demo/example/**'...
 Creating Queryable on 'demo/example/zenoh-pico-queryable'...
 Press CTRL-C to quit...
  >> [Queryable handler] Received Query 'demo/example/**'
-   with attachment:
+    with encoding: zenoh/string;utf8
+    with attachment:
      0: test_key, test_value"""
 
     print("Start queryable")

--- a/tests/z_channels_test.c
+++ b/tests/z_channels_test.c
@@ -27,13 +27,15 @@
     do {                                                                                            \
         _z_bytes_t payload;                                                                         \
         _z_bytes_from_slice(&payload, (_z_slice_t){.start = (const uint8_t *)v, .len = strlen(v)}); \
-        _z_sample_t s = {.keyexpr = _z_rname("key"),                                                \
-                         .payload = payload,                                                        \
-                         .timestamp = _z_timestamp_null(),                                          \
-                         .encoding = _z_encoding_null(),                                            \
-                         .kind = 0,                                                                 \
-                         .qos = {0}};                                                               \
-        z_loaned_sample_t sample = _z_sample_rc_new_from_val(s);                                    \
+        z_loaned_sample_t sample = {                                                                \
+            .keyexpr = _z_rname("key"),                                                             \
+            .payload = payload,                                                                     \
+            .timestamp = _z_timestamp_null(),                                                       \
+            .encoding = _z_encoding_null(),                                                         \
+            .kind = 0,                                                                              \
+            .qos = {0},                                                                             \
+            .attachment = _z_bytes_null(),                                                          \
+        };                                                                                          \
         z_call(*z_loan(closure), &sample);                                                          \
     } while (0);
 


### PR DESCRIPTION
Oudated.

_For Zenoh-C compatibility issue, we have a single `z_loaned_sample_t` type which corresponds both to a sample received by a sub and the sample contained in a reply.

This type is refcounted as required for potential out-of-context usage by a subscriber. As replies are themselves refcounted that create a double refcount which is slightly wasteful memory-wise in a Query/reply scenario.

This PR attemps to offer a way to avoid this double refcounting by storing the reply sample without refcounting, provide a zenoh pico api to interact with it, while a call to the Zenoh-C api will still generate the recounted sample._