### PR TITLE
make owned functions for handlers inline

### DIFF
--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -23,10 +23,6 @@
 #include "zenoh-pico/collections/ring_mt.h"
 #include "zenoh-pico/utils/logging.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // -- Channel
 #define _Z_CHANNEL_DEFINE_IMPL(handler_type, handler_name, handler_new_f_name, callback_type, callback_new_f,          \
                                collection_type, collection_new_f, collection_free_f, collection_push_f,                \
@@ -106,8 +102,8 @@ extern "C" {
         return h;                                                                                                      \
     }                                                                                                                  \
                                                                                                                        \
-    _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(handler_type, handler_name, _z_##handler_name##_check,                       \
-                                          _z_##handler_name##_null, _z_##handler_name##_clear)                         \
+    _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_INLINE_IMPL(handler_type, handler_name, _z_##handler_name##_check,                \
+                                                 _z_##handler_name##_null, _z_##handler_name##_clear)                  \
                                                                                                                        \
     static inline int8_t handler_new_f_name(callback_type *callback, z_owned_##handler_name##_t *handler,              \
                                             size_t capacity) {                                                         \
@@ -191,7 +187,4 @@ _Z_CHANNEL_DEFINE_DUMMY(reply, ring)
 _Z_CHANNEL_DEFINE_DUMMY(reply, fifo)
 #endif  // Z_FEATURE_QUERY
 
-#ifdef __cplusplus
-}
-#endif
 #endif  // INCLUDE_ZENOH_PICO_API_HANDLERS_H

--- a/include/zenoh-pico/api/olv_macros.h
+++ b/include/zenoh-pico/api/olv_macros.h
@@ -113,16 +113,23 @@
     void z_##name##_drop(z_owned_##name##_t *obj) {                                                  \
         if (obj != NULL) f_drop((&obj->_val));                                                       \
     }
-
-#define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(type, name, f_check, f_null, f_drop)                   \
-    _Bool z_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }          \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; } \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }         \
-    void z_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                          \
-    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }                     \
-    void z_##name##_drop(z_owned_##name##_t *obj) {                                                  \
-        if (obj != NULL) f_drop((&obj->_val));                                                       \
+#define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_INNER(type, name, f_check, f_null, f_drop, attribute)            \
+    attribute _Bool z_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }          \
+    attribute const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; } \
+    attribute z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }         \
+    attribute void z_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                          \
+    attribute z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }                     \
+    attribute void z_##name##_drop(z_owned_##name##_t *obj) {                                                  \
+        if (obj != NULL) f_drop((&obj->_val));                                                                 \
     }
+
+#define _ZP_NOTHING
+
+#define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(type, name, f_check, f_null, f_drop) \
+    _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_INNER(type, name, f_check, f_null, f_drop, _ZP_NOTHING)
+
+#define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_INLINE_IMPL(type, name, f_check, f_null, f_drop) \
+    _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_INNER(type, name, f_check, f_null, f_drop, static inline)
 
 #define _Z_OWNED_FUNCTIONS_RC_IMPL(name)                                                            \
     _Bool z_##name##_check(const z_owned_##name##_t *val) { return val->_rc.in != NULL; }           \


### PR DESCRIPTION
make owned functions for handlers inline;
remove unnecessary extern C from handlers.h;
resolves #538