### PR TITLE
Add z_view_string methods

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -293,7 +293,9 @@ Macros
 Primitives
 ~~~~~~~~~~
 
+.. autocfunction:: primitives.h::z_view_string_empty
 .. autocfunction:: primitives.h::z_view_string_wrap
+.. autocfunction:: primitives.h::z_view_string_from_substring
 .. autocfunction:: primitives.h::z_view_keyexpr_from_str
 .. autocfunction:: primitives.h::z_view_keyexpr_from_str_unchecked
 .. autocfunction:: primitives.h::z_view_keyexpr_from_str_autocanonize

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -34,6 +34,17 @@ extern "C" {
 
 /********* Data Types Handlers *********/
 /**
+ * Builds an empty :c:type:`z_view_string_t`.
+ *
+ * Parameters:
+ *   str: Pointer to an uninitialized :c:type:`z_view_string_t`.
+ *
+ * Return:
+ *   ``0`` if creation successful, ``negative value`` otherwise.
+ */
+int8_t z_view_string_empty(z_view_string_t *str);
+
+/**
  * Builds a :c:type:`z_view_string_t` by wrapping a ``const char *`` string.
  *
  * Parameters:
@@ -44,6 +55,19 @@ extern "C" {
  *   ``0`` if creation successful, ``negative value`` otherwise.
  */
 int8_t z_view_string_wrap(z_view_string_t *str, const char *value);
+
+/**
+ * Builds a :c:type:`z_view_string_t` by wrapping a substring specified by ``const char *`` and length `len`.
+ *
+ * Parameters:
+ *   value: Pointer to a string.
+ *   len: String size.
+ *   str: Pointer to an uninitialized :c:type:`z_view_string_t`.
+ *
+ * Return:
+ *   ``0`` if creation successful, ``negative value`` otherwise.
+ */
+int8_t z_view_string_from_substring(z_view_string_t *str, const char *value, size_t len);
 
 /**
  * Builds a :c:type:`z_keyexpr_t` from a null-terminated string.

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -46,8 +46,20 @@
 
 /********* Data Types Handlers *********/
 
+int8_t z_view_string_empty(z_view_string_t *str) {
+    str->_val.val = NULL;
+    str->_val.len = 0;
+    return _Z_RES_OK;
+}
+
 int8_t z_view_string_wrap(z_view_string_t *str, const char *value) {
     str->_val = _z_string_wrap((char *)value);
+    return _Z_RES_OK;
+}
+
+int8_t z_view_string_from_substring(z_view_string_t *str, const char *value, size_t len) {
+    str->_val.val = (char *)value;
+    str->_val.len = len;
     return _Z_RES_OK;
 }
 


### PR DESCRIPTION
 - `z_view_string_empty`
 - `z_view_string_from_substring`

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/473