### PR TITLE
store value instead of pointer for z_publisher, z_subscriber and z_queryable

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -140,7 +140,7 @@ _Z_LOANED_TYPE(_z_session_rc_t, session)
  *   - :c:func:`z_declare_subscriber`
  *   - :c:func:`z_undeclare_subscriber`
  */
-_Z_OWNED_TYPE_PTR(_z_subscriber_t, subscriber)
+_Z_OWNED_TYPE_VALUE(_z_subscriber_t, subscriber)
 _Z_LOANED_TYPE(_z_subscriber_t, subscriber)
 
 /**
@@ -153,7 +153,7 @@ _Z_LOANED_TYPE(_z_subscriber_t, subscriber)
  *   - :c:func:`z_publisher_put`
  *   - :c:func:`z_publisher_delete`
  */
-_Z_OWNED_TYPE_PTR(_z_publisher_t, publisher)
+_Z_OWNED_TYPE_VALUE(_z_publisher_t, publisher)
 _Z_LOANED_TYPE(_z_publisher_t, publisher)
 
 /**
@@ -164,7 +164,7 @@ _Z_LOANED_TYPE(_z_publisher_t, publisher)
  *   - :c:func:`z_declare_queryable`
  *   - :c:func:`z_undeclare_queryable`
  */
-_Z_OWNED_TYPE_PTR(_z_queryable_t, queryable)
+_Z_OWNED_TYPE_VALUE(_z_queryable_t, queryable)
 _Z_LOANED_TYPE(_z_queryable_t, queryable)
 
 /**

--- a/include/zenoh-pico/collections/refcount.h
+++ b/include/zenoh-pico/collections/refcount.h
@@ -95,6 +95,11 @@
     typedef struct name##_rc_t {                                                          \
         name##_inner_rc_t *in;                                                            \
     } name##_rc_t;                                                                        \
+    static inline name##_rc_t name##_rc_null(void) {                                      \
+        name##_rc_t p;                                                                    \
+        p.in = NULL;                                                                      \
+        return p;                                                                         \
+    }                                                                                     \
     static inline name##_rc_t name##_rc_new(void) {                                       \
         name##_rc_t p;                                                                    \
         p.in = (name##_inner_rc_t *)z_malloc(sizeof(name##_inner_rc_t));                  \

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -85,10 +85,10 @@ int8_t _z_undeclare_resource(_z_session_t *zn, uint16_t rid);
  *              of any allocated value.
  *
  * Returns:
- *    The created :c:type:`_z_publisher_t` or null if the declaration failed.
+ *    The created :c:type:`_z_publisher_t` (in null state if the declaration failed)..
  */
-_z_publisher_t *_z_declare_publisher(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr,
-                                     z_congestion_control_t congestion_control, z_priority_t priority);
+_z_publisher_t _z_declare_publisher(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr,
+                                    z_congestion_control_t congestion_control, z_priority_t priority);
 
 /**
  * Undeclare a :c:type:`_z_publisher_t`.
@@ -137,10 +137,10 @@ int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload
  * received. arg: A pointer that will be passed to the **callback** on each call.
  *
  * Returns:
- *    The created :c:type:`_z_subscriber_t` or null if the declaration failed.
+ *    The created :c:type:`_z_subscriber_t` (in null state if the declaration failed).
  */
-_z_subscriber_t *_z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_subinfo_t sub_info,
-                                       _z_data_handler_t callback, _z_drop_handler_t dropper, void *arg);
+_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_subinfo_t sub_info,
+                                      _z_data_handler_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_subscriber_t`.
@@ -167,10 +167,10 @@ int8_t _z_undeclare_subscriber(_z_subscriber_t *sub);
  *     arg: A pointer that will be passed to the **callback** on each call.
  *
  * Returns:
- *    The created :c:type:`_z_queryable_t` or null if the declaration failed.
+ *    The created :c:type:`_z_queryable_t` (in null state if the declaration failed)..
  */
-_z_queryable_t *_z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _Bool complete,
-                                     _z_queryable_handler_t callback, _z_drop_handler_t dropper, void *arg);
+_z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _Bool complete,
+                                    _z_queryable_handler_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_queryable_t`.

