### PR TITLE
Remove legacy closures

### DIFF
--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -104,7 +104,6 @@
                   z_owned_slice_t  *: z_slice_drop,                                 \
                   z_owned_bytes_t  *: z_bytes_drop,                                 \
                   z_owned_closure_sample_t * : z_closure_sample_drop,               \
-                  z_owned_closure_owned_sample_t * : z_closure_owned_sample_drop,   \
                   z_owned_closure_query_t * : z_closure_query_drop,                 \
                   z_owned_closure_reply_t * : z_closure_reply_drop,                 \
                   z_owned_closure_hello_t * : z_closure_hello_drop,                 \
@@ -160,10 +159,7 @@
                   z_owned_closure_query_t : z_closure_query_call,                   \
                   z_owned_closure_reply_t : z_closure_reply_call,                   \
                   z_owned_closure_hello_t : z_closure_hello_call,                   \
-                  z_owned_closure_zid_t : z_closure_zid_call,                       \
-                  z_owned_closure_owned_sample_t : z_closure_owned_sample_call,     \
-                  z_owned_closure_owned_query_t : z_closure_owned_query_call,       \
-                  z_owned_closure_owned_reply_t : z_closure_owned_reply_call        \
+                  z_owned_closure_zid_t : z_closure_zid_call                        \
             ) (&x, __VA_ARGS__)
 
 #define z_try_recv(x, ...) \
@@ -208,9 +204,7 @@
                   z_owned_string_t : z_string_move,                               \
                   z_owned_string_array_t : z_string_array_move,                   \
                   z_owned_closure_sample_t : z_closure_sample_move,               \
-                  z_owned_closure_owned_sample_t : z_closure_owned_sample_move,   \
                   z_owned_closure_query_t : z_closure_query_move,                 \
-                  z_owned_closure_owned_query_t : z_closure_owned_query_move,     \
                   z_owned_closure_reply_t : z_closure_reply_move,                 \
                   z_owned_closure_hello_t : z_closure_hello_move,                 \
                   z_owned_closure_zid_t  : z_closure_zid_move,                    \
@@ -276,9 +270,7 @@
                   z_owned_slice_t  *: z_slice_null,                                 \
                   z_owned_bytes_t  *: z_bytes_null,                                 \
                   z_owned_closure_sample_t * : z_closure_sample_null,               \
-                  z_owned_closure_owned_sample_t * : z_closure_owned_sample_null,   \
                   z_owned_closure_query_t * : z_closure_query_null,                 \
-                  z_owned_closure_owned_query_t * : z_closure_owned_query_null,     \
                   z_owned_closure_reply_t * : z_closure_reply_null,                 \
                   z_owned_closure_hello_t * : z_closure_hello_null,                 \
                   z_owned_closure_zid_t * : z_closure_zid_null,                     \
