### PR TITLE
store value instead of pointer for owned handlers

### DIFF
--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -24,78 +24,81 @@
 #include "zenoh-pico/utils/logging.h"
 
 // -- Channel
-#define _Z_CHANNEL_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,        \
-                               collection_type, collection_new_f, collection_free_f, collection_push_f,              \
-                               collection_pull_f, collection_try_pull_f, elem_owned_type, elem_loaned_type,          \
-                               elem_copy_f, elem_drop_f)                                                             \
-    typedef struct {                                                                                                 \
-        collection_type *collection;                                                                                 \
-    } handler_type;                                                                                                  \
-                                                                                                                     \
-    _Z_OWNED_TYPE_PTR(handler_type, handler_name)                                                                    \
-    _Z_LOANED_TYPE(handler_type, handler_name)                                                                       \
-                                                                                                                     \
-    static inline void _z_##handler_name##_elem_free(void **elem) {                                                  \
-        elem_drop_f((elem_owned_type *)*elem);                                                                       \
-        z_free(*elem);                                                                                               \
-        *elem = NULL;                                                                                                \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_elem_move(void *dst, void *src) {                                         \
-        memcpy(dst, src, sizeof(elem_owned_type));                                                                   \
-        z_free(src);                                                                                                 \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_send(const elem_loaned_type *elem, void *context) {                       \
-        elem_owned_type *internal_elem = (elem_owned_type *)z_malloc(sizeof(elem_owned_type));                       \
-        if (internal_elem == NULL) {                                                                                 \
-            _Z_ERROR("Out of memory");                                                                               \
-            return;                                                                                                  \
-        }                                                                                                            \
-        if (elem == NULL) {                                                                                          \
-            internal_elem->_rc.in = NULL;                                                                            \
-        } else {                                                                                                     \
-            elem_copy_f(&internal_elem->_rc, elem);                                                                  \
-        }                                                                                                            \
-        int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                       \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_push_f, ret);                                                      \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void z_##handler_name##_recv(const z_loaned_##handler_name##_t *handler, elem_owned_type *elem) {  \
-        int8_t ret = collection_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move); \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_pull_f, ret);                                                      \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void z_##handler_name##_try_recv(const z_loaned_##handler_name##_t *handler,                       \
-                                                   elem_owned_type *elem) {                                          \
-        int8_t ret =                                                                                                 \
-            collection_try_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move);      \
-        if (ret != _Z_RES_OK) {                                                                                      \
-            _Z_ERROR("%s failed: %i", #collection_try_pull_f, ret);                                                  \
-        }                                                                                                            \
-    }                                                                                                                \
-                                                                                                                     \
-    static inline void _z_##handler_name##_free(handler_type **handler) {                                            \
-        handler_type *ptr = *handler;                                                                                \
-        if (ptr != NULL) {                                                                                           \
-            collection_free_f(ptr->collection, _z_##handler_name##_elem_free);                                       \
-            z_free(ptr);                                                                                             \
-            *handler = NULL;                                                                                         \
-        }                                                                                                            \
-    }                                                                                                                \
-    static inline void _z_##handler_name##_copy(void *dst, const void *src) {                                        \
-        (void)(dst);                                                                                                 \
-        (void)(src);                                                                                                 \
-    }                                                                                                                \
-                                                                                                                     \
-    _Z_OWNED_FUNCTIONS_PTR_IMPL(handler_type, handler_name, _z_##handler_name##_copy, _z_##handler_name##_free)      \
-                                                                                                                     \
-    static inline int8_t handler_new_f_name(callback_type *callback, z_owned_##handler_name##_t *handler,            \
-                                            size_t capacity) {                                                       \
-        handler->_val = (handler_type *)z_malloc(sizeof(handler_type));                                              \
-        handler->_val->collection = collection_new_f(capacity);                                                      \
-        callback_new_f(callback, _z_##handler_name##_send, NULL, handler->_val->collection);                         \
-        return _Z_RES_OK;                                                                                            \
+#define _Z_CHANNEL_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,          \
+                               collection_type, collection_new_f, collection_free_f, collection_push_f,                \
+                               collection_pull_f, collection_try_pull_f, elem_owned_type, elem_loaned_type,            \
+                               elem_copy_f, elem_drop_f)                                                               \
+    typedef struct {                                                                                                   \
+        collection_type *collection;                                                                                   \
+    } handler_type;                                                                                                    \
+                                                                                                                       \
+    _Z_OWNED_TYPE_VALUE(handler_type, handler_name)                                                                    \
+    _Z_LOANED_TYPE(handler_type, handler_name)                                                                         \
+                                                                                                                       \
+    static inline void _z_##handler_name##_elem_free(void **elem) {                                                    \
+        elem_drop_f((elem_owned_type *)*elem);                                                                         \
+        z_free(*elem);                                                                                                 \
+        *elem = NULL;                                                                                                  \
+    }                                                                                                                  \
+    static inline void _z_##handler_name##_elem_move(void *dst, void *src) {                                           \
+        memcpy(dst, src, sizeof(elem_owned_type));                                                                     \
+        z_free(src);                                                                                                   \
+    }                                                                                                                  \
+    static inline void _z_##handler_name##_send(const elem_loaned_type *elem, void *context) {                         \
+        elem_owned_type *internal_elem = (elem_owned_type *)z_malloc(sizeof(elem_owned_type));                         \
+        if (internal_elem == NULL) {                                                                                   \
+            _Z_ERROR("Out of memory");                                                                                 \
+            return;                                                                                                    \
+        }                                                                                                              \
+        if (elem == NULL) {                                                                                            \
+            internal_elem->_rc.in = NULL;                                                                              \
+        } else {                                                                                                       \
+            elem_copy_f(&internal_elem->_rc, elem);                                                                    \
+        }                                                                                                              \
+        int8_t ret = collection_push_f(internal_elem, context, _z_##handler_name##_elem_free);                         \
+        if (ret != _Z_RES_OK) {                                                                                        \
+            _Z_ERROR("%s failed: %i", #collection_push_f, ret);                                                        \
+        }                                                                                                              \
+    }                                                                                                                  \
+    static inline void z_##handler_name##_recv(const z_loaned_##handler_name##_t *handler, elem_owned_type *elem) {    \
+        int8_t ret = collection_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move);   \
+        if (ret != _Z_RES_OK) {                                                                                        \
+            _Z_ERROR("%s failed: %i", #collection_pull_f, ret);                                                        \
+        }                                                                                                              \
+    }                                                                                                                  \
+    static inline void z_##handler_name##_try_recv(const z_loaned_##handler_name##_t *handler,                         \
+                                                   elem_owned_type *elem) {                                            \
+        int8_t ret =                                                                                                   \
+            collection_try_pull_f(elem, (collection_type *)handler->collection, _z_##handler_name##_elem_move);        \
+        if (ret != _Z_RES_OK) {                                                                                        \
+            _Z_ERROR("%s failed: %i", #collection_try_pull_f, ret);                                                    \
+        }                                                                                                              \
+    }                                                                                                                  \
+                                                                                                                       \
+    static inline void _z_##handler_name##_clear(handler_type *handler) {                                              \
+        if (handler != NULL && handler->collection != NULL) {                                                          \
+            collection_free_f(handler->collection, _z_##handler_name##_elem_free);                                     \
+            handler->collection = NULL;                                                                                \
+        }                                                                                                              \
+    }                                                                                                                  \
+    static inline _Bool _z_##handler_name##_check(const handler_type *handler) { return handler->collection == NULL; } \
+    static inline handler_type _z_##handler_name##_null(void) {                                                        \
+        handler_type h;                                                                                                \
+        h.collection = NULL;                                                                                           \
+        return h;                                                                                                      \
+    }                                                                                                                  \
+                                                                                                                       \
+    _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(handler_type, handler_name, _z_##handler_name##_check,                       \
+                                          _z_##handler_name##_null, _z_##handler_name##_clear)                         \
+                                                                                                                       \
+    static inline int8_t handler_new_f_name(callback_type *callback, z_owned_##handler_name##_t *handler,              \
+                                            size_t capacity) {                                                         \
+        handler->_val.collection = collection_new_f(capacity);                                                         \
+        if (handler->_val.collection == NULL) {                                                                        \
+            return _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                                        \
+        }                                                                                                              \
+        callback_new_f(callback, _z_##handler_name##_send, NULL, handler->_val.collection);                            \
+        return _Z_RES_OK;                                                                                              \
     }
 
 #define _Z_CHANNEL_DEFINE(item_name, kind_name)                                                             \

--- a/zenohpico.pc
+++ b/zenohpico.pc
@@ -3,6 +3,6 @@ prefix=/usr/local
 Name: zenohpico
 Description: 
 URL: 
-Version: 1.0.20240628dev
+Version: 1.0.20240702dev
 Cflags: -I${prefix}/include
 Libs: -L${prefix}/lib -lzenohpico


### PR DESCRIPTION
Store value instead of pointer for owned handlers.
Partially resolves #475.