### PR TITLE
Fix session close not to close session independently of refcount

### DIFF
--- a/examples/espidf/z_get.c
+++ b/examples/espidf/z_get.c
@@ -178,9 +178,6 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
 
     z_close(z_move(s));
     printf("OK!\n");

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -165,10 +165,6 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_move(pub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 }

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -171,10 +171,6 @@ void app_main() {
     // z_undeclare_pull_subscriber(z_move(sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 }

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -186,10 +186,6 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_move(qable));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 }

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -167,10 +167,6 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_move(sub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 }

--- a/examples/freertos_plus_tcp/z_get.c
+++ b/examples/freertos_plus_tcp/z_get.c
@@ -99,10 +99,6 @@ void app_main(void) {
         }
     }
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -108,8 +108,6 @@ void app_main(void) {
 
     // Clean-up
     z_undeclare_publisher(z_move(pub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -81,10 +81,6 @@ void app_main(void) {
     // z_undeclare_pull_subscriber(z_move(sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_put.c
+++ b/examples/freertos_plus_tcp/z_put.c
@@ -57,8 +57,6 @@ void app_main(void) {
     z_view_keyexpr_from_str_unchecked(&vke, KEYEXPR);
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        zp_stop_read_task(z_loan_mut(s));
-        zp_stop_lease_task(z_loan_mut(s));
         z_close(z_move(s));
         return;
     }
@@ -81,8 +79,6 @@ void app_main(void) {
 
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -97,10 +97,6 @@ void app_main(void) {
 
     z_undeclare_queryable(z_move(qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -77,10 +77,6 @@ void app_main(void) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }
 #else

--- a/examples/mbed/z_get.cpp
+++ b/examples/mbed/z_get.cpp
@@ -99,9 +99,6 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
 
     z_close(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -85,10 +85,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_publisher_move(&pub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
     printf("OK!\n");
 

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -90,10 +90,6 @@ int main(int argc, char **argv) {
     // z_undeclare_pull_subscriber(z_pull_subscriber_move(&sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
     printf("OK!\n");
 

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -104,10 +104,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_queryable_move(&qable));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
     printf("OK!\n");
 

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -88,10 +88,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
     printf("OK!\n");
 

--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -142,10 +142,6 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -231,10 +231,6 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_get_channel.c
+++ b/examples/unix/c11/z_get_channel.c
@@ -123,10 +123,6 @@ int main(int argc, char **argv) {
 
     z_drop(z_move(handler));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_info.c
+++ b/examples/unix/c11/z_info.c
@@ -96,9 +96,5 @@ int main(int argc, char **argv) {
     z_closure(&callback2, print_zid);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -135,9 +135,6 @@ int main(int argc, char** argv) {
     z_drop(z_move(pub));
     z_drop(z_move(sub));
 
-    zp_stop_read_task(z_loan_mut(session));
-    zp_stop_lease_task(z_loan_mut(session));
-
     z_close(z_move(session));
 }
 

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -74,9 +74,6 @@ int main(int argc, char** argv) {
 
     z_drop(z_move(sub));
 
-    zp_stop_read_task(z_loan_mut(session));
-    zp_stop_lease_task(z_loan_mut(session));
-
     z_close(z_move(session));
 }
 #else

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -120,8 +120,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -171,8 +171,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -69,8 +69,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     z_free(value);
     exit(0);

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -105,10 +105,6 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_put.c
+++ b/examples/unix/c11/z_put.c
@@ -90,9 +90,6 @@ int main(int argc, char **argv) {
     z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
-        printf("Unable to declare key expression!\n");
-        zp_stop_read_task(z_loan_mut(s));
-        zp_stop_lease_task(z_loan_mut(s));
         z_close(z_move(s));
         return -1;
     }
@@ -107,8 +104,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -162,10 +162,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -246,10 +246,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -128,10 +128,6 @@ int main(int argc, char **argv) {
     z_drop(z_move(handler));
     z_undeclare_queryable(z_move(qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -116,8 +116,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -172,8 +172,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -93,10 +93,6 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -110,8 +110,6 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     exit(0);
 }

--- a/examples/unix/c99/z_get.c
+++ b/examples/unix/c99/z_get.c
@@ -135,10 +135,6 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_condvar_loan_mut(&cond), z_mutex_loan_mut(&mutex));
     z_mutex_unlock(z_mutex_loan_mut(&mutex));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
 
     return 0;

--- a/examples/unix/c99/z_info.c
+++ b/examples/unix/c99/z_info.c
@@ -96,9 +96,5 @@ int main(int argc, char **argv) {
     z_closure_zid(&callback2, print_zid, NULL, NULL);
     z_info_peers_zid(z_session_loan(&s), z_closure_zid_move(&callback2));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
 }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -139,9 +139,6 @@ int main(int argc, char** argv) {
     z_undeclare_subscriber(z_subscriber_move(&sub));
     z_undeclare_publisher(z_publisher_move(&pub));
 
-    zp_stop_read_task(z_session_loan_mut(&session));
-    zp_stop_lease_task(z_session_loan_mut(&session));
-
     z_close(z_session_move(&session));
 }
 

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -81,9 +81,6 @@ int main(int argc, char** argv) {
 
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    zp_stop_read_task(z_session_loan_mut(&session));
-    zp_stop_lease_task(z_session_loan_mut(&session));
-
     z_close(z_session_move(&session));
 }
 #else

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -110,8 +110,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_publisher_move(&pub));
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
     z_close(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -101,10 +101,6 @@ int main(int argc, char **argv) {
     // z_undeclare_pull_subscriber(z_pull_subscriber_move(&sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
 
     return 0;

--- a/examples/unix/c99/z_put.c
+++ b/examples/unix/c99/z_put.c
@@ -87,8 +87,6 @@ int main(int argc, char **argv) {
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_session_loan(&s), z_view_keyexpr_loan(&vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        zp_stop_read_task(z_session_loan_mut(&s));
-        zp_stop_lease_task(z_session_loan_mut(&s));
         z_close(z_session_move(&s));
         return -1;
     }
@@ -104,8 +102,6 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_keyexpr(z_keyexpr_move(&ke), z_session_loan(&s));
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
     z_close(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -128,10 +128,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_queryable_move(&qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
 
     return 0;

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -108,10 +108,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_session_loan_mut(&s));
-    zp_stop_lease_task(z_session_loan_mut(&s));
-
     z_close(z_session_move(&s));
 
     return 0;

--- a/examples/windows/z_get.c
+++ b/examples/windows/z_get.c
@@ -99,10 +99,6 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/windows/z_info.c
+++ b/examples/windows/z_info.c
@@ -69,9 +69,5 @@ int main(int argc, char **argv) {
     z_closure(&callback2, print_zid);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 }

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -135,9 +135,6 @@ int main(int argc, char** argv) {
     z_drop(z_move(pub));
     z_drop(z_move(sub));
 
-    zp_stop_read_task(z_loan_mut(session));
-    zp_stop_lease_task(z_loan_mut(session));
-
     z_close(z_move(session));
 }
 

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -77,9 +77,6 @@ int main(int argc, char** argv) {
 
     z_drop(z_move(sub));
 
-    zp_stop_read_task(z_loan_mut(session));
-    zp_stop_lease_task(z_loan_mut(session));
-
     z_close(z_move(session));
 }
 #else

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -78,10 +78,6 @@ int main(int argc, char **argv) {
     // z_undeclare_pull_subscriber(z_move(sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/windows/z_put.c
+++ b/examples/windows/z_put.c
@@ -54,8 +54,6 @@ int main(int argc, char **argv) {
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        zp_stop_read_task(z_loan_mut(s));
-        zp_stop_lease_task(z_loan_mut(s));
         z_close(z_move(s));
         return -1;
     }
@@ -71,8 +69,6 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -92,10 +92,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -75,10 +75,6 @@ int main(int argc, char **argv) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
 
     return 0;

--- a/examples/zephyr/z_get.c
+++ b/examples/zephyr/z_get.c
@@ -96,9 +96,6 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
 
     z_close(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -82,10 +82,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_move(pub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -84,10 +84,6 @@ int main(int argc, char **argv) {
     // z_undeclare_pull_subscriber(z_move(sub));
     printf("Pull Subscriber not supported... exiting\n");
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -99,10 +99,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_move(qable));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -82,10 +82,6 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_move(sub));
 
-    // Stop the receive and the session lease loop for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     z_close(z_move(s));
     printf("OK!\n");
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -893,7 +893,6 @@ int8_t z_close(z_owned_session_t *zs) {
     if (zs == NULL || !z_session_check(zs)) {
         return _Z_RES_OK;
     }
-    _z_close(&_Z_OWNED_RC_IN_VAL(zs));
     z_session_drop(zs);
     return _Z_RES_OK;
 }

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -101,8 +101,10 @@ int8_t _z_session_init(_z_session_rc_t *zsrc, _z_id_t *zid) {
 }
 
 void _z_session_clear(_z_session_t *zn) {
+#if Z_FEATURE_MULTI_THREAD == 1
     _zp_stop_read_task(zn);
     _zp_stop_lease_task(zn);
+#endif
     _z_close(zn);
     // Clear Zenoh PID
     // Clean up transports

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -101,8 +101,10 @@ int8_t _z_session_init(_z_session_rc_t *zsrc, _z_id_t *zid) {
 }
 
 void _z_session_clear(_z_session_t *zn) {
+    _zp_stop_read_task(zn);
+    _zp_stop_lease_task(zn);
+    _z_close(zn);
     // Clear Zenoh PID
-
     // Clean up transports
     _z_transport_clear(&zn->_tp);
 

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -388,15 +388,6 @@ int main(int argc, char **argv) {
 
     z_sleep_s(SLEEP);
 
-    // Stop both sessions
-    printf("Stopping threads on session 1\n");
-    zp_stop_read_task(z_loan_mut(s1));
-    zp_stop_lease_task(z_loan_mut(s1));
-
-    printf("Stopping threads on session 2\n");
-    zp_stop_read_task(z_loan_mut(s2));
-    zp_stop_lease_task(z_loan_mut(s2));
-
     // Close both sessions
     printf("Closing session 1\n");
     z_close(z_move(s1));

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -177,15 +177,6 @@ int main(int argc, char **argv) {
 
     z_sleep_s(SLEEP);
 
-    // Stop both sessions
-    printf("Stopping threads on session 1\n");
-    zp_stop_read_task(z_loan_mut(s1));
-    zp_stop_lease_task(z_loan_mut(s1));
-
-    printf("Stopping threads on session 2\n");
-    zp_stop_read_task(z_loan_mut(s2));
-    zp_stop_lease_task(z_loan_mut(s2));
-
     // Close both sessions
     printf("Closing session 1\n");
     z_close(z_move(s1));

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -120,8 +120,6 @@ int main(int argc, char **argv) {
     z_sleep_s(1);
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     exit(0);
 }

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -108,8 +108,6 @@ int main(int argc, char **argv) {
     z_publisher_put(z_loan(pub), z_move(payload), NULL);
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     free(value);
     exit(0);

--- a/tests/z_session_test.c
+++ b/tests/z_session_test.c
@@ -43,10 +43,6 @@ int main(void) {
     // Commented out wait for 1 second. Stopping should work without it.
     // z_sleep_ms(1000);
 
-    // Stop read and lease tasks for zenoh-pico
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
-
     // Immediately close the session
     z_close(&s);
 }

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -96,8 +96,6 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     return 0;
 }

--- a/tests/z_test_fragment_tx.c
+++ b/tests/z_test_fragment_tx.c
@@ -89,8 +89,6 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
     // Clean up
-    zp_stop_read_task(z_loan_mut(s));
-    zp_stop_lease_task(z_loan_mut(s));
     z_close(z_move(s));
     free(value);
     return 0;

--- a/zenohpico.pc
+++ b/zenohpico.pc
@@ -3,6 +3,6 @@ prefix=/usr/local
 Name: zenohpico
 Description: 
 URL: 
-Version: 1.0.20240709dev
+Version: 1.0.20240711dev
 Cflags: -I${prefix}/include
 Libs: -L${prefix}/lib -lzenohpico


### PR DESCRIPTION
Fix session close to account for ref count;
Automatically stop read/lease task on session drop;