### PR TITLE
Unify the names of methods that receive/return strings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -269,8 +269,8 @@ Primitives
 ~~~~~~~~~~
 
 .. autocfunction:: primitives.h::z_view_string_wrap
-.. autocfunction:: primitives.h::z_view_keyexpr_from_string
-.. autocfunction:: primitives.h::z_view_keyexpr_from_string_unchecked
+.. autocfunction:: primitives.h::z_view_keyexpr_from_str
+.. autocfunction:: primitives.h::z_view_keyexpr_from_str_unchecked
 .. autocfunction:: primitives.h::z_keyexpr_to_string
 .. autocfunction:: primitives.h::zp_keyexpr_resolve
 .. autocfunction:: primitives.h::z_keyexpr_is_initialized
@@ -328,8 +328,8 @@ Primitives
 .. autocfunction:: primitives.h::z_bytes_serialize_from_double
 .. autocfunction:: primitives.h::z_bytes_serialize_from_slice
 .. autocfunction:: primitives.h::z_bytes_serialize_from_slice_copy
-.. autocfunction:: primitives.h::z_bytes_serialize_from_string
-.. autocfunction:: primitives.h::z_bytes_serialize_from_string_copy
+.. autocfunction:: primitives.h::z_bytes_serialize_from_str
+.. autocfunction:: primitives.h::z_bytes_serialize_from_str_copy
 .. autocfunction:: primitives.h::z_bytes_empty
 .. autocfunction:: primitives.h::z_bytes_len
 .. autocfunction:: primitives.h::z_bytes_is_empty