--- a/include/zenoh-pico/net/publish.h
+++ b/include/zenoh-pico/net/publish.h
@@ -36,6 +36,8 @@ typedef struct _z_publisher_t {
 #if Z_FEATURE_PUBLICATION == 1
 void _z_publisher_clear(_z_publisher_t *pub);
 void _z_publisher_free(_z_publisher_t **pub);
+_Bool _z_publisher_check(const _z_publisher_t *publisher);
+_z_publisher_t _z_publisher_null(void);
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PUBLISH_H */

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -54,6 +54,8 @@ _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_
                            uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
+_z_queryable_t _z_queryable_null(void);
+_Bool _z_queryable_check(const _z_queryable_t *queryable);
 #endif
 
 #endif /* ZENOH_PICO_QUERY_NETAPI_H */

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -39,6 +39,8 @@ _z_subinfo_t _z_subinfo_default(void);
 
 void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
+_Bool _z_subscriber_check(const _z_subscriber_t *subscriber);
+_z_subscriber_t _z_subscriber_null(void);
 #endif
 
 #endif /* ZENOH_PICO_SUBSCRIBE_NETAPI_H */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -606,11 +606,6 @@ void z_closure_zid_call(const z_loaned_closure_zid_t *closure, const z_id_t *id)
     }
 }
 
-static inline void _z_owner_noop_copy(void *dst, const void *src) {
-    (void)(dst);
-    (void)(src);
-}
-
 _Bool _z_config_check(const _z_config_t *config) { return !_z_str_intmap_is_empty(config); }
 _z_config_t _z_config_null(void) { return _z_str_intmap_make(); }
 void _z_config_drop(_z_config_t *config) { _z_str_intmap_clear(config); }
@@ -831,16 +826,17 @@ const char *z_string_data(const z_loaned_string_t *str) { return str->val; }
 size_t z_string_len(const z_loaned_string_t *str) { return str->len; }
 
 #if Z_FEATURE_PUBLICATION == 1
-int8_t _z_publisher_drop(_z_publisher_t **pub) {
+int8_t _z_undeclare_and_clear_publisher(_z_publisher_t *pub) {
     int8_t ret = _Z_RES_OK;
-
-    ret = _z_undeclare_publisher(*pub);
-    _z_publisher_free(pub);
-
+    ret = _z_undeclare_publisher(pub);
+    _z_publisher_clear(pub);
     return ret;
 }
 
-_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_publisher_t, publisher, _z_owner_noop_copy, _z_publisher_drop)
+void _z_publisher_drop(_z_publisher_t *pub) { _z_undeclare_and_clear_publisher(pub); }
+
+_Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_publisher_t, publisher, _z_publisher_check, _z_publisher_null,
+                                      _z_publisher_drop)
 
 void z_put_options_default(z_put_options_t *options) {
     options->congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
@@ -906,7 +902,7 @@ int8_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *z
                            const z_publisher_options_t *options) {
     _z_keyexpr_t key = *keyexpr;
 
-    pub->_val = NULL;
+    pub->_val = _z_publisher_null();
     // TODO: Currently, if resource declarations are done over multicast transports, the current protocol definition
     //       lacks a way to convey them to later-joining nodes. Thus, in the current version automatic
     //       resource declarations are only performed on unicast transports.
@@ -925,15 +921,9 @@ int8_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *z
         opt.priority = options->priority;
     }
     // Set publisher
-    _z_publisher_t *int_pub = _z_declare_publisher(zs, key, opt.congestion_control, opt.priority);
-    if (int_pub == NULL) {
-        if (key._id != Z_RESOURCE_ID_NONE) {
-            _z_undeclare_resource(&_Z_RC_IN_VAL(zs), key._id);
-        }
-        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
-    }
+    _z_publisher_t int_pub = _z_declare_publisher(zs, key, opt.congestion_control, opt.priority);
     // Create write filter