@@ -432,8 +424,6 @@ inline void z_call(const z_owned_closure_query_t &closure, const z_loaned_query_
     { z_closure_query_call(&closure, query); }
 inline void z_call(const z_owned_closure_reply_t &closure, const z_loaned_reply_t *reply)
     { z_closure_reply_call(&closure, reply); }
-inline void z_call(const z_owned_closure_owned_reply_t &closure, z_owned_reply_t *reply)
-    { z_closure_owned_reply_call(&closure, reply); }
 inline void z_call(const z_owned_closure_hello_t &closure, const z_loaned_hello_t *hello)
     { z_closure_hello_call(&closure, hello); }
 inline void z_call(const z_owned_closure_zid_t &closure, const z_id_t *zid)
@@ -442,15 +432,6 @@ inline void z_call(const z_owned_closure_zid_t &closure, const z_id_t *zid)
 inline void z_closure(
     z_owned_closure_hello_t* closure,
     void (*call)(const z_loaned_hello_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
-    closure->context = context;
-    closure->drop = drop;
-    closure->call = call;
-};
-inline void z_closure(
-    z_owned_closure_owned_query_t* closure,
-    void (*call)(z_owned_query_t*, void*),
     void (*drop)(void*) = NULL,
     void *context = NULL) {
     closure->context = context;
@@ -537,9 +518,6 @@ inline bool z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t
 
 inline z_owned_bytes_t* z_move(z_owned_bytes_t& x) { return z_bytes_move(&x); };
 inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return z_closure_hello_move(&closure); };
-inline z_owned_closure_owned_query_t* z_move(z_owned_closure_owned_query_t& closure) {
-    return z_closure_owned_query_move(&closure);
-};
 inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return z_closure_query_move(&closure); };
 inline z_owned_closure_reply_t* z_move(z_owned_closure_reply_t& closure) { return z_closure_reply_move(&closure); };
 inline z_owned_closure_sample_t* z_move(z_owned_closure_sample_t& closure) { return z_closure_sample_move(&closure); };
@@ -579,14 +557,6 @@ struct z_loaned_to_owned_type_t<z_loaned_closure_hello_t> {
 template <>
 struct z_owned_to_loaned_type_t<z_owned_closure_hello_t> {
     typedef z_loaned_closure_hello_t type;
-};
-template <>
-struct z_loaned_to_owned_type_t<z_loaned_closure_owned_query_t> {
-    typedef z_owned_closure_owned_query_t type;
-};
-template <>
-struct z_owned_to_loaned_type_t<z_owned_closure_owned_query_t> {
-    typedef z_loaned_closure_owned_query_t type;
 };
 template <>
 struct z_loaned_to_owned_type_t<z_loaned_closure_query_t> {

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1079,21 +1079,6 @@ int8_t z_closure_sample(z_owned_closure_sample_t *closure, z_data_handler_t call
                         void *context);
 
 /**
- * Builds a new sample closure.
- * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Parameters:
- *   call: Pointer to the callback function. ``context`` will be passed as its last argument.
- *   drop: Pointer to the function that will free the callback state. ``context`` will be passed as its last argument.
- *   context: Pointer to an arbitrary state.
- *
- * Return:
- *   The sample closure.
- */
-int8_t z_closure_owned_sample(z_owned_closure_owned_sample_t *closure, z_owned_sample_handler_t call,
-                              z_dropper_handler_t drop, void *context);
-
-/**
  * Builds a new query closure.
  * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
@@ -1109,21 +1094,6 @@ int8_t z_closure_query(z_owned_closure_query_t *closure, z_queryable_handler_t c
                        void *context);
 
 /**
- * Builds a new query closure.
- * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Parameters:
- *   call: Pointer to the callback function. ``context`` will be passed as its last argument.
- *   drop: Pointer to the function that will free the callback state. ``context`` will be passed as its last argument.
- *   context: Pointer to an arbitrary state.
- *
- * Return:
- *   The query closure.
- */
-int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, z_owned_query_handler_t call,
-                             z_dropper_handler_t drop, void *context);
-
-/**
  * Builds a new reply closure.
  * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
@@ -1137,21 +1107,6 @@ int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, z_owned_que
  */
 int8_t z_closure_reply(z_owned_closure_reply_t *closure, z_reply_handler_t call, z_dropper_handler_t drop,
                        void *context);
-
-/**
- * Builds a new reply closure.
- * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Parameters:
- *   call: Pointer to the callback function. ``context`` will be passed as its last argument.
- *   drop: Pointer to the function that will free the callback state. ``context`` will be passed as its last argument.
- *   context: Pointer to an arbitrary state.
- *
- * Return:
- *   The reply closure.
- */
-int8_t z_closure_owned_reply(z_owned_closure_owned_reply_t *closure, z_owned_reply_handler_t call,
-                             z_dropper_handler_t drop, void *context);
 
 /**
  * Builds a new hello closure.
@@ -1202,11 +1157,8 @@ _Z_OWNED_FUNCTIONS_DEF(z_loaned_bytes_writer_t, z_owned_bytes_writer_t, bytes_wr
 _Z_OWNED_FUNCTIONS_DEF(z_loaned_reply_err_t, z_owned_reply_err_t, reply_err)
 
 _Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_sample_t, closure_sample)
-_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_sample_t, closure_owned_sample)
 _Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_query_t, closure_query)
-_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_query_t, closure_owned_query)
 _Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_reply_t, closure_reply)
-_Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_owned_reply_t, closure_owned_reply)
 _Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_hello_t, closure_hello)
 _Z_OWNED_FUNCTIONS_CLOSURE_DEF(z_owned_closure_zid_t, closure_zid)
 

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -457,7 +457,6 @@ size_t z_string_array_len(const z_loaned_string_array_t *a);
 _Bool z_string_array_is_empty(const z_loaned_string_array_t *a);
 
 typedef void (*z_dropper_handler_t)(void *arg);
-typedef void (*z_owned_sample_handler_t)(z_owned_sample_t *sample, void *arg);
 typedef _z_data_handler_t z_data_handler_t;
 
 /**
@@ -477,26 +476,6 @@ typedef struct {
 } z_owned_closure_sample_t;
 
 void z_closure_sample_call(const z_owned_closure_sample_t *closure, const z_loaned_sample_t *sample);
-
-/**
- * Represents the owned sample closure.
- *
- * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Members:
- *   void *context: a pointer to an arbitrary state.
- *   z_owned_sample_handler_t call: `void *call(const struct z_owned_sample_t*, const void *context)` is the callback
- *   function.
- * 	 z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
- *   pointer to an arbitrary state.
- */
-typedef struct {
-    void *context;
-    z_owned_sample_handler_t call;
-    z_dropper_handler_t drop;
-} z_owned_closure_owned_sample_t;
-
-void z_closure_owned_sample_call(const z_owned_closure_owned_sample_t *closure, z_owned_sample_t *sample);
 
 typedef _z_queryable_handler_t z_queryable_handler_t;
 
@@ -520,29 +499,6 @@ typedef struct {
 
 void z_closure_query_call(const z_owned_closure_query_t *closure, const z_loaned_query_t *query);
 
-typedef void (*z_owned_query_handler_t)(z_owned_query_t *query, void *arg);
-
-/**
- * Represents the owned query closure.
- *
- * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Members:
- *   void *context: a pointer to an arbitrary state.
- *   z_owned_query_handler_t call: `void *call(const struct z_owned_query_t*, const void *context)` is the callback
- *   function.
- * 	 z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
- *   pointer to an arbitrary state.
- */
-typedef struct {
-    void *context;
-    z_owned_query_handler_t call;
-    z_dropper_handler_t drop;
-} z_owned_closure_owned_query_t;
-
-void z_closure_owned_query_call(const z_owned_closure_owned_query_t *closure, z_owned_query_t *query);
-
-typedef void (*z_owned_reply_handler_t)(z_owned_reply_t *reply, void *arg);
 typedef _z_reply_handler_t z_reply_handler_t;
 
 /**
@@ -564,26 +520,6 @@ typedef struct {
 } z_owned_closure_reply_t;
 
 void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned_reply_t *reply);
-
-/**
- * Represents the owned query reply callback closure.
- *
- * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
- *
- * Members:
- *   void *context: a pointer to an arbitrary state.
- *   z_owned_reply_handler_t call: `void (*z_owned_reply_handler_t)(const z_owned_reply_t *reply, void *arg)` is the
- * callback function.
- *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
- *   void *context: a pointer to an arbitrary state.
- */
-typedef struct {
-    void *context;
-    z_owned_reply_handler_t call;
-    z_dropper_handler_t drop;
-} z_owned_closure_owned_reply_t;
-
-void z_closure_owned_reply_call(const z_owned_closure_owned_reply_t *closure, z_owned_reply_t *reply);
 
 typedef void (*z_loaned_hello_handler_t)(const z_loaned_hello_t *hello, void *arg);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -705,31 +705,13 @@ void z_closure_sample_call(const z_owned_closure_sample_t *closure, const z_loan
     }
 }
 
-void z_closure_owned_sample_call(const z_owned_closure_owned_sample_t *closure, z_owned_sample_t *sample) {
-    if (closure->call != NULL) {
-        (closure->call)(sample, closure->context);
-    }
-}
-
 void z_closure_query_call(const z_owned_closure_query_t *closure, const z_loaned_query_t *query) {
     if (closure->call != NULL) {
         (closure->call)(query, closure->context);
     }
 }
 
-void z_closure_owned_query_call(const z_owned_closure_owned_query_t *closure, z_owned_query_t *query) {
-    if (closure->call != NULL) {
-        (closure->call)(query, closure->context);
-    }
-}
-
 void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned_reply_t *reply) {
-    if (closure->call != NULL) {
-        (closure->call)(reply, closure->context);
-    }
-}
-
-void z_closure_owned_reply_call(const z_owned_closure_owned_reply_t *closure, z_owned_reply_t *reply) {
     if (closure->call != NULL) {
         (closure->call)(reply, closure->context);
     }
@@ -794,14 +776,8 @@ _Z_OWNED_FUNCTIONS_RC_IMPL(sample)
 _Z_OWNED_FUNCTIONS_RC_IMPL(session)
 
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_sample_t, closure_sample, _z_data_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_sample_t, closure_owned_sample, z_owned_sample_handler_t,
-                                z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_query_t, closure_owned_query, z_owned_query_handler_t,
-                                z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_owned_reply_t, closure_owned_reply, z_owned_reply_handler_t,
-                                z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_hello_t, closure_hello, z_loaned_hello_handler_t, z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(z_owned_closure_zid_t, closure_zid, z_id_handler_t, z_dropper_handler_t)
 


### PR DESCRIPTION
These closures were only used for old channels, are no longer needed and was removed
 - z_owned_closure_owned_reply_t
 - z_owned_closure_owned_sample_t
 - z_owned_closure_owned_query_t

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/448