--- a/examples/arduino/z_get.ino
+++ b/examples/arduino/z_get.ino
@@ -118,13 +118,13 @@ void loop() {
     // Value encoding
     z_owned_bytes_t payload;
     if (strcmp(VALUE, "") != 0) {
-        z_bytes_serialize_from_string(&payload, VALUE);
+        z_bytes_serialize_from_str(&payload, VALUE);
         opts.payload = &payload;
     }
     z_owned_closure_reply_t callback;
     z_closure_reply(&callback, reply_handler, reply_dropper, NULL);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_get(z_session_loan(&s), z_view_keyexpr_loan(&ke), "", z_closure_reply_move(&callback), &opts) < 0) {
         Serial.println("Unable to send query.");
     }

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -82,7 +82,7 @@ void setup() {
     Serial.print(KEYEXPR);
     Serial.println("...");
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         Serial.println("Unable to declare publisher for key expression!");
         while (1) {
@@ -108,7 +108,7 @@ void loop() {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, buf);
+    z_bytes_serialize_from_str(&payload, buf);
 
     if (z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL) < 0) {
         Serial.println("Error while publishing data");

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -100,7 +100,7 @@ void setup() {
     // z_closure_sample(&callback, data_handler, NULL, NULL);
     // @TODO
     // z_view_keyexpr_t ke;
-    // z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    // z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     // sub = z_declare_pull_subscriber(z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
     // NULL); if (!z_pull_subscriber_check(&sub)) {
     //     Serial.println("Unable to declare subscriber.");

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -53,11 +53,11 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
     z_string_drop(z_string_move(&payload_string));
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, VALUE);
+    z_bytes_serialize_from_str(&reply_payload, VALUE);
 
     z_query_reply(query, z_view_keyexpr_loan(&ke), z_bytes_move(&reply_payload), NULL);
 
@@ -111,7 +111,7 @@ void setup() {
     z_closure_query(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         Serial.println("Unable to declare queryable.");

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -97,7 +97,7 @@ void setup() {
     z_closure_sample(&callback, data_handler, NULL, NULL);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         Serial.println("Unable to declare subscriber.");

--- a/examples/espidf/z_get.c
+++ b/examples/espidf/z_get.c
@@ -165,13 +165,13 @@ void app_main() {
         // Value encoding
         z_owned_bytes_t payload;
         if (strcmp(VALUE, "") != 0) {
-            z_bytes_serialize_from_string(&payload, VALUE);
+            z_bytes_serialize_from_str(&payload, VALUE);
             opts.payload = &payload;
         }
         z_owned_closure_reply_t callback;
         z_closure(&callback, reply_handler, reply_dropper);
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+        z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
         if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
             printf("Unable to send query.\n");
             exit(-1);

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -142,7 +142,7 @@ void app_main() {
     printf("Declaring publisher for '%s'...", KEYEXPR);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
@@ -157,7 +157,7 @@ void app_main() {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -154,7 +154,7 @@ void app_main() {
     printf("Declaring Subscriber on '%s'...", KEYEXPR);
     // @TODO
     // z_view_keyexpr_t ke;
-    // z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    // z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     // z_owned_pull_subscriber_t sub = z_declare_pull_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL);
     // if (!z_check(sub)) {
     //     printf("Unable to declare subscriber.\n");

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -118,11 +118,11 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
     z_drop(z_move(payload_string));
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, VALUE);
+    z_bytes_serialize_from_str(&reply_payload, VALUE);
 
     z_query_reply(query, z_loan(ke), z_move(reply_payload), NULL);
     z_drop(z_move(keystr));
@@ -172,7 +172,7 @@ void app_main() {
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -154,7 +154,7 @@ void app_main() {
     z_closure(&callback, data_handler);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);

--- a/examples/freertos_plus_tcp/z_get.c
+++ b/examples/freertos_plus_tcp/z_get.c
@@ -76,7 +76,7 @@ void app_main(void) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, KEYEXPR) < 0) {
+    if (z_view_keyexpr_from_str(&ke, KEYEXPR) < 0) {
         printf("%s is not a valid key expression", KEYEXPR);
         return -1;
     }
@@ -89,7 +89,7 @@ void app_main(void) {
         // Value encoding
         z_owned_bytes_t payload;
         if (strcmp(VALUE, "") != 0) {
-            z_bytes_serialize_from_string(&payload, VALUE);
+            z_bytes_serialize_from_str(&payload, VALUE);
             opts.payload = &payload;
         }
         z_owned_closure_reply_t callback;

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -85,7 +85,7 @@ void app_main(void) {
     printf("Declaring publisher for '%s'...\n", KEYEXPR);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
@@ -99,7 +99,7 @@ void app_main(void) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put_options_t options;
         z_publisher_put_options_default(&options);

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -50,7 +50,7 @@ void app_main(void) {
     printf("Declaring publisher for '%s'...\n", KEYEXPR);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
@@ -65,7 +65,7 @@ void app_main(void) {
 
             // Create payload
             z_owned_bytes_t payload;
-            z_bytes_serialize_from_string(&payload, buf);
+            z_bytes_serialize_from_str(&payload, buf);
 
             z_publisher_put(z_loan(pub), z_move(payload), NULL);
             ++idx;

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -66,7 +66,7 @@ void app_main(void) {
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     // @TODO
     // z_view_keyexpr_t ke;
-    // z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    // z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     // z_owned_pull_subscriber_t sub = z_declare_pull_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL);
     // if (!z_check(sub)) {
     //     printf("Unable to declare subscriber.\n");

--- a/examples/freertos_plus_tcp/z_put.c
+++ b/examples/freertos_plus_tcp/z_put.c
@@ -54,7 +54,7 @@ void app_main(void) {
     printf("Declaring key expression '%s'...\n", KEYEXPR);
     z_owned_keyexpr_t ke;
     z_view_keyexpr_t vke;
-    z_view_keyexpr_from_string_unchecked(&vke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&vke, KEYEXPR);
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
         zp_stop_read_task(z_loan_mut(s));
@@ -69,7 +69,7 @@ void app_main(void) {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, VALUE);
+    z_bytes_serialize_from_str(&payload, VALUE);
 
     if (z_put(z_loan(s), z_loan(ke), z_move(payload), &options) < 0) {
         printf("Oh no! Put has failed...\n");

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -49,7 +49,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
     z_query_reply_options_default(&options);
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, VALUE);
+    z_bytes_serialize_from_str(&reply_payload, VALUE);
 
     z_query_reply(query, z_query_keyexpr(query), z_move(reply_payload), &options);
     z_drop(z_move(keystr));
@@ -78,7 +78,7 @@ void app_main(void) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, KEYEXPR) < 0) {
+    if (z_view_keyexpr_from_str(&ke, KEYEXPR) < 0) {
         printf("%s is not a valid key expression", KEYEXPR);
         return -1;
     }

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -65,7 +65,7 @@ void app_main(void) {
     z_closure(&callback, data_handler);
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -62,7 +62,7 @@ void app_main(void) {
     z_closure(&callback, data_handler);
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/examples/mbed/z_get.cpp
+++ b/examples/mbed/z_get.cpp
@@ -86,13 +86,13 @@ int main(int argc, char **argv) {
         // Value encoding
         z_owned_bytes_t payload;
         if (strcmp(VALUE, "") != 0) {
-            z_bytes_serialize_from_string(&payload, VALUE);
+            z_bytes_serialize_from_str(&payload, VALUE);
             opts.payload = &payload;
         }
         z_owned_closure_reply_t callback;
         z_closure_reply(&callback, reply_handler, reply_dropper, NULL);
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+        z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
         if (z_get(z_session_loan(&s), z_view_keyexpr_loan(&ke), "", z_closure_reply_move(&callback), &opts) < 0) {
             printf("Unable to send query.\n");
             exit(-1);

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...", KEYEXPR);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL);
     }

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -49,7 +49,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, VALUE);
+    z_bytes_serialize_from_str(&reply_payload, VALUE);
 
     z_query_reply(query, z_query_keyexpr(query), z_bytes_move(&reply_payload), NULL);
     z_string_drop(z_string_move(&keystr));
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     z_closure_query(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         printf("Unable to declare queryable.\n");

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     z_closure_sample(&callback, data_handler, NULL, NULL);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     // Value encoding
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
 

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -52,8 +52,8 @@ _Bool create_attachment_iter(z_owned_bytes_t *kv_pair, void *context) {
     if (kvs->current_idx >= kvs->len) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, kvs->data[kvs->current_idx].key);
-        z_bytes_serialize_from_string(&v, kvs->data[kvs->current_idx].value);
+        z_bytes_serialize_from_str(&k, kvs->data[kvs->current_idx].key);
+        z_bytes_serialize_from_str(&v, kvs->data[kvs->current_idx].value);
         z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
         kvs->current_idx++;
         return true;
@@ -189,7 +189,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
     // Value encoding
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
 

--- a/examples/unix/c11/z_get_channel.c
+++ b/examples/unix/c11/z_get_channel.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
     // Value encoding
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
     z_owned_closure_reply_t closure;

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -78,9 +78,9 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
 
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL) < 0) {

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)z_move(pub));
     z_owned_subscriber_t sub;

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -41,8 +41,8 @@ _Bool create_attachment_iter(z_owned_bytes_t *kv_pair, void *context) {
     if (kvs->current_idx >= kvs->len) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, kvs->data[kvs->current_idx].key);
-        z_bytes_serialize_from_string(&v, kvs->data[kvs->current_idx].value);
+        z_bytes_serialize_from_str(&k, kvs->data[kvs->current_idx].key);
+        z_bytes_serialize_from_str(&v, kvs->data[kvs->current_idx].value);
         z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
         kvs->current_idx++;
         return true;
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     // Declare publisher
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         // Add attachment value
         sprintf(buf_ind, "%d", idx);

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
 

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     // Declare publisher
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     while (1) {
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, (char *)value);
+        z_bytes_serialize_from_str(&payload, (char *)value);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
     z_ring_channel_sample_new(&closure, &handler, size);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c11/z_put.c
+++ b/examples/unix/c11/z_put.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring key expression '%s'...\n", keyexpr);
     z_view_keyexpr_t vke;
-    z_view_keyexpr_from_string(&vke, keyexpr);
+    z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     if (z_put(z_loan(s), z_loan(ke), z_move(payload), NULL) < 0) {

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -41,7 +41,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     z_query_reply(query, z_query_keyexpr(query), z_move(reply_payload), NULL);
     z_drop(z_move(keystr));
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -64,8 +64,8 @@ _Bool create_attachment_iter(z_owned_bytes_t *kv_pair, void *context) {
     if (kvs->current_idx >= kvs->len) {
         return false;
     } else {
-        z_bytes_serialize_from_string(&k, kvs->data[kvs->current_idx].key);
-        z_bytes_serialize_from_string(&v, kvs->data[kvs->current_idx].value);
+        z_bytes_serialize_from_str(&k, kvs->data[kvs->current_idx].key);
+        z_bytes_serialize_from_str(&v, kvs->data[kvs->current_idx].value);
         z_bytes_serialize_from_pair(kv_pair, z_move(k), z_move(v));
         kvs->current_idx++;
         return true;
@@ -128,7 +128,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     // Reply attachment
     kv_pair_t kvs[1];
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         z_query_reply_options_default(&options);
         // Reply value encoding
         z_owned_bytes_t reply_payload;
-        z_bytes_serialize_from_string(&reply_payload, value);
+        z_bytes_serialize_from_str(&reply_payload, value);
 
         z_query_reply(q, z_query_keyexpr(q), z_move(reply_payload), &options);
         z_drop(z_move(keystr));

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
 
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, on_sample, drop_stats, (void *)context);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);

--- a/examples/unix/c99/z_get.c
+++ b/examples/unix/c99/z_get.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
     // Value encoding
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
     z_owned_closure_reply_t callback;

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_session_loan(&session), z_view_keyexpr_loan(&ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_session_loan(&session), z_view_keyexpr_loan(&pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, (void*)z_publisher_move(&pub));
     z_owned_subscriber_t sub;

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL);
     }

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
             // Create payload
             z_owned_bytes_t payload;
-            z_bytes_serialize_from_string(&payload, buf);
+            z_bytes_serialize_from_str(&payload, buf);
 
             z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL);
             ++idx;

--- a/examples/unix/c99/z_put.c
+++ b/examples/unix/c99/z_put.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring key expression '%s'...\n", keyexpr);
     z_view_keyexpr_t vke;
-    z_view_keyexpr_from_string(&vke, keyexpr);
+    z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_session_loan(&s), z_view_keyexpr_loan(&vke)) < 0) {
         printf("Unable to declare key expression!\n");
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     if (z_put(z_session_loan(&s), z_keyexpr_loan(&ke), z_bytes_move(&payload), NULL) < 0) {

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -40,7 +40,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     z_query_reply(query, z_query_keyexpr(query), z_bytes_move(&reply_payload), NULL);
     z_string_drop(z_string_move(&keystr));
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/examples/windows/z_get.c
+++ b/examples/windows/z_get.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
     // Value encoding
     z_owned_bytes_t payload;
     if (value != NULL) {
-        z_bytes_serialize_from_string(&payload, value);
+        z_bytes_serialize_from_str(&payload, value);
         opts.payload = &payload;
     }
     z_owned_closure_reply_t callback;

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t pong;
-    z_view_keyexpr_from_string_unchecked(&pong, "test/pong");
+    z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     }
 
     z_view_keyexpr_t ping;
-    z_view_keyexpr_from_string_unchecked(&ping, "test/ping");
+    z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)z_move(pub));
     z_owned_subscriber_t sub;

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     printf("Declaring publisher for '%s'...\n", keyexpr);
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
             // Create payload
             z_owned_bytes_t payload;
-            z_bytes_serialize_from_string(&payload, buf);
+            z_bytes_serialize_from_str(&payload, buf);
 
             z_publisher_put(z_loan(pub), z_move(payload), NULL);
             ++idx;

--- a/examples/windows/z_put.c
+++ b/examples/windows/z_put.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring key expression '%s'...\n", keyexpr);
     z_view_keyexpr_t vke;
-    z_view_keyexpr_from_string(&vke, keyexpr);
+    z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     printf("Putting Data ('%s': '%s')...\n", keyexpr, value);
     if (z_put(z_loan(s), z_loan(ke), z_move(payload), NULL) < 0) {

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -40,7 +40,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     z_query_reply(query, z_query_keyexpr(query), z_move(reply_payload), NULL);
 
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
     }
 
     z_view_keyexpr_t ke;
-    if (z_view_keyexpr_from_string(&ke, keyexpr) < 0) {
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
         printf("%s is not a valid key expression", keyexpr);
         return -1;
     }

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/zephyr/z_get.c
+++ b/examples/zephyr/z_get.c
@@ -83,13 +83,13 @@ int main(int argc, char **argv) {
         // Value encoding
         z_owned_bytes_t payload;
         if (strcmp(VALUE, "") != 0) {
-            z_bytes_serialize_from_string(&payload, VALUE);
+            z_bytes_serialize_from_str(&payload, VALUE);
             opts.payload = &payload;
         }
         z_owned_closure_reply_t callback;
         z_closure(&callback, reply_handler, reply_dropper);
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+        z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
         if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
             printf("Unable to send query.\n");
             exit(-1);

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring publisher for '%s'...", KEYEXPR);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_publisher_t pub;
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 
         // Create payload
         z_owned_bytes_t payload;
-        z_bytes_serialize_from_string(&payload, buf);
+        z_bytes_serialize_from_str(&payload, buf);
 
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -49,7 +49,7 @@ void query_handler(const z_loaned_query_t *query, void *ctx) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, VALUE);
+    z_bytes_serialize_from_str(&reply_payload, VALUE);
 
     z_query_reply(query, z_query_keyexpr(query), z_move(reply_payload), NULL);
     z_drop(z_move(keystr));
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     z_owned_closure_sample_t callback;
     z_closure(&callback, data_handler);
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string_unchecked(&ke, KEYEXPR);
+    z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -57,7 +57,7 @@ int8_t z_view_string_wrap(z_view_string_t *str, const char *value);
  * Return:
  *   ``0`` if creation successful, ``negative value`` otherwise.
  */
-int8_t z_view_keyexpr_from_string(z_view_keyexpr_t *keyexpr, const char *name);
+int8_t z_view_keyexpr_from_str(z_view_keyexpr_t *keyexpr, const char *name);
 
 /**
  * Builds a :c:type:`z_keyexpr_t` from a null-terminated string.
@@ -71,7 +71,7 @@ int8_t z_view_keyexpr_from_string(z_view_keyexpr_t *keyexpr, const char *name);
  * Return:
  *   ``0`` if creation successful, ``negative value`` otherwise.
  */
-int8_t z_view_keyexpr_from_string_unchecked(z_view_keyexpr_t *keyexpr, const char *name);
+int8_t z_view_keyexpr_from_str_unchecked(z_view_keyexpr_t *keyexpr, const char *name);
 
 /**
  * Gets a null-terminated string from a :c:type:`z_keyexpr_t`.
@@ -773,7 +773,7 @@ int8_t z_bytes_serialize_from_slice_copy(z_owned_bytes_t *bytes, const uint8_t *
  * Return:
  *   ``0`` if encode successful, ``negative value`` otherwise.
  */
-int8_t z_bytes_serialize_from_string(z_owned_bytes_t *bytes, const char *s);
+int8_t z_bytes_serialize_from_str(z_owned_bytes_t *bytes, const char *s);
 
 /**
  * Encodes a string into a :c:type:`z_owned_bytes_t` by copying
@@ -785,7 +785,7 @@ int8_t z_bytes_serialize_from_string(z_owned_bytes_t *bytes, const char *s);
  * Return:
  *   ``0`` if encode successful, ``negative value`` otherwise.
  */
-int8_t z_bytes_serialize_from_string_copy(z_owned_bytes_t *bytes, const char *s);
+int8_t z_bytes_serialize_from_str_copy(z_owned_bytes_t *bytes, const char *s);
 
 /**
  * Constructs payload from an iterator to `z_owned_bytes_t`.

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -59,12 +59,12 @@ size_t z_string_array_len(const z_loaned_string_array_t *a) { return _z_string_v
 
 _Bool z_string_array_is_empty(const z_loaned_string_array_t *a) { return _z_string_vec_is_empty(a); }
 
-int8_t z_view_keyexpr_from_string(z_view_keyexpr_t *keyexpr, const char *name) {
+int8_t z_view_keyexpr_from_str(z_view_keyexpr_t *keyexpr, const char *name) {
     keyexpr->_val = _z_rname(name);
     return _Z_RES_OK;
 }
 
-int8_t z_view_keyexpr_from_string_unchecked(z_view_keyexpr_t *keyexpr, const char *name) {
+int8_t z_view_keyexpr_from_str_unchecked(z_view_keyexpr_t *keyexpr, const char *name) {
     keyexpr->_val = _z_rname(name);
     return _Z_RES_OK;
 }
@@ -303,7 +303,7 @@ static uint16_t _z_encoding_values_str_to_int(const char *schema, size_t len) {
     return UINT16_MAX;
 }
 
-static int8_t _z_encoding_convert_from_string(z_owned_encoding_t *encoding, const char *s) {
+static int8_t _z_encoding_convert_from_str(z_owned_encoding_t *encoding, const char *s) {
     const char *id_end = strchr(s, ENCODING_SCHEMA_SEPARATOR);
     // Check id_end value + corner cases
     if ((id_end != NULL) && (id_end != s)) {
@@ -353,7 +353,7 @@ static int8_t _z_encoding_convert_into_string(const z_loaned_encoding_t *encodin
 }
 
 #else
-static int8_t _z_encoding_convert_from_string(z_owned_encoding_t *encoding, const char *s) {
+static int8_t _z_encoding_convert_from_str(z_owned_encoding_t *encoding, const char *s) {
     return _z_encoding_make(encoding->_val, _Z_ENCODING_ID_DEFAULT, s);
 }
 
@@ -402,7 +402,7 @@ int8_t z_encoding_from_str(z_owned_encoding_t *encoding, const char *s) {
     }
     // Convert string to encoding
     if (s != NULL) {
-        return _z_encoding_convert_from_string(encoding, s);
+        return _z_encoding_convert_from_str(encoding, s);
     }
     return _Z_RES_OK;
 }
@@ -583,13 +583,13 @@ int8_t z_bytes_serialize_from_slice_copy(z_owned_bytes_t *bytes, const uint8_t *
     return _Z_RES_OK;
 }
 
-int8_t z_bytes_serialize_from_string(z_owned_bytes_t *bytes, const char *s) {
+int8_t z_bytes_serialize_from_str(z_owned_bytes_t *bytes, const char *s) {
     // Encode string without null terminator
     size_t len = strlen(s);
     return z_bytes_serialize_from_slice(bytes, (uint8_t *)s, len);
 }
 
-int8_t z_bytes_serialize_from_string_copy(z_owned_bytes_t *bytes, const char *s) {
+int8_t z_bytes_serialize_from_str_copy(z_owned_bytes_t *bytes, const char *s) {
     // Encode string without null terminator
     size_t len = strlen(s);
     return z_bytes_serialize_from_slice_copy(bytes, (uint8_t *)s, len);

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -83,7 +83,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, value);
+    z_bytes_serialize_from_str(&reply_payload, value);
 
     z_query_reply(query, query_ke, z_move(reply_payload), &_ret_qreply_opt);
 
@@ -137,9 +137,9 @@ int main(int argc, char **argv) {
 #endif
 
     z_view_keyexpr_t key_demo_example, key_demo_example_a, key_demo_example_starstar;
-    z_view_keyexpr_from_string(&key_demo_example, "demo/example");
-    z_view_keyexpr_from_string(&key_demo_example_a, "demo/example/a");
-    z_view_keyexpr_from_string(&key_demo_example_starstar, "demo/example/**");
+    z_view_keyexpr_from_str(&key_demo_example, "demo/example");
+    z_view_keyexpr_from_str(&key_demo_example_a, "demo/example/a");
+    z_view_keyexpr_from_str(&key_demo_example_starstar, "demo/example/**");
 
     _Bool _ret_bool = z_keyexpr_includes(z_loan(key_demo_example_starstar), z_loan(key_demo_example_a));
     assert(_ret_bool);
@@ -296,7 +296,7 @@ int main(int argc, char **argv) {
     z_subscriber_options_default(&_ret_sub_opt);
 
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr_str);
+    z_view_keyexpr_from_str(&ke, keyexpr_str);
     z_owned_subscriber_t _ret_sub;
     _ret_int8 = z_declare_subscriber(&_ret_sub, z_loan(s2), z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
     assert(_ret_int8 == _Z_RES_OK);
@@ -307,7 +307,7 @@ int main(int argc, char **argv) {
     char s1_res[64];
     sprintf(s1_res, "%s/chunk/%d", keyexpr_str, 1);
     z_view_keyexpr_t s1_key;
-    z_view_keyexpr_from_string(&s1_key, s1_res);
+    z_view_keyexpr_from_str(&s1_key, s1_res);
     z_owned_keyexpr_t _ret_expr;
     z_declare_keyexpr(&_ret_expr, z_loan(s1), z_loan(s1_key));
     assert(z_check(_ret_expr));
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
 
     // Create payload
     z_owned_bytes_t payload;
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     _ret_int8 = z_put(z_loan(s1), z_loan(_ret_expr), z_move(payload), &_ret_put_opt);
     assert_eq(_ret_int8, 0);
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
 
     printf("Publisher Put...");
     // Create payload
-    z_bytes_serialize_from_string(&payload, value);
+    z_bytes_serialize_from_str(&payload, value);
 
     z_publisher_put_options_t _ret_pput_opt;
     z_publisher_put_options_default(&_ret_pput_opt);

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -63,7 +63,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 
     // Reply value encoding
     z_owned_bytes_t reply_payload;
-    z_bytes_serialize_from_string(&reply_payload, res);
+    z_bytes_serialize_from_str(&reply_payload, res);
 
     z_query_reply(query, z_query_keyexpr(query), z_move(reply_payload), NULL);
     queries++;
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
     for (unsigned int i = 0; i < SET; i++) {
         snprintf(s1_res, 64, "%s%u", uri, i);
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string(&ke, s1_res);
+        z_view_keyexpr_from_str(&ke, s1_res);
         z_owned_keyexpr_t expr;
         z_declare_keyexpr(&expr, z_loan(s1), z_loan(ke));
         printf("Declared resource on session 1: %u %s\n", z_loan(expr)->_id, z_loan(expr)->_suffix);
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     for (unsigned int i = 0; i < SET; i++) {
         snprintf(s1_res, 64, "%s%u", uri, i);
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string(&ke, s1_res);
+        z_view_keyexpr_from_str(&ke, s1_res);
         z_owned_keyexpr_t expr;
         z_declare_keyexpr(&expr, z_loan(s2), z_loan(ke));
         printf("Declared resource on session 2: %u %s\n", z_loan(expr)->_id, z_loan(expr)->_suffix);
@@ -210,7 +210,7 @@ int main(int argc, char **argv) {
         z_closure(&callback, query_handler, NULL, &idx[i]);
         z_owned_queryable_t *qle = (z_owned_queryable_t *)z_malloc(sizeof(z_owned_queryable_t));
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string(&ke, s1_res);
+        z_view_keyexpr_from_str(&ke, s1_res);
         assert(z_declare_queryable(qle, z_loan(s2), z_loan(ke), &callback, NULL) == _Z_RES_OK);
         printf("Declared queryable on session 2: %ju %zu %s\n", (uintmax_t)qle->_val->_entity_id, (z_zint_t)0, s1_res);
         qles2 = _z_list_push(qles2, qle);
@@ -312,7 +312,7 @@ int main(int argc, char **argv) {
             z_owned_closure_reply_t callback;
             z_closure(&callback, reply_handler, NULL, &idx[i]);
             z_view_keyexpr_t ke;
-            z_view_keyexpr_from_string(&ke, s1_res);
+            z_view_keyexpr_from_str(&ke, s1_res);
             z_get(z_loan(s1), z_loan(ke), "", &callback, NULL);
             printf("Queried data from session 1: %zu %s\n", (z_zint_t)0, s1_res);
         }

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
         z_closure(&callback, data_handler, NULL, &idx[i]);
         z_owned_subscriber_t *sub = (z_owned_subscriber_t *)z_malloc(sizeof(z_owned_subscriber_t));
         z_view_keyexpr_t ke;
-        z_view_keyexpr_from_string(&ke, s1_res);
+        z_view_keyexpr_from_str(&ke, s1_res);
         int8_t res = z_declare_subscriber(sub, z_loan(s2), z_loan(ke), &callback, NULL);
         assert(res == _Z_RES_OK);
         printf("Declared subscription on session 2: %ju %zu %s\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id,
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
             z_put_options_default(&opt);
             opt.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
             z_view_keyexpr_t ke;
-            z_view_keyexpr_from_string(&ke, s1_res);
+            z_view_keyexpr_from_str(&ke, s1_res);
 
             // Create payload
             z_owned_bytes_t payload;

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, on_sample, NULL, (void *)&test_stats);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     // Declare publisher
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, data_handler);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/tests/z_test_fragment_tx.c
+++ b/tests/z_test_fragment_tx.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     }
     // Put data
     z_view_keyexpr_t ke;
-    z_view_keyexpr_from_string(&ke, keyexpr);
+    z_view_keyexpr_from_str(&ke, keyexpr);
     for (int i = 0; i < 5; i++) {
         // Create payload
         z_owned_bytes_t payload;


### PR DESCRIPTION
These renamings were performed:
 - `z_view_keyexpr_from_string` -> `z_view_keyexpr_from_str`
 - `z_view_keyexpr_from_string_unchecked` -> `z_view_keyexpr_from_str_unchecked`
 - `z_bytes_serialize_from_string` -> `z_bytes_serialize_from_str`
 - `z_bytes_serialize_from_string_copy` -> `z_bytes_serialize_from_str_copy`
 - `_z_encoding_convert_from_string` -> `_z_encoding_convert_from_str`

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/469