### PR TITLE
Rework z_task_t cleanup

### DIFF
--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -116,7 +116,6 @@
                   z_owned_closure_reply_t * : z_closure_reply_drop,                 \
                   z_owned_closure_hello_t * : z_closure_hello_drop,                 \
                   z_owned_closure_zid_t * : z_closure_zid_drop,                     \
-                  z_owned_task_t *: z_task_drop,                                    \
                   z_owned_mutex_t *: z_mutex_drop,                                  \
                   z_owned_condvar_t *: z_condvar_drop,                              \
                   z_owned_fifo_handler_query_t * : z_fifo_handler_query_drop,       \
@@ -382,7 +381,6 @@ inline void z_drop(z_owned_sample_t* v) { z_sample_drop(v); }
 inline void z_drop(z_owned_query_t* v) { z_query_drop(v); }
 inline void z_drop(z_owned_bytes_t* v) { z_bytes_drop(v); }
 inline void z_drop(z_owned_encoding_t* v) { z_encoding_drop(v); }
-inline void z_drop(z_owned_task_t* v) { z_task_drop(v); }
 inline void z_drop(z_owned_mutex_t* v) { z_mutex_drop(v); }
 inline void z_drop(z_owned_condvar_t* v) { z_condvar_drop(v); }
 inline void z_drop(z_owned_reply_err_t* v) { z_reply_err_drop(v); }

--- a/include/zenoh-pico/system/platform-common.h
+++ b/include/zenoh-pico/system/platform-common.h
@@ -73,15 +73,14 @@ typedef void *z_task_attr_t;
 int8_t _z_task_init(_z_task_t *task, z_task_attr_t *attr, void *(*fun)(void *), void *arg);
 int8_t _z_task_join(_z_task_t *task);
 int8_t _z_task_cancel(_z_task_t *task);
-void _z_task_drop(_z_task_t **task);
+void _z_task_free(_z_task_t **task);
 
 _Z_OWNED_TYPE_VALUE(_z_task_t, task)
 _Z_LOANED_TYPE(_z_task_t, task)
 _Z_OWNED_FUNCTIONS_SYSTEM_DEF(task)
 
 int8_t z_task_init(z_owned_task_t *task, z_task_attr_t *attr, void *(*fun)(void *), void *arg);
-int8_t z_task_join(z_loaned_task_t *task);
-void z_task_drop(z_owned_task_t *task);
+int8_t z_task_join(z_owned_task_t *task);
 
 /*------------------ Mutex ------------------*/
 int8_t _z_mutex_init(_z_mutex_t *m);

--- a/src/system/arduino/esp32/system.c
+++ b/src/system/arduino/esp32/system.c
@@ -87,7 +87,7 @@ int8_t _z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/system/arduino/opencr/system.c
+++ b/src/system/arduino/opencr/system.c
@@ -69,7 +69,7 @@ int8_t _z_task_join(_z_task_t *task) { return -1; }
 
 int8_t _z_task_cancel(_z_task_t *task) { return -1; }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -52,7 +52,7 @@ int8_t _z_task_join(_z_task_t *task) { return pthread_join(*task, NULL); }
 
 int8_t _z_task_cancel(_z_task_t *task) { return pthread_cancel(*task); }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -120,7 +120,7 @@ int8_t z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);
 }

--- a/src/system/flipper/system.c
+++ b/src/system/flipper/system.c
@@ -89,7 +89,7 @@ int8_t _z_task_join(_z_task_t* task) {
 
 int8_t _z_task_cancel(_z_task_t* task) { return -1; }
 
-void _z_task_drop(_z_task_t** task) {
+void _z_task_free(_z_task_t** task) {
     if (task == NULL || *task == NULL) {
         return;
     }

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -129,7 +129,7 @@ int8_t _z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);
 }

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -59,7 +59,7 @@ int8_t _z_task_cancel(_z_task_t *task) {
     return res;
 }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/system/platform-common.c
+++ b/src/system/platform-common.c
@@ -24,11 +24,11 @@ int8_t z_task_init(z_owned_task_t *task, z_task_attr_t *attr, void *(*fun)(void 
     return _z_task_init(&task->_val, attr, fun, arg);
 }
 
-int8_t z_task_join(z_loaned_task_t *task) { return _z_task_join(task); }
-
-void z_task_drop(z_owned_task_t *task) {
+int8_t z_task_join(z_owned_task_t *task) {
     _z_task_t *ptr = &task->_val;
-    _z_task_drop(&ptr);
+    int8_t ret = _z_task_join(ptr);
+    _z_task_free(&ptr);
+    return ret;
 }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -109,7 +109,7 @@ int8_t _z_task_join(_z_task_t *task) { return (int8_t)pthread_join(*task, NULL);
 
 int8_t _z_task_cancel(_z_task_t *task) { return (int8_t)pthread_cancel(*task); }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -82,7 +82,7 @@ int8_t _z_task_cancel(_z_task_t *task) {
     return ret;
 }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     CloseHandle(*ptr);
     z_free(ptr);

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -87,7 +87,7 @@ int8_t _z_task_join(_z_task_t *task) { return pthread_join(*task, NULL); }
 
 int8_t _z_task_cancel(_z_task_t *task) { return pthread_cancel(*task); }
 
-void _z_task_drop(_z_task_t **task) {
+void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);
     *task = NULL;

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -185,11 +185,11 @@ void _z_multicast_transport_clear(_z_transport_t *zt) {
     // Clean up tasks
     if (ztm->_read_task != NULL) {
         _z_task_join(ztm->_read_task);
-        _z_task_drop(&ztm->_read_task);
+        _z_task_free(&ztm->_read_task);
     }
     if (ztm->_lease_task != NULL) {
         _z_task_join(ztm->_lease_task);
-        _z_task_drop(&ztm->_lease_task);
+        _z_task_free(&ztm->_lease_task);
     }
     // Clean up the mutexes
     _z_mutex_drop(&ztm->_mutex_tx);

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -291,11 +291,11 @@ void _z_unicast_transport_clear(_z_transport_t *zt) {
     // Clean up tasks
     if (ztu->_read_task != NULL) {
         _z_task_join(ztu->_read_task);
-        _z_task_drop(&ztu->_read_task);
+        _z_task_free(&ztu->_read_task);
     }
     if (ztu->_lease_task != NULL) {
         _z_task_join(ztu->_lease_task);
-        _z_task_drop(&ztu->_lease_task);
+        _z_task_free(&ztu->_lease_task);
     }
 
     // Clean up the mutexes


### PR DESCRIPTION
Task should have no explicit drop, we will cleanup it at join.