### PR TITLE
Add timestamp to the put/delete options

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -256,12 +256,14 @@ typedef struct {
  *   z_owned_encoding_t *encoding: The encoding of the payload.
  *   z_congestion_control_t congestion_control: The congestion control to apply when routing this message.
  *   z_priority_t priority: The priority of this message when routed.
+ *   z_timestamp_t *timestamp: The API level timestamp (e.g. of the data when it was created).
  *   z_owned_bytes_t *attachment: An optional attachment to the publication.
  */
 typedef struct {
     z_owned_encoding_t *encoding;
     z_congestion_control_t congestion_control;
     z_priority_t priority;
+    z_timestamp_t *timestamp;
     z_owned_bytes_t *attachment;
 } z_put_options_t;
 
@@ -271,10 +273,12 @@ typedef struct {
  * Members:
  *   z_congestion_control_t congestion_control: The congestion control to apply when routing this message.
  *   z_priority_t priority: The priority of this message when router.
+ *   z_timestamp_t *timestamp: The API level timestamp (e.g. of the data when it was created).
  */
 typedef struct {
     z_congestion_control_t congestion_control;
     z_priority_t priority;
+    z_timestamp_t *timestamp;
 } z_delete_options_t;
 
 /**
@@ -283,19 +287,24 @@ typedef struct {
  *
  * Members:
  *   z_owned_encoding_t *encoding: The encoding of the payload.
+ *   z_timestamp_t *timestamp: The API level timestamp (e.g. of the data when it was created).
  *   z_owned_bytes_t *attachment: An optional attachment to the publication.
  */
 typedef struct {
     z_owned_encoding_t *encoding;
+    z_timestamp_t *timestamp;
     z_owned_bytes_t *attachment;
 } z_publisher_put_options_t;
 
 /**
  * Represents the configuration used to configure a delete operation by a previously declared publisher,
  * sent via :c:func:`z_publisher_delete`.
+ *
+ * Members:
+ *   z_timestamp_t *timestamp: The API level timestamp (e.g. of the data when it was created).
  */
 typedef struct {
-    uint8_t __dummy;  // Just to avoid empty structures that might cause undefined behavior
+    z_timestamp_t *timestamp;
 } z_publisher_delete_options_t;
 
 /**

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -114,13 +114,14 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub);
  *     kind: The kind of the value.
  *     cong_ctrl: The congestion control of this write. Possible values defined
  *                in :c:type:`_z_congestion_control_t`.
+ *     timestamp: The timestamp of this write. The API level timestamp (e.g. of the data when it was created).
  *     attachment: An optional attachment to this write.
  * Returns:
  *     ``0`` in case of success, ``-1`` in case of failure.
  */
 int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t payload, const _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
-                const _z_bytes_t attachment);
+                const _z_timestamp_t *timestamp, const _z_bytes_t attachment);
 #endif
 
 #if Z_FEATURE_SUBSCRIPTION == 1

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -129,7 +129,7 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub) {
 /*------------------ Write ------------------*/
 int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload, const _z_encoding_t encoding,
                 const z_sample_kind_t kind, const z_congestion_control_t cong_ctrl, z_priority_t priority,
-                const _z_bytes_t attachment) {
+                const _z_timestamp_t *timestamp, const _z_bytes_t attachment) {
     int8_t ret = _Z_RES_OK;
     _z_network_message_t msg;
     switch (kind) {
@@ -144,7 +144,8 @@ int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t p
                         ._body._is_put = true,
                         ._body._body._put =
                             {
-                                ._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()},
+                                ._commons = {._timestamp = ((timestamp != NULL) ? *timestamp : _z_timestamp_null()),
+                                             ._source_info = _z_source_info_null()},
                                 ._payload = payload,
                                 ._encoding = encoding,
                                 ._attachment = attachment,
@@ -161,7 +162,8 @@ int8_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t p
                         ._qos = _z_n_qos_make(0, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK, priority),
                         ._timestamp = _z_timestamp_null(),
                         ._body._is_put = false,
-                        ._body._body._del = {._commons = {._timestamp = _z_timestamp_null(),
+                        ._body._body._del = {._commons = {._timestamp =
+                                                              ((timestamp != NULL) ? *timestamp : _z_timestamp_null()),
                                                           ._source_info = _z_source_info_null()}},
                     },
             };


### PR DESCRIPTION
Add timestamp field to the:
 - z_put_options_t
 - z_delete_options_t
 - z_publisher_put_options_t
 - z_publisher_delete_options_t

Partially closed:
https://github.com/eclipse-zenoh/zenoh-pico/issues/468
https://github.com/eclipse-zenoh/zenoh-pico/issues/457