### PR TITLE
Update zenoh-pico version in pio manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ configure_file(
   @ONLY
 )
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/library.json.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/library.json
+  @ONLY
+)
+
 set(project_version "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 if(NOT DEFINED PROJECT_VERSION_TWEAK)
 	set(project_version "${project_version}")

--- a/library.json.in
+++ b/library.json.in
@@ -1,6 +1,6 @@
 {
     "name": "zenoh-pico",
-    "version": "1.0.0.0",
+    "version": "@ZENOH_PICO_MAJOR@.@ZENOH_PICO_MINOR@.@ZENOH_PICO_PATCH@.@ZENOH_PICO_TWEAK@",
     "description": "The Eclipse Zenoh: Zero Overhead Pub/sub, Store/Query and Compute. It unifies data in motion, data in-use, data at rest and computations. It carefully blends traditional pub/sub with geo-distributed storages, queries and computations, while retaining a level of time and space efficiency that is well beyond any of the mainstream stacks. Zenoh-Pico is the implementation able to scale down to extremely constrainded devices and networks.",
     "keywords": [
         "pubsub",


### PR DESCRIPTION
It was still stuck in 0.11, now it will be updated along the other version numbers.