-    int8_t res = _z_write_filter_create(int_pub);
+    int8_t res = _z_write_filter_create(&int_pub);
     if (res != _Z_RES_OK) {
         if (key._id != Z_RESOURCE_ID_NONE) {
             _z_undeclare_resource(&_Z_RC_IN_VAL(zs), key._id);
@@ -944,7 +934,7 @@ int8_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *z
     return _Z_RES_OK;
 }
 
-int8_t z_undeclare_publisher(z_owned_publisher_t *pub) { return _z_publisher_drop(&pub->_val); }
+int8_t z_undeclare_publisher(z_owned_publisher_t *pub) { return _z_undeclare_and_clear_publisher(&pub->_val); }
 
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
     options->encoding = NULL;
@@ -1063,16 +1053,20 @@ const z_loaned_reply_err_t *z_reply_err(const z_loaned_reply_t *reply) {
 #endif
 
 #if Z_FEATURE_QUERYABLE == 1
-int8_t _z_queryable_drop(_z_queryable_t **queryable) {
+_Z_OWNED_FUNCTIONS_RC_IMPL(query)
+
+int8_t _z_undeclare_and_clear_queryable(_z_queryable_t *queryable) {
     int8_t ret = _Z_RES_OK;
 
-    ret = _z_undeclare_queryable(*queryable);
-    _z_queryable_free(queryable);
+    ret = _z_undeclare_queryable(queryable);
+    _z_queryable_clear(queryable);
     return ret;
 }
 
-_Z_OWNED_FUNCTIONS_RC_IMPL(query)
-_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_queryable_t, queryable, _z_owner_noop_copy, _z_queryable_drop)
+void _z_queryable_drop(_z_queryable_t *queryable) { _z_undeclare_and_clear_queryable(queryable); }
+
+_Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_check, _z_queryable_null,
+                                      _z_queryable_drop)
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
 
@@ -1107,7 +1101,9 @@ int8_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_sessio
     return _Z_RES_OK;
 }
 
-int8_t z_undeclare_queryable(z_owned_queryable_t *queryable) { return _z_queryable_drop(&queryable->_val); }
+int8_t z_undeclare_queryable(z_owned_queryable_t *queryable) {
+    return _z_undeclare_and_clear_queryable(&queryable->_val);
+}
 
 void z_query_reply_options_default(z_query_reply_options_t *options) {
     options->encoding = NULL;
@@ -1163,16 +1159,17 @@ int8_t z_undeclare_keyexpr(const z_loaned_session_t *zs, z_owned_keyexpr_t *keye
 }
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-int8_t _z_subscriber_drop(_z_subscriber_t **sub) {
+int8_t _z_undeclare_and_clear_subscriber(_z_subscriber_t *sub) {
     int8_t ret = _Z_RES_OK;
-
-    ret = _z_undeclare_subscriber(*sub);
-    _z_subscriber_free(sub);
-
+    ret = _z_undeclare_subscriber(sub);
+    _z_subscriber_clear(sub);
     return ret;
 }
 
-_Z_OWNED_FUNCTIONS_PTR_IMPL(_z_subscriber_t, subscriber, _z_owner_noop_copy, _z_subscriber_drop)
+void _z_subscriber_drop(_z_subscriber_t *sub) { _z_undeclare_and_clear_subscriber(sub); }
+
+_Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber_check, _z_subscriber_null,
+                                      _z_subscriber_drop)
 
 void z_subscriber_options_default(z_subscriber_options_t *options) { options->reliability = Z_RELIABILITY_DEFAULT; }
 
@@ -1217,21 +1214,21 @@ int8_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t 
     if (options != NULL) {
         subinfo.reliability = options->reliability;
     }
-    _z_subscriber_t *int_sub = _z_declare_subscriber(zs, key, subinfo, callback->_val.call, callback->_val.drop, ctx);
+    _z_subscriber_t int_sub = _z_declare_subscriber(zs, key, subinfo, callback->_val.call, callback->_val.drop, ctx);
     if (suffix != NULL) {
         z_free(suffix);
     }
     z_closure_sample_null(callback);
     sub->_val = int_sub;
 
-    if (int_sub == NULL) {
+    if (!_z_subscriber_check(&sub->_val)) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     } else {
         return _Z_RES_OK;
     }
 }
 
