### PR TITLE
Temporary fix for fragmentation test.

### DIFF
--- a/src/protocol/definitions/transport.c
+++ b/src/protocol/definitions/transport.c
@@ -122,7 +122,9 @@ _z_transport_message_t _z_t_msg_make_init_syn(z_whatami_t whatami, _z_id_t zid) 
     msg._body._init._zid = zid;
     msg._body._init._seq_num_res = Z_SN_RESOLUTION;
     msg._body._init._req_id_res = Z_REQ_RESOLUTION;
-    msg._body._init._batch_size = Z_BATCH_UNICAST_SIZE;
+    msg._body._init._batch_size = (Z_BATCH_UNICAST_SIZE + _Z_MSG_LEN_ENC_SIZE > UINT16_MAX)
+                                      ? Z_BATCH_UNICAST_SIZE
+                                      : Z_BATCH_UNICAST_SIZE + _Z_MSG_LEN_ENC_SIZE;
     _z_slice_reset(&msg._body._init._cookie);
 
     if ((msg._body._init._batch_size != _Z_DEFAULT_UNICAST_BATCH_SIZE) ||

--- a/tests/z_test_fragment_tx.c
+++ b/tests/z_test_fragment_tx.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
         printf("[tx]: Sending packet on %s, len: %d\n", keyexpr, (int)size);
         if (z_put(z_loan(s), z_loan(ke), z_move(payload), NULL) < 0) {
             printf("Oh no! Put has failed...\n");
+            return -1;
         }
         z_sleep_s(1);
     }


### PR DESCRIPTION
Due to #512 , fragmentation test is currently failing. This is only a temporary fix while we find a way to realign pico and Zenoh on how to measure mtu/batch_size.