### PR TITLE
Add missed z_string_* methods

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -379,8 +379,8 @@ Primitives
 .. autocfunction:: primitives.h::z_sample_loan
 .. autocfunction:: primitives.h::z_string_data
 .. autocfunction:: primitives.h::z_string_len
-.. autocfunction:: primitives.h::z_string_wrap
-.. autocfunction:: primitives.h::z_string_from_substring
+.. autocfunction:: primitives.h::z_string_from_str
+.. autocfunction:: primitives.h::z_string_from_substr
 .. autocfunction:: primitives.h::z_string_empty
 .. autocfunction:: primitives.h::z_string_is_empty
 .. autocfunction:: primitives.h::z_scout

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -379,6 +379,10 @@ Primitives
 .. autocfunction:: primitives.h::z_sample_loan
 .. autocfunction:: primitives.h::z_string_data
 .. autocfunction:: primitives.h::z_string_len
+.. autocfunction:: primitives.h::z_string_wrap
+.. autocfunction:: primitives.h::z_string_from_substring
+.. autocfunction:: primitives.h::z_string_empty
+.. autocfunction:: primitives.h::z_string_is_empty
 .. autocfunction:: primitives.h::z_scout
 .. autocfunction:: primitives.h::z_open
 .. autocfunction:: primitives.h::z_close

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1133,6 +1133,49 @@ const char *z_string_data(const z_loaned_string_t *str);
  */
 size_t z_string_len(const z_loaned_string_t *str);
 
+/**
+ * Builds a :c:type:`z_string_t` by wrapping a ``const char *`` string.
+ *
+ * Parameters:
+ *   str: Pointer to an uninitialized :c:type:`z_string_t`.
+ *   value: Pointer to a null terminated string.
+ *
+ * Return:
+ *   ``0`` if creation successful, ``negative value`` otherwise.
+ */
+int8_t z_string_wrap(z_owned_string_t *str, const char *value);
+
+/**
+ * Builds an empty :c:type:`z_string_t`.
+ *
+ * Parameters:
+ *   str: Pointer to an uninitialized :c:type:`z_string_t`.
+ */
+void z_string_empty(z_owned_string_t *str);
+
+/**
+ * Builds a :c:type:`z_string_t` by wrapping a substring specified by ``const char *`` and length `len`.
+ *
+ * Parameters:
+ *   value: Pointer to a string.
+ *   len: String size.
+ *   str: Pointer to an uninitialized :c:type:`z_string_t`.
+ *
+ * Return:
+ *   ``0`` if creation successful, ``negative value`` otherwise.
+ */
+int8_t z_string_from_substring(z_owned_string_t *str, const char *value, size_t len);
+
+/**
+ * Checks if string is empty
+ *
+ * Parameters:
+ *   str: Pointer to a :c:type:`z_loaned_string_t` to check.
+ * Return:
+ *  ``true`` if conainer is empty, ``false`` otherwise.
+ */
+bool z_string_is_empty(const z_loaned_string_t *str);
+
 /************* Primitives **************/
 /**
  * Scouts for other Zenoh entities like routers and/or peers.

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1143,7 +1143,7 @@ size_t z_string_len(const z_loaned_string_t *str);
  * Return:
  *   ``0`` if creation successful, ``negative value`` otherwise.
  */
-int8_t z_string_wrap(z_owned_string_t *str, const char *value);
+int8_t z_string_from_str(z_owned_string_t *str, const char *value);
 
 /**
  * Builds an empty :c:type:`z_string_t`.
@@ -1164,7 +1164,7 @@ void z_string_empty(z_owned_string_t *str);
  * Return:
  *   ``0`` if creation successful, ``negative value`` otherwise.
  */