-int8_t z_undeclare_subscriber(z_owned_subscriber_t *sub) { return _z_subscriber_drop(&sub->_val); }
+int8_t z_undeclare_subscriber(z_owned_subscriber_t *sub) { return _z_undeclare_and_clear_subscriber(&sub->_val); }
 
 int8_t z_subscriber_keyexpr(z_owned_keyexpr_t *keyexpr, z_loaned_subscriber_t *sub) {
     // Init keyexpr

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -17,7 +17,10 @@
 #include <stddef.h>
 
 #if Z_FEATURE_PUBLICATION == 1
-void _z_publisher_clear(_z_publisher_t *pub) { _z_keyexpr_clear(&pub->_key); }
+void _z_publisher_clear(_z_publisher_t *pub) {
+    _z_keyexpr_clear(&pub->_key);
+    *pub = _z_publisher_null();
+}
 
 void _z_publisher_free(_z_publisher_t **pub) {
     _z_publisher_t *ptr = *pub;
@@ -28,5 +31,19 @@ void _z_publisher_free(_z_publisher_t **pub) {
         z_free(ptr);
         *pub = NULL;
     }
+}
+
+_Bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
+_z_publisher_t _z_publisher_null(void) {
+    return (_z_publisher_t) {
+        ._congestion_control = Z_CONGESTION_CONTROL_DEFAULT, ._id = 0, ._key = _z_keyexpr_null(),
+        ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_rc_null(),
+#if Z_FEATURE_INTEREST == 1
+        ._filter = (_z_write_filter_t){
+            ._interest_id = 0,
+            .ctx = NULL
+        }
+#endif
+    };
 }
 #endif

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -39,9 +39,8 @@ _z_publisher_t _z_publisher_null(void) {
         ._congestion_control = Z_CONGESTION_CONTROL_DEFAULT, ._id = 0, ._key = _z_keyexpr_null(),
         ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_rc_null(),
 #if Z_FEATURE_INTEREST == 1
-        ._filter = (_z_write_filter_t){
-            ._interest_id = 0,
-            .ctx = NULL
+        ._filter = (_z_write_filter_t) {
+            ._interest_id = 0, .ctx = NULL
         }
 #endif
     };

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -75,9 +75,13 @@ _z_query_t _z_query_create(const _z_value_t *value, _z_keyexpr_t *key, const _z_
     return q;
 }
 
+_z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){._entity_id = 0, ._zn = _z_session_rc_null()}; }
+
+_Bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
+
 void _z_queryable_clear(_z_queryable_t *qbl) {
     // Nothing to clear
-    (void)(qbl);
+    *qbl = _z_queryable_null();
 }
 
 void _z_queryable_free(_z_queryable_t **qbl) {

--- a/src/net/subscribe.c
+++ b/src/net/subscribe.c
@@ -23,6 +23,7 @@ _z_subinfo_t _z_subinfo_default(void) {
 void _z_subscriber_clear(_z_subscriber_t *sub) {
     // Nothing to clear
     (void)(sub);
+    *sub = _z_subscriber_null();
 }
 
 void _z_subscriber_free(_z_subscriber_t **sub) {
@@ -35,4 +36,8 @@ void _z_subscriber_free(_z_subscriber_t **sub) {
         *sub = NULL;
     }
 }
+
+_Bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
+_z_subscriber_t _z_subscriber_null(void) { return (_z_subscriber_t){._entity_id = 0, ._zn = _z_session_rc_null()}; }
+
 #endif

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
         assert(z_declare_queryable(qle, z_loan(s2), z_loan(ke), &callback, NULL) == _Z_RES_OK);
-        printf("Declared queryable on session 2: %ju %zu %s\n", (uintmax_t)qle->_val->_entity_id, (z_zint_t)0, s1_res);
+        printf("Declared queryable on session 2: %ju %zu %s\n", (uintmax_t)qle->_val._entity_id, (z_zint_t)0, s1_res);
         qles2 = _z_list_push(qles2, qle);
     }
 
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
     // Undeclare subscribers and queryables on second session
     while (subs2) {
         z_owned_subscriber_t *sub = _z_list_head(subs2);
-        printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)sub->_val->_entity_id);
+        printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)sub->_val._entity_id);
         z_undeclare_subscriber(z_move(*sub));
         subs2 = _z_list_pop(subs2, _z_noop_elem_free, NULL);
     }
@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
 
     while (qles2) {
         z_owned_queryable_t *qle = _z_list_head(qles2);
-        printf("Undeclared queryable on session 2: %ju\n", (uintmax_t)qle->_val->_entity_id);
+        printf("Undeclared queryable on session 2: %ju\n", (uintmax_t)qle->_val._entity_id);
         z_undeclare_queryable(z_move(*qle));
         qles2 = _z_list_pop(qles2, _z_noop_elem_free, NULL);
     }


### PR DESCRIPTION
store value instead of pointer for z_publisher, z_subscriber and z_queryable.
Closes #475.