### PR TITLE
fix: use debian compatible arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,11 @@ if(PACKAGING)
 
   if(PACKAGING MATCHES "DEB")
     if(NOT DEBARCH)
-      set(DEBARCH ${CMAKE_SYSTEM_PROCESSOR})
+      execute_process(
+        COMMAND dpkg --print-architecture
+        OUTPUT_VARIABLE DEBARCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
     endif()
 
     message(STATUS "Configure DEB packaging for Linux ${DEBARCH}")

--- a/ci/scripts/build-linux.bash
+++ b/ci/scripts/build-linux.bash
@@ -5,7 +5,7 @@ set -xeo pipefail
 # Repository
 readonly repo=${REPO:?input REPO is required}
 # Release number
-readonly version=${VERSION:?input TARGET is required}
+readonly version=${VERSION:?input VERSION is required}
 # Build target
 readonly target=${TARGET:?input TARGET is required}
 


### PR DESCRIPTION
similar to what was done for zenoh-cpp:
https://github.com/eclipse-zenoh/zenoh-cpp/pull/137/files just for consistency since zenoh-pico debian packages were created with the correct `DEBARCH` as the env var is set earlier in the build process: https://github.com/eclipse-zenoh/zenoh-pico/blob/dev/1.0.0/GNUmakefile#L115-L138