-int8_t z_string_from_substring(z_owned_string_t *str, const char *value, size_t len);
+int8_t z_string_from_substr(z_owned_string_t *str, const char *value, size_t len);
 
 /**
  * Checks if string is empty

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -25,6 +25,7 @@
 typedef char *_z_str_t;
 
 char *_z_str_clone(const char *src);
+char *_z_str_n_clone(const char *src, size_t len);
 void _z_str_clear(char *src);
 void _z_str_free(char **src);
 _Bool _z_str_eq(const char *left, const char *right);
@@ -72,6 +73,7 @@ typedef struct {
 _z_string_t _z_string_null(void);
 _Bool _z_string_check(const _z_string_t *value);
 _z_string_t _z_string_make(const char *value);
+_z_string_t _z_string_n_make(const char *value, size_t len);
 _z_string_t _z_string_wrap(char *value);
 _z_string_t *_z_string_make_as_ptr(const char *value);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -837,6 +837,24 @@ const z_loaned_encoding_t *z_reply_err_encoding(const z_loaned_reply_err_t *repl
 const char *z_string_data(const z_loaned_string_t *str) { return str->val; }
 size_t z_string_len(const z_loaned_string_t *str) { return str->len; }
 
+int8_t z_string_wrap(z_owned_string_t *str, const char *value) {
+    str->_val = _z_string_wrap((char *)value);
+    return _Z_RES_OK;
+}
+
+void z_string_empty(z_owned_string_t *str) {
+    str->_val.val = NULL;
+    str->_val.len = 0;
+}
+
+int8_t z_string_from_substring(z_owned_string_t *str, const char *value, size_t len) {
+    str->_val.val = (char *)value;
+    str->_val.len = len;
+    return _Z_RES_OK;
+}
+
+bool z_string_is_empty(const z_loaned_string_t *str) { return str->val == NULL; }
+
 #if Z_FEATURE_PUBLICATION == 1
 int8_t _z_undeclare_and_clear_publisher(_z_publisher_t *pub) {
     int8_t ret = _Z_RES_OK;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -837,19 +837,15 @@ const z_loaned_encoding_t *z_reply_err_encoding(const z_loaned_reply_err_t *repl
 const char *z_string_data(const z_loaned_string_t *str) { return str->val; }
 size_t z_string_len(const z_loaned_string_t *str) { return str->len; }
 
-int8_t z_string_wrap(z_owned_string_t *str, const char *value) {
-    str->_val = _z_string_wrap((char *)value);
+int8_t z_string_from_str(z_owned_string_t *str, const char *value) {
+    str->_val = _z_string_make(value);
     return _Z_RES_OK;
 }
 
-void z_string_empty(z_owned_string_t *str) {
-    str->_val.val = NULL;
-    str->_val.len = 0;
-}
+void z_string_empty(z_owned_string_t *str) { str->_val = _z_string_null(); }
 
-int8_t z_string_from_substring(z_owned_string_t *str, const char *value, size_t len) {
-    str->_val.val = (char *)value;
-    str->_val.len = len;
+int8_t z_string_from_substr(z_owned_string_t *str, const char *value, size_t len) {
+    str->_val = _z_string_n_make(value, len);
     return _Z_RES_OK;
 }
 

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -182,12 +182,12 @@ void _z_str_free(char **src) {
 
 void _z_str_copy(char *dst, const char *src) {
     size_t size = _z_str_size(src);
-    strncpy(dst, src, size);
+    strncpy(dst, src, size - 1);
     dst[size - 1] = '\0';  // No matter what, strings are always null-terminated upon copy
 }
 
 void _z_str_n_copy(char *dst, const char *src, size_t size) {
-    strncpy(dst, src, size);
+    strncpy(dst, src, size - 1);
     dst[size - 1] = '\0';  // No matter what, strings are always null-terminated upon copy
 }
 

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -36,6 +36,17 @@ _z_string_t _z_string_make(const char *value) {
     return s;
 }
 
+_z_string_t _z_string_n_make(const char *value, size_t len) {
+    _z_string_t s;
+    s.val = _z_str_n_clone(value, len);
+    if (s.val == NULL) {
+        s.len = 0;
+    } else {
+        s.len = len;
+    }
+    return s;
+}
+
 _z_string_t _z_string_wrap(char *value) {
     _z_string_t s;
     s.val = value;
@@ -185,6 +196,15 @@ char *_z_str_clone(const char *src) {
     char *dst = (char *)z_malloc(len);
     if (dst != NULL) {
         _z_str_n_copy(dst, src, len);
+    }
+
+    return dst;
+}
+
+char *_z_str_n_clone(const char *src, size_t len) {
+    char *dst = (char *)z_malloc(len + 1);
+    if (dst != NULL) {
+        _z_str_n_copy(dst, src, len + 1);
     }
 
     return dst;


### PR DESCRIPTION
Add methods:
 - z_string_empty
 - z_string_from_str
 - z_string_from_substr
 - z_string_is_empty

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/470