### PR TITLE
Add malloc value guards for freertos

### DIFF
--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -136,11 +136,20 @@ void z_task_free(z_task_t **task) {
 
 /*------------------ Mutex ------------------*/
 int8_t z_mutex_init(z_mutex_t *m) {
+    if (m == NULL) {
+        return -1;
+    }
     *m = xSemaphoreCreateRecursiveMutex();
     return *m == NULL ? -1 : 0;
 }
 
 int8_t z_mutex_free(z_mutex_t *m) {
+    if (m == NULL) {
+        return -1;
+    }
+    if (*m == NULL) {
+        return 0;
+    }
     z_free(*m);
     return 0;
 }


### PR DESCRIPTION
Similar changes that were made to the flipper platform.
Should fix #477