### PR TITLE
compatibility fixes for Zenoh-cpp

### DIFF
--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -14,6 +14,9 @@
 #ifndef INCLUDE_ZENOH_PICO_API_HANDLERS_H
 #define INCLUDE_ZENOH_PICO_API_HANDLERS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stdint.h>
 
 #include "zenoh-pico/api/primitives.h"
@@ -187,4 +190,7 @@ _Z_CHANNEL_DEFINE_DUMMY(reply, ring)
 _Z_CHANNEL_DEFINE_DUMMY(reply, fifo)
 #endif  // Z_FEATURE_QUERY
 
+#ifdef __cplusplus
+}
+#endif
 #endif  // INCLUDE_ZENOH_PICO_API_HANDLERS_H

--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -14,9 +14,6 @@
 #ifndef INCLUDE_ZENOH_PICO_API_HANDLERS_H
 #define INCLUDE_ZENOH_PICO_API_HANDLERS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <stdint.h>
 
 #include "zenoh-pico/api/primitives.h"
@@ -25,6 +22,10 @@ extern "C" {
 #include "zenoh-pico/collections/fifo_mt.h"
 #include "zenoh-pico/collections/ring_mt.h"
 #include "zenoh-pico/utils/logging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // -- Channel
 #define _Z_CHANNEL_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,          \

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -768,7 +768,54 @@ template <>
 struct z_loaned_to_owned_type_t<z_loaned_closure_zid_t> {
     typedef z_owned_closure_zid_t type;
 };
-
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_fifo_handler_query_t> {
+    typedef z_owned_fifo_handler_query_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_fifo_handler_query_t> {
+    typedef z_loaned_fifo_handler_query_t type;
+};
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_fifo_handler_reply_t> {
+    typedef z_owned_fifo_handler_reply_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_fifo_handler_reply_t> {
+    typedef z_loaned_fifo_handler_reply_t type;
+};
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_fifo_handler_sample_t> {
+    typedef z_owned_fifo_handler_sample_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_fifo_handler_sample_t> {
+    typedef z_loaned_fifo_handler_sample_t type;
+};
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_ring_handler_query_t> {
+    typedef z_owned_ring_handler_query_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_ring_handler_query_t> {
+    typedef z_loaned_ring_handler_query_t type;
+};
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_ring_handler_reply_t> {
+    typedef z_owned_ring_handler_reply_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_ring_handler_reply_t> {
+    typedef z_loaned_ring_handler_reply_t type;
+};
+template <>
+struct z_loaned_to_owned_type_t<z_loaned_ring_handler_sample_t> {
+    typedef z_owned_ring_handler_sample_t type;
+};
+template <>
+struct z_owned_to_loaned_type_t<z_owned_ring_handler_sample_t> {
+    typedef z_loaned_ring_handler_sample_t type;
+};
 #endif
 
 #endif /* ZENOH_C_STANDARD != 99 */

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1419,9 +1419,9 @@ const z_loaned_bytes_t *z_sample_payload(const z_loaned_sample_t *sample);
  *   sample: Pointer to a :c:type:`z_loaned_sample_t` to get the timestamp from.
  *
  * Return:
- *   The timestamp wrapped as a :c:type:`z_timestamp_t`.
+ *   The pointer to timestamp wrapped as a :c:type:`z_timestamp_t`. Returns NULL if no timestamp was set.
  */
-z_timestamp_t z_sample_timestamp(const z_loaned_sample_t *sample);
+const z_timestamp_t *z_sample_timestamp(const z_loaned_sample_t *sample);
 
 /**
  * Gets the encoding of a sample by aliasing it.

--- a/include/zenoh-pico/collections/fifo_mt.h
+++ b/include/zenoh-pico/collections/fifo_mt.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/fifo.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Fifo Buffer Multithreaded --------*/
 typedef struct {
     _z_fifo_t _fifo;
@@ -42,5 +46,9 @@ int8_t _z_fifo_mt_push(const void *src, void *context, z_element_free_f element_
 
 int8_t _z_fifo_mt_pull(void *dst, void *context, z_element_move_f element_move);
 int8_t _z_fifo_mt_try_pull(void *dst, void *context, z_element_move_f element_move);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // ZENOH_PICO_COLLECTIONS_FIFO_MT_H

--- a/include/zenoh-pico/collections/refcount.h
+++ b/include/zenoh-pico/collections/refcount.h
@@ -39,6 +39,7 @@
 #define _z_memory_order_release memory_order_release
 #define _z_memory_order_relaxed memory_order_relaxed
 #else
+extern "C++" {
 #include <atomic>
 #define _z_atomic(X) std::atomic<X>
 #define _z_atomic_store_explicit std::atomic_store_explicit
@@ -323,5 +324,9 @@
         _ZP_UNUSED(p);                                                                          \
         return sizeof(name##_rc_t);                                                             \
     }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_REFCOUNT_H */

--- a/include/zenoh-pico/collections/refcount.h
+++ b/include/zenoh-pico/collections/refcount.h
@@ -23,6 +23,9 @@
 
 #define _Z_RC_MAX_COUNT INT32_MAX  // Based on Rust lazy overflow check
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
 #if Z_FEATURE_MULTI_THREAD == 1
 #if ZENOH_C_STANDARD != 99
 
@@ -39,7 +42,6 @@
 #define _z_memory_order_release memory_order_release
 #define _z_memory_order_relaxed memory_order_relaxed
 #else
-extern "C++" {
 #include <atomic>
 #define _z_atomic(X) std::atomic<X>
 #define _z_atomic_store_explicit std::atomic_store_explicit

--- a/include/zenoh-pico/collections/ring_mt.h
+++ b/include/zenoh-pico/collections/ring_mt.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/fifo.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Ring Buffer Multithreaded --------*/
 typedef struct {
     _z_ring_t _ring;
@@ -41,5 +45,9 @@ int8_t _z_ring_mt_push(const void *src, void *context, z_element_free_f element_
 
 int8_t _z_ring_mt_pull(void *dst, void *context, z_element_move_f element_move);
 int8_t _z_ring_mt_try_pull(void *dst, void *context, z_element_move_f element_move);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // ZENOH_PICO_COLLECTIONS_RING_MT_H

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -38,7 +38,6 @@ typedef struct _z_reply_data_t {
 
 void _z_reply_data_clear(_z_reply_data_t *rd);
 int8_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
-_z_reply_t _z_reply_move(_z_reply_t *src_reply);
 
 _Z_ELEM_DEFINE(_z_reply_data, _z_reply_data_t, _z_noop_size, _z_reply_data_clear, _z_noop_copy)
 _Z_LIST_DEFINE(_z_reply_data, _z_reply_data_t)
@@ -56,6 +55,8 @@ typedef struct _z_reply_t {
     _z_reply_data_t data;
     z_reply_tag_t _tag;
 } _z_reply_t;
+
+_z_reply_t _z_reply_move(_z_reply_t *src_reply);
 
 _z_reply_t _z_reply_null(void);
 _Bool _z_reply_check(const _z_reply_t *reply);

--- a/include/zenoh-pico/utils/result.h
+++ b/include/zenoh-pico/utils/result.h
@@ -72,6 +72,7 @@ typedef enum {
 
     _Z_ERR_DID_NOT_READ = -76,
     _Z_ERR_INVALID = -75,
+    Z_EINVAL = -75,
 
     _Z_ERR_GENERIC = -128
 } _z_res_t;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -944,7 +944,13 @@ z_id_t z_info_zid(const z_loaned_session_t *zs) { return _Z_RC_IN_VAL(zs)._local
 const z_loaned_keyexpr_t *z_sample_keyexpr(const z_loaned_sample_t *sample) { return &sample->keyexpr; }
 z_sample_kind_t z_sample_kind(const z_loaned_sample_t *sample) { return sample->kind; }
 const z_loaned_bytes_t *z_sample_payload(const z_loaned_sample_t *sample) { return &sample->payload; }
-z_timestamp_t z_sample_timestamp(const z_loaned_sample_t *sample) { return sample->timestamp; }
+const z_timestamp_t *z_sample_timestamp(const z_loaned_sample_t *sample) {
+    if (_z_timestamp_check(&sample->timestamp)) {
+        return &sample->timestamp;
+    } else {
+        return NULL;
+    }
+}
 const z_loaned_encoding_t *z_sample_encoding(const z_loaned_sample_t *sample) { return &sample->encoding; }
 z_qos_t z_sample_qos(const z_loaned_sample_t *sample) { return sample->qos; }
 const z_loaned_bytes_t *z_sample_attachment(const z_loaned_sample_t *sample) { return &sample->attachment; }


### PR DESCRIPTION
z_sample_timestamp now returns const pointer to timestamp (same as zenoh-c, due to Zenoh-rust returning Option<&Timestamp>)
added extern "C" wrapper for handlers.h;
added extern "C++" wrapper for refcount.h (to overwrite higher-level extern "C" wrapper);
defined Z_EINVAL constant;
added missing macro-defines for channels;