### PR TITLE
add "close" support for channel handlers

### DIFF
--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -391,12 +391,12 @@ inline void z_drop(z_owned_closure_query_t* v) { z_closure_query_drop(v); }
 inline void z_drop(z_owned_closure_reply_t* v) { z_closure_reply_drop(v); }
 inline void z_drop(z_owned_closure_hello_t* v) { z_closure_hello_drop(v); }
 inline void z_drop(z_owned_closure_zid_t* v) { z_closure_zid_drop(v); }
-inline void z_drop(z_owned_sample_ring_channel_t* v) { z_sample_ring_channel_drop(v); }
-inline void z_drop(z_owned_sample_fifo_channel_t* v) { z_sample_fifo_channel_drop(v); }
-inline void z_drop(z_owned_query_ring_channel_t* v) { z_query_ring_channel_drop(v); }
-inline void z_drop(z_owned_query_fifo_channel_t* v) { z_query_fifo_channel_drop(v); }
-inline void z_drop(z_owned_reply_ring_channel_t* v) { z_reply_ring_channel_drop(v); }
-inline void z_drop(z_owned_reply_fifo_channel_t* v) { z_reply_fifo_channel_drop(v); }
+inline void z_drop(z_owned_ring_handler_sample_t* v) { z_ring_handler_sample_drop(v); }
+inline void z_drop(z_owned_fifo_handler_sample_t* v) { z_fifo_handler_sample_drop(v); }
+inline void z_drop(z_owned_ring_handler_query_t* v) { z_ring_handler_query_drop(v); }
+inline void z_drop(z_owned_fifo_handler_query_t* v) { z_fifo_handler_query_drop(v); }
+inline void z_drop(z_owned_ring_handler_reply_t* v) { z_ring_handler_reply_drop(v); }
+inline void z_drop(z_owned_fifo_handler_reply_t* v) { z_fifo_handler_reply_drop(v); }
 
 // z_null definition
 

--- a/include/zenoh-pico/collections/fifo_mt.h
+++ b/include/zenoh-pico/collections/fifo_mt.h
@@ -23,6 +23,7 @@
 /*-------- Fifo Buffer Multithreaded --------*/
 typedef struct {
     _z_fifo_t _fifo;
+    _Bool is_closed;
 #if Z_FEATURE_MULTI_THREAD == 1
     _z_mutex_t _mutex;
     _z_condvar_t _cv_not_full;
@@ -33,6 +34,7 @@ typedef struct {
 int8_t _z_fifo_mti_init(size_t capacity);
 _z_fifo_mt_t *_z_fifo_mt_new(size_t capacity);
 
+int8_t _z_fifo_mt_close(_z_fifo_mt_t *fifo);
 void _z_fifo_mt_clear(_z_fifo_mt_t *fifo, z_element_free_f free_f);
 void _z_fifo_mt_free(_z_fifo_mt_t *fifo, z_element_free_f free_f);
 

--- a/include/zenoh-pico/collections/ring_mt.h
+++ b/include/zenoh-pico/collections/ring_mt.h
@@ -23,6 +23,7 @@
 /*-------- Ring Buffer Multithreaded --------*/
 typedef struct {
     _z_ring_t _ring;
+    _Bool is_closed;
 #if Z_FEATURE_MULTI_THREAD == 1
     _z_mutex_t _mutex;
     _z_condvar_t _cv_not_empty;
@@ -31,6 +32,7 @@ typedef struct {
 
 int8_t _z_ring_mt_init(_z_ring_mt_t *ring, size_t capacity);
 _z_ring_mt_t *_z_ring_mt_new(size_t capacity);
+int8_t _z_ring_mt_close(_z_ring_mt_t *ring);
 
 void _z_ring_mt_clear(_z_ring_mt_t *ring, z_element_free_f free_f);
 void _z_ring_mt_free(_z_ring_mt_t *ring, z_element_free_f free_f);

--- a/include/zenoh-pico/system/platform-common.h
+++ b/include/zenoh-pico/system/platform-common.h
@@ -107,6 +107,7 @@ int8_t _z_condvar_init(_z_condvar_t *cv);
 int8_t _z_condvar_drop(_z_condvar_t *cv);
 
 int8_t _z_condvar_signal(_z_condvar_t *cv);
+int8_t _z_condvar_signal_all(_z_condvar_t *cv);
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m);
 
 _Z_OWNED_TYPE_VALUE(_z_condvar_t, condvar)

--- a/include/zenoh-pico/utils/result.h
+++ b/include/zenoh-pico/utils/result.h
@@ -30,6 +30,7 @@ typedef int8_t z_error_t;
 /*------------------ Result Enums ------------------*/
 typedef enum {
     _Z_RES_OK = 0,
+    _Z_RES_CHANNEL_CLOSED = 1,
 
     _Z_ERR_MESSAGE_DESERIALIZATION_FAILED = -119,
     _Z_ERR_MESSAGE_SERIALIZATION_FAILED = -118,

--- a/src/collections/fifo_mt.c
+++ b/src/collections/fifo_mt.c
@@ -21,6 +21,7 @@
 /*-------- Fifo Buffer Multithreaded --------*/
 int8_t _z_fifo_mt_init(_z_fifo_mt_t *fifo, size_t capacity) {
     _Z_RETURN_IF_ERR(_z_fifo_init(&fifo->_fifo, capacity))
+    fifo->is_closed = false;
 
 #if Z_FEATURE_MULTI_THREAD == 1
     _Z_RETURN_IF_ERR(_z_mutex_init(&fifo->_mutex))
@@ -89,6 +90,18 @@ int8_t _z_fifo_mt_push(const void *elem, void *context, z_element_free_f element
     return _Z_RES_OK;
 }
 
+int8_t _z_fifo_mt_close(_z_fifo_mt_t *fifo) {
+#if Z_FEATURE_MULTI_THREAD == 1
+    _Z_RETURN_IF_ERR(_z_mutex_lock(&fifo->_mutex))
+    fifo->is_closed = true;
+    _Z_RETURN_IF_ERR(_z_condvar_signal_all(&fifo->_cv_not_empty))
+    _Z_RETURN_IF_ERR(_z_mutex_unlock(&fifo->_mutex))
+#else
+    fifo->is_closed = true;
+#endif
+    return _Z_RES_OK;
+}
+
 int8_t _z_fifo_mt_pull(void *dst, void *context, z_element_move_f element_move) {
     _z_fifo_mt_t *f = (_z_fifo_mt_t *)context;
 
@@ -98,17 +111,21 @@ int8_t _z_fifo_mt_pull(void *dst, void *context, z_element_move_f element_move) 
     while (src == NULL) {
         src = _z_fifo_pull(&f->_fifo);
         if (src == NULL) {
+            if (f->is_closed) break;
             _Z_RETURN_IF_ERR(_z_condvar_wait(&f->_cv_not_empty, &f->_mutex))
         } else {
             _Z_RETURN_IF_ERR(_z_condvar_signal(&f->_cv_not_full))
         }
     }
     _Z_RETURN_IF_ERR(_z_mutex_unlock(&f->_mutex))
+    if (f->is_closed && src == NULL) return _Z_RES_CHANNEL_CLOSED;
     element_move(dst, src);
 #else   // Z_FEATURE_MULTI_THREAD == 1
     void *src = _z_fifo_pull(&f->_fifo);
     if (src != NULL) {
         element_move(dst, src);
+    } else if (f->is_closed) {
+        return _Z_RES_CHANNEL_CLOSED;
     }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
@@ -132,6 +149,8 @@ int8_t _z_fifo_mt_try_pull(void *dst, void *context, z_element_move_f element_mo
 
     if (src != NULL) {
         element_move(dst, src);
+    } else if (f->is_closed) {
+        return _Z_RES_CHANNEL_CLOSED;
     }
 
     return _Z_RES_OK;

--- a/src/system/arduino/esp32/system.c
+++ b/src/system/arduino/esp32/system.c
@@ -111,6 +111,8 @@ int8_t _z_condvar_free(_z_condvar_t *cv) { return pthread_cond_destroy(cv); }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return pthread_cond_signal(cv); }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return pthread_cond_broadcast(cv); }
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return pthread_cond_wait(cv, m); }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/src/system/arduino/opencr/system.c
+++ b/src/system/arduino/opencr/system.c
@@ -92,6 +92,7 @@ int8_t _z_condvar_init(_z_condvar_t *cv) { return -1; }
 int8_t _z_condvar_drop(_z_condvar_t *cv) { return -1; }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return -1; }
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return -1; }
 
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return -1; }
 #endif  // Z_FEATURE_MULTI_THREAD == 1

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -76,6 +76,8 @@ int8_t _z_condvar_drop(_z_condvar_t *cv) { return pthread_cond_destroy(cv); }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return pthread_cond_signal(cv); }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return pthread_cond_broadcast(cv); }
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return pthread_cond_wait(cv, m); }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -143,6 +143,8 @@ int8_t _z_condvar_drop(_z_condvar_t *cv) { return pthread_cond_destroy(cv); }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return pthread_cond_signal(cv); }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return pthread_cond_broadcast(cv); }
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return pthread_cond_wait(cv, m); }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/src/system/flipper/system.c
+++ b/src/system/flipper/system.c
@@ -147,6 +147,8 @@ int8_t _z_condvar_drop(_z_condvar_t* cv) { return -1; }
 
 int8_t _z_condvar_signal(_z_condvar_t* cv) { return -1; }
 
+int8_t _z_condvar_signal_all(_z_condvar_t* cv) { return -1; }
+
 int8_t _z_condvar_wait(_z_condvar_t* cv, _z_mutex_t* m) { return -1; }
 
 /*------------------ Sleep ------------------*/

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -156,6 +156,7 @@ int8_t _z_mutex_unlock(_z_mutex_t *m) { return xSemaphoreGiveRecursive(*m) == pd
 int8_t _z_condvar_init(_z_condvar_t *cv) { return -1; }
 int8_t _z_condvar_drop(_z_condvar_t *cv) { return -1; }
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return -1; }
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return -1; }
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return -1; }
 #endif  // Z_MULTI_THREAD == 1
 

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -97,6 +97,11 @@ int8_t _z_condvar_drop(_z_condvar_t *cv) {
 }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) {
+    ((ConditionVariable *)*cv)->notify_one();
+    return 0;
+}
+
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) {
     ((ConditionVariable *)*cv)->notify_all();
     return 0;
 }

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -133,6 +133,8 @@ int8_t _z_condvar_drop(_z_condvar_t *cv) { return (int8_t)pthread_cond_destroy(c
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return (int8_t)pthread_cond_signal(cv); }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return (int8_t)pthread_cond_broadcast(cv); }
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return (int8_t)pthread_cond_wait(cv, m); }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -143,7 +143,7 @@ int8_t _z_condvar_signal(_z_condvar_t *cv) {
 
 int8_t _z_condvar_signal_all(_z_condvar_t *cv) {
     int8_t ret = _Z_RES_OK;
-    WakeAllConditionVariables(cv);
+    WakeAllConditionVariable(cv);
     return ret;
 }
 

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -141,6 +141,12 @@ int8_t _z_condvar_signal(_z_condvar_t *cv) {
     return ret;
 }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) {
+    int8_t ret = _Z_RES_OK;
+    WakeAllConditionVariables(cv);
+    return ret;
+}
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) {
     int8_t ret = _Z_RES_OK;
     SleepConditionVariableSRW(cv, m, INFINITE, 0);

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -111,6 +111,8 @@ int8_t _z_condvar_drop(_z_condvar_t *cv) { return pthread_cond_destroy(cv); }
 
 int8_t _z_condvar_signal(_z_condvar_t *cv) { return pthread_cond_signal(cv); }
 
+int8_t _z_condvar_signal_all(_z_condvar_t *cv) { return pthread_cond_broadcast(cv); }
+
 int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return pthread_cond_wait(cv, m); }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/zenohpico.pc
+++ b/zenohpico.pc
@@ -3,6 +3,6 @@ prefix=/usr/local
 Name: zenohpico
 Description: 
 URL: 
-Version: 1.0.20240702dev
+Version: 1.0.20240703dev
 Cflags: -I${prefix}/include
 Libs: -L${prefix}/lib -lzenohpico


### PR DESCRIPTION
add "close" support for channel handlers to allow z_recv, z_try_recv to return true / false depending whether the channel is disconnected or not as it is done in zenoh-c;