### PR TITLE
Store value instead of pointer in owned z_string, z_slice, z_bytes, z_string_array and z_bytes_writer.

### DIFF
--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -816,10 +816,8 @@ int8_t z_bytes_serialize_from_pair(z_owned_bytes_t *bytes, z_owned_bytes_t *firs
 /**
  * Parameters:
  *   bytes: Pointer to an unitialized :c:type:`z_lowned_bytes_t` instance.
- * Return:
- *   ``0`` if decode successful, or a ``negative value`` otherwise.
  */
-int8_t z_bytes_empty(z_owned_bytes_t *bytes);
+void z_bytes_empty(z_owned_bytes_t *bytes);
 
 /**
  * Returns total number of bytes in the container.
@@ -922,10 +920,8 @@ int64_t z_bytes_reader_tell(z_bytes_reader_t *reader);
  *   bytes: Data container to write to.
  *   writer: Uninitialized memory location where writer is to be constructed.
  *
- * Return:
- *   ``0`` if encode successful, ``negative value`` otherwise.
  */
-int8_t z_bytes_get_writer(z_loaned_bytes_t *bytes, z_owned_bytes_writer_t *writer);
+void z_bytes_get_writer(z_loaned_bytes_t *bytes, z_owned_bytes_writer_t *writer);
 
 /**
  * Writes `len` bytes from `src` into underlying :c:type:`z_loaned_bytes_t.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -63,22 +63,19 @@ typedef _z_timestamp_t z_timestamp_t;
  *   size_t len: The length of the bytes array.
  *   uint8_t *start: A pointer to the bytes array.
  */
-_Z_OWNED_TYPE_PTR(_z_slice_t, slice)
+_Z_OWNED_TYPE_VALUE(_z_slice_t, slice)
 _Z_LOANED_TYPE(_z_slice_t, slice)
 
 /**
  * Represents a container for slices.
- *
- * Members:
- *   _z_slice_t slice: content of the container.
  */
-_Z_OWNED_TYPE_PTR(_z_bytes_t, bytes)
+_Z_OWNED_TYPE_VALUE(_z_bytes_t, bytes)
 _Z_LOANED_TYPE(_z_bytes_t, bytes)
 
 /**
  * Represents a writer for serialized data.
  */
-_Z_OWNED_TYPE_PTR(_z_bytes_writer_t, bytes_writer)
+_Z_OWNED_TYPE_VALUE(_z_bytes_writer_t, bytes_writer)
 _Z_LOANED_TYPE(_z_bytes_writer_t, bytes_writer)
 
 /**
@@ -98,7 +95,7 @@ typedef _z_bytes_reader_t z_bytes_reader_t;
  *   size_t len: The length of the string.
  *   const char *val: A pointer to the string.
  */
-_Z_OWNED_TYPE_PTR(_z_string_t, string)
+_Z_OWNED_TYPE_VALUE(_z_string_t, string)
 _Z_LOANED_TYPE(_z_string_t, string)
 _Z_VIEW_TYPE(_z_string_t, string)
 
@@ -448,9 +445,9 @@ _Z_LOANED_TYPE(_z_reply_rc_t, reply)
  *   - :c:func:`z_string_array_len`
  *   - :c:func:`z_str_array_array_is_empty`
  */
-_Z_OWNED_TYPE_PTR(_z_string_vec_t, string_array)
-_Z_LOANED_TYPE(_z_string_vec_t, string_array)
-_Z_VIEW_TYPE(_z_string_vec_t, string_array)
+_Z_OWNED_TYPE_VALUE(_z_string_svec_t, string_array)
+_Z_LOANED_TYPE(_z_string_svec_t, string_array)
+_Z_VIEW_TYPE(_z_string_svec_t, string_array)
 
 const z_loaned_string_t *z_string_array_get(const z_loaned_string_array_t *a, size_t k);
 size_t z_string_array_len(const z_loaned_string_array_t *a);

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -35,7 +35,7 @@ typedef struct {
 } _z_slice_t;
 
 _z_slice_t _z_slice_empty(void);
-inline static _Bool _z_slice_check(_z_slice_t value) { return value.start != NULL; }
+inline static _Bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
 int8_t _z_slice_init(_z_slice_t *bs, size_t capacity);
 _z_slice_t _z_slice_make(size_t capacity);
 _z_slice_t _z_slice_wrap(const uint8_t *bs, size_t len);

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -70,13 +70,13 @@ typedef struct {
 } _z_string_t;
 
 _z_string_t _z_string_null(void);
-_Bool _z_string_check(_z_string_t value);
+_Bool _z_string_check(const _z_string_t *value);
 _z_string_t _z_string_make(const char *value);
 _z_string_t _z_string_wrap(char *value);
 _z_string_t *_z_string_make_as_ptr(const char *value);
 
 size_t _z_string_size(const _z_string_t *s);
-void _z_string_copy(_z_string_t *dst, const _z_string_t *src);
+int8_t _z_string_copy(_z_string_t *dst, const _z_string_t *src);
 void _z_string_move(_z_string_t *dst, _z_string_t *src);
 void _z_string_move_str(_z_string_t *dst, char *src);
 void _z_string_clear(_z_string_t *s);
@@ -88,7 +88,8 @@ _z_string_t _z_string_preallocate(const size_t len);
 
 _Z_ELEM_DEFINE(_z_string, _z_string_t, _z_string_size, _z_string_clear, _z_string_copy)
 
-_Z_VEC_DEFINE(_z_string, _z_string_t)
+static inline void _z_string_elem_move(void *dst, void *src) { _z_string_move((_z_string_t *)dst, (_z_string_t *)src); }
+_Z_SVEC_DEFINE(_z_string, _z_string_t)
 _Z_LIST_DEFINE(_z_string, _z_string_t)
 _Z_INT_MAP_DEFINE(_z_string, _z_string_t)
 

--- a/include/zenoh-pico/collections/vec.h
+++ b/include/zenoh-pico/collections/vec.h
@@ -21,7 +21,7 @@
 
 /*-------- Dynamically allocated vector --------*/
 /**
- * A dynamically allocate vector.
+ * A dynamically allocated vector. Elements are stored as pointers.
  */
 typedef struct {
     size_t _capacity;
@@ -66,7 +66,7 @@ void _z_vec_release(_z_vec_t *v);
 
 /*-------- Dynamically allocated sized vector --------*/
 /**
- * A dynamically allocate vector.
+ * A dynamically allocated vector. Elements are stored by value.
  */
 typedef struct {
     size_t _capacity;

--- a/include/zenoh-pico/link/endpoint.h
+++ b/include/zenoh-pico/link/endpoint.h
@@ -49,7 +49,7 @@ typedef struct {
 _Bool _z_locator_eq(const _z_locator_t *left, const _z_locator_t *right);
 
 void _z_locator_init(_z_locator_t *locator);
-_z_string_t *_z_locator_to_string(const _z_locator_t *loc);
+_z_string_t _z_locator_to_string(const _z_locator_t *loc);
 int8_t _z_locator_from_str(_z_locator_t *lc, const char *s);
 
 size_t _z_locator_size(_z_locator_t *lc);

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -181,7 +181,7 @@ void _z_value_free(_z_value_t **hello);
  */
 typedef struct {
     _z_id_t zid;
-    _z_string_vec_t locators;
+    _z_string_svec_t locators;
     z_whatami_t whatami;
     uint8_t version;
 } _z_hello_t;

--- a/src/collections/bytes.c
+++ b/src/collections/bytes.c
@@ -118,7 +118,7 @@ int8_t _z_bytes_to_slice(const _z_bytes_t *bytes, _z_slice_t *s) {
     // Allocate slice
     size_t len = _z_bytes_len(bytes);
     *s = _z_slice_make(len);
-    if (!_z_slice_check(*s) && len > 0) {
+    if (!_z_slice_check(s) && len > 0) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }
     uint8_t *start = (uint8_t *)s->start;

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -23,12 +23,16 @@ _z_string_t _z_string_null(void) {
     return s;
 }
 
-_Bool _z_string_check(_z_string_t value) { return value.val != NULL; }
+_Bool _z_string_check(const _z_string_t *value) { return value->val != NULL; }
 
 _z_string_t _z_string_make(const char *value) {
     _z_string_t s;
     s.val = _z_str_clone(value);
-    s.len = strlen(value);
+    if (s.val == NULL) {
+        s.len = 0;
+    } else {
+        s.len = strlen(value);
+    }
     return s;
 }
 
@@ -48,13 +52,18 @@ _z_string_t *_z_string_make_as_ptr(const char *value) {
 
 size_t _z_string_size(const _z_string_t *s) { return s->len; }
 
-void _z_string_copy(_z_string_t *dst, const _z_string_t *src) {
+int8_t _z_string_copy(_z_string_t *dst, const _z_string_t *src) {
     if (src->val != NULL) {
         dst->val = _z_str_clone(src->val);
+        if (dst->val == NULL) {
+            dst->len = 0;
+            return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+        }
     } else {
         dst->val = NULL;
     }
     dst->len = src->len;
+    return _Z_RES_OK;
 }
 
 void _z_string_move(_z_string_t *dst, _z_string_t *src) {

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -252,16 +252,17 @@ void __z_locator_onto_str(char *dst, size_t dst_len, const _z_locator_t *loc) {
  *   loc: :c:type:`_z_locator_t` to be converted into its _z_string format.
  *
  * Returns:
- *   The pointer to the z_stringified :c:type:`_z_locator_t`.
+ *   The z_stringified :c:type:`_z_locator_t`.
  */
-_z_string_t *_z_locator_to_string(const _z_locator_t *loc) {
-    _z_string_t *s = (_z_string_t *)z_malloc(sizeof(_z_string_t));
-    s->len = _z_locator_strlen(loc) + (size_t)1;
-    s->val = (char *)z_malloc(s->len);
-    if (s->val == NULL) {
-        return NULL;
+_z_string_t _z_locator_to_string(const _z_locator_t *loc) {
+    _z_string_t s;
+    s.len = _z_locator_strlen(loc);
+    s.val = (char *)z_malloc(s.len + 1);
+    if (s.val == NULL) {
+        s.len = 0;
+        return s;
     }
-    __z_locator_onto_str(s->val, s->len, loc);
+    __z_locator_onto_str(s.val, s.len + 1, loc);
     return s;
 }
 
@@ -420,11 +421,11 @@ int8_t _z_endpoint_from_str(_z_endpoint_t *ep, const char *str) {
 char *_z_endpoint_to_str(const _z_endpoint_t *endpoint) {
     char *ret = NULL;
     // Retrieve locator
-    _z_string_t *locator = _z_locator_to_string(&endpoint->_locator);
-    if (locator == NULL) {
+    _z_string_t locator = _z_locator_to_string(&endpoint->_locator);
+    if (locator.val == NULL) {
         return NULL;
     }
-    size_t curr_len = locator->len;
+    size_t curr_len = locator.len;
     // Retrieve config
     char *config = _z_endpoint_config_to_str(&endpoint->_config, endpoint->_locator._protocol);
     if (config != NULL) {
@@ -439,8 +440,8 @@ char *_z_endpoint_to_str(const _z_endpoint_t *endpoint) {
     curr_len -= (size_t)1;
     // Copy locator
     if (curr_len > (size_t)0) {
-        (void)strncat(ret, locator->val, curr_len);
-        curr_len -= locator->len;
+        (void)strncat(ret, locator.val, curr_len);
+        curr_len -= locator.len;
     }
     // Copy config
     if (config != NULL) {
@@ -450,6 +451,6 @@ char *_z_endpoint_to_str(const _z_endpoint_t *endpoint) {
         }
     }
     // Clean up
-    _z_string_free(&locator);
+    _z_string_clear(&locator);
     return ret;
 }

--- a/src/net/encoding.c
+++ b/src/net/encoding.c
@@ -42,7 +42,7 @@ _z_encoding_t _z_encoding_null(void) { return _z_encoding_wrap(_Z_ENCODING_ID_DE
 void _z_encoding_clear(_z_encoding_t *encoding) { _z_string_clear(&encoding->schema); }
 
 _Bool _z_encoding_check(const _z_encoding_t *encoding) {
-    return ((encoding->id != _Z_ENCODING_ID_DEFAULT) || _z_string_check(encoding->schema));
+    return ((encoding->id != _Z_ENCODING_ID_DEFAULT) || _z_string_check(&encoding->schema));
 }
 
 void _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src) {

--- a/src/net/memory.c
+++ b/src/net/memory.c
@@ -17,8 +17,8 @@
 #include "zenoh-pico/protocol/core.h"
 
 void _z_hello_clear(_z_hello_t *hello) {
-    if (!_z_string_vec_is_empty(&hello->locators)) {
-        _z_string_vec_clear(&hello->locators);
+    if (!_z_string_svec_is_empty(&hello->locators)) {
+        _z_string_svec_clear(&hello->locators);
     }
 }
 

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -65,7 +65,7 @@ int8_t _z_open(_z_session_t *zn, _z_config_t *config) {
     }
 
     if (config != NULL) {
-        _z_string_vec_t locators = _z_string_vec_make(0);
+        _z_string_svec_t locators = _z_string_svec_make(0);
         char *connect = _z_config_get(config, Z_CONFIG_CONNECT_KEY);
         char *listen = _z_config_get(config, Z_CONFIG_LISTEN_KEY);
         if (connect == NULL && listen == NULL) {  // Scout if peer is not configured
@@ -91,7 +91,7 @@ int8_t _z_open(_z_session_t *zn, _z_config_t *config) {
             _z_hello_list_t *hellos = _z_scout_inner(what, zid, mcast_locator, timeout, true);
             if (hellos != NULL) {
                 _z_hello_t *hello = _z_hello_list_head(hellos);
-                _z_string_vec_copy(&locators, &hello->locators);
+                _z_string_svec_copy(&locators, &hello->locators);
             }
             _z_hello_list_free(&hellos);
         } else {
@@ -104,16 +104,17 @@ int8_t _z_open(_z_session_t *zn, _z_config_t *config) {
                     return _Z_ERR_GENERIC;
                 }
             }
-            locators = _z_string_vec_make(1);
-            _z_string_vec_append(&locators, _z_string_make_as_ptr(_z_config_get(config, key)));
+            locators = _z_string_svec_make(1);
+            _z_string_t s = _z_string_make(_z_config_get(config, key));
+            _z_string_svec_append(&locators, &s);
         }
 
         ret = _Z_ERR_SCOUT_NO_RESULTS;
-        size_t len = _z_string_vec_len(&locators);
+        size_t len = _z_string_svec_len(&locators);
         for (size_t i = 0; i < len; i++) {
             ret = _Z_RES_OK;
 
-            _z_string_t *locator = _z_string_vec_get(&locators, i);
+            _z_string_t *locator = _z_string_svec_get(&locators, i);
             // @TODO: check invalid configurations
             // For example, client mode in multicast links
 
@@ -139,7 +140,7 @@ int8_t _z_open(_z_session_t *zn, _z_config_t *config) {
                 _Z_ERROR("Trying to configure an invalid mode.");
             }
         }
-        _z_string_vec_clear(&locators);
+        _z_string_svec_clear(&locators);
     } else {
         _Z_ERROR("A valid config is missing.");
         ret = _Z_ERR_GENERIC;

--- a/src/protocol/codec.c
+++ b/src/protocol/codec.c
@@ -371,14 +371,14 @@ int8_t _z_string_decode(_z_string_t *str, _z_zbuf_t *zbf) {
 
 size_t _z_encoding_len(const _z_encoding_t *en) {
     size_t en_len = _z_zint_len((uint32_t)(en->id) << 1);
-    if (_z_string_check(en->schema)) {
+    if (_z_string_check(&en->schema)) {
         en_len += _z_zint_len(en->schema.len) + en->schema.len;
     }
     return en_len;
 }
 
 int8_t _z_encoding_encode(_z_wbuf_t *wbf, const _z_encoding_t *en) {
-    _Bool has_schema = _z_string_check(en->schema);
+    _Bool has_schema = _z_string_check(&en->schema);
     uint32_t id = (uint32_t)(en->id) << 1;
     if (has_schema) {
         id |= _Z_ENCODING_FLAG_S;

--- a/src/protocol/codec/message.c
+++ b/src/protocol/codec/message.c
@@ -150,9 +150,9 @@ int8_t _z_locators_encode(_z_wbuf_t *wbf, const _z_locator_array_t *la) {
     _Z_DEBUG("Encoding _LOCATORS");
     _Z_RETURN_IF_ERR(_z_zsize_encode(wbf, la->_len))
     for (size_t i = 0; i < la->_len; i++) {
-        _z_string_t *s = _z_locator_to_string(&la->_val[i]);
-        _Z_RETURN_IF_ERR(_z_string_encode(wbf, s))
-        _z_string_free(&s);
+        _z_string_t s = _z_locator_to_string(&la->_val[i]);
+        _Z_RETURN_IF_ERR(_z_string_encode(wbf, &s))
+        _z_string_clear(&s);
     }
 
     return ret;

--- a/src/protocol/codec/message.c
+++ b/src/protocol/codec/message.c
@@ -393,7 +393,7 @@ int8_t _z_query_encode(_z_wbuf_t *wbf, const _z_msg_query_t *msg) {
     int8_t ret = _Z_RES_OK;
     uint8_t header = _Z_MID_Z_QUERY;
 
-    _Bool has_params = _z_slice_check(msg->_parameters);
+    _Bool has_params = _z_slice_check(&msg->_parameters);
     if (has_params) {
         _Z_SET_FLAG(header, _Z_FLAG_Z_Q_P);
     }

--- a/src/protocol/codec/transport.c
+++ b/src/protocol/codec/transport.c
@@ -382,7 +382,7 @@ int8_t _z_fragment_encode(_z_wbuf_t *wbf, uint8_t header, const _z_t_msg_fragmen
     if (_Z_HAS_FLAG(header, _Z_FLAG_T_Z)) {
         ret = _Z_ERR_MESSAGE_SERIALIZATION_FAILED;
     }
-    if (ret == _Z_RES_OK && _z_slice_check(msg->_payload)) {
+    if (ret == _Z_RES_OK && _z_slice_check(&msg->_payload)) {
         _Z_RETURN_IF_ERR(_z_wbuf_write_bytes(wbf, msg->_payload.start, 0, msg->_payload.len));
     }
 

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -85,10 +85,10 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
                                 size_t n_loc = _z_locator_array_len(&s_msg._body._hello._locators);
                                 if (n_loc > 0) {
                                     hello->locators = _z_string_svec_make(n_loc);
+
                                     for (size_t i = 0; i < n_loc; i++) {
-                                        _z_string_svec_append(
-                                            &hello->locators,
-                                            _z_locator_to_string(&s_msg._body._hello._locators._val[i]));
+                                        _z_string_t s = _z_locator_to_string(&s_msg._body._hello._locators._val[i]);
+                                        _z_string_svec_append(&hello->locators, &s);
                                     }
                                 } else {
                                     // @TODO: construct the locator departing from the sock address

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -84,15 +84,15 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
 
                                 size_t n_loc = _z_locator_array_len(&s_msg._body._hello._locators);
                                 if (n_loc > 0) {
-                                    hello->locators = _z_string_vec_make(n_loc);
+                                    hello->locators = _z_string_svec_make(n_loc);
                                     for (size_t i = 0; i < n_loc; i++) {
-                                        _z_string_vec_append(
+                                        _z_string_svec_append(
                                             &hello->locators,
                                             _z_locator_to_string(&s_msg._body._hello._locators._val[i]));
                                     }
                                 } else {
                                     // @TODO: construct the locator departing from the sock address
-                                    _z_string_vec_clear(&hello->locators);
+                                    _z_string_svec_clear(&hello->locators);
                                 }
 
                                 ret = _z_hello_list_push(ret, hello);

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -224,10 +224,11 @@ char *gen_str(size_t size) {
     return str;
 }
 
-_z_string_vec_t gen_str_array(size_t size) {
-    _z_string_vec_t sa = _z_string_vec_make(size);
+_z_string_svec_t gen_str_array(size_t size) {
+    _z_string_svec_t sa = _z_string_svec_make(size);
     for (size_t i = 0; i < size; i++) {
-        _z_string_vec_append(&sa, _z_string_make_as_ptr(gen_str(16)));
+        _z_string_t s = _z_string_make(gen_str(16));
+        _z_string_svec_append(&sa, &s);
     }
 
     return sa;
@@ -310,15 +311,15 @@ void assert_eq_uint8_array(const _z_slice_t *left, const _z_slice_t *right) {
     printf(")");
 }
 
-void assert_eq_str_array(_z_string_vec_t *left, _z_string_vec_t *right) {
+void assert_eq_str_array(_z_string_svec_t *left, _z_string_svec_t *right) {
     printf("Array -> ");
     printf("Length (%zu:%zu), ", left->_len, right->_len);
 
     assert(left->_len == right->_len);
     printf("Content (");
     for (size_t i = 0; i < left->_len; i++) {
-        const char *l = left->_val[i];
-        const char *r = right->_val[i];
+        const char *l = _z_string_svec_get(left, i)->val;
+        const char *r = _z_string_svec_get(right, i)->val;
 
         printf("%s:%s", l, r);
         if (i < left->_len - 1) printf(" ");

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -339,14 +339,14 @@ void assert_eq_locator_array(const _z_locator_array_t *left, const _z_locator_ar
         const _z_locator_t *l = &left->_val[i];
         const _z_locator_t *r = &right->_val[i];
 
-        _z_string_t *ls = _z_locator_to_string(l);
-        _z_string_t *rs = _z_locator_to_string(r);
+        _z_string_t ls = _z_locator_to_string(l);
+        _z_string_t rs = _z_locator_to_string(r);
 
-        printf("%s:%s", ls->val, rs->val);
+        printf("%s:%s", ls.val, rs.val);
         if (i < left->_len - 1) printf(" ");
 
-        _z_string_free(&ls);
-        _z_string_free(&rs);
+        _z_string_clear(&ls);
+        _z_string_clear(&rs);
 
         assert(_z_locator_eq(l, r) == true);
     }

--- a/zenohpico.pc
+++ b/zenohpico.pc
@@ -3,6 +3,6 @@ prefix=/usr/local
 Name: zenohpico
 Description: 
 URL: 
-Version: 0.11.20240627dev
+Version: 1.0.20240628dev
 Cflags: -I${prefix}/include
 Libs: -L${prefix}/lib -lzenohpico


### PR DESCRIPTION
Store value instead of pointer in owned z_string, z_slice, z_bytes, z_string_array and z_bytes_writer;
z_string_array uses svec instead of vec to reduce number of malloc calls;

Partially resolves #475.