### PR TITLE
z_bytes_reader and z_bytes_writer update

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,6 +55,7 @@ Data Structures
 .. autoctype:: types.h::z_qos_t
 .. autoctype:: types.h::z_bytes_reader_t
 .. autoctype:: types.h::z_bytes_iterator_t
+.. autoctype:: types.h::z_owned_bytes_writer_t
   
 
 Owned Types
@@ -126,10 +127,6 @@ TODO: owned type description
 
   Represents an array of non null-terminated string.
 
-.. c:type:: z_owned_bytes_writer_t
-
-  Represents a writer for serialized data.
-
 Loaned Types
 ~~~~~~~~~~~
 
@@ -198,10 +195,6 @@ TODO: loaned type description
 .. c:type:: z_loaned_string_array_t
 
   Represents an array of non null-terminated string.
-
-.. c:type:: z_loaned_bytes_writer_t
-
-  Represents a writer for serialized data.
 
 View Types
 ~~~~~~~~~~~
@@ -367,10 +360,13 @@ Primitives
 .. autocfunction:: primitives.h::z_bytes_iterator_next
 .. autocfunction:: primitives.h::z_bytes_get_reader
 .. autocfunction:: primitives.h::z_bytes_reader_read
+.. autocfunction:: primitives.h::z_bytes_reader_read_bounded
 .. autocfunction:: primitives.h::z_bytes_reader_seek
 .. autocfunction:: primitives.h::z_bytes_reader_tell
 .. autocfunction:: primitives.h::z_bytes_get_writer
 .. autocfunction:: primitives.h::z_bytes_writer_write_all
+.. autocfunction:: primitives.h::z_bytes_writer_append
+.. autocfunction:: primitives.h::z_bytes_writer_append_bounded
 .. autocfunction:: primitives.h::z_timestamp_check
 .. autocfunction:: primitives.h::z_query_target_default
 .. autocfunction:: primitives.h::z_query_consolidation_auto

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,7 +55,7 @@ Data Structures
 .. autoctype:: types.h::z_qos_t
 .. autoctype:: types.h::z_bytes_reader_t
 .. autoctype:: types.h::z_bytes_iterator_t
-.. autoctype:: types.h::z_owned_bytes_writer_t
+.. autoctype:: types.h::z_bytes_writer_t
   
 
 Owned Types

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -333,7 +333,6 @@ inline const z_loaned_sample_t* z_loan(const z_owned_sample_t& x) { return z_sam
 inline const z_loaned_query_t* z_loan(const z_owned_query_t& x) { return z_query_loan(&x); }
 inline const z_loaned_slice_t* z_loan(const z_owned_slice_t& x) { return z_slice_loan(&x); }
 inline const z_loaned_bytes_t* z_loan(const z_owned_bytes_t& x) { return z_bytes_loan(&x); }
-inline const z_loaned_bytes_writer_t* z_loan(const z_owned_bytes_writer_t& x) { return z_bytes_writer_loan(&x); }
 inline const z_loaned_encoding_t* z_loan(const z_owned_encoding_t& x) { return z_encoding_loan(&x); }
 inline const z_loaned_task_t* z_loan(const z_owned_task_t& x) { return z_task_loan(&x); }
 inline const z_loaned_mutex_t* z_loan(const z_owned_mutex_t& x) { return z_mutex_loan(&x); }
@@ -367,7 +366,6 @@ inline z_loaned_sample_t* z_loan_mut(z_owned_sample_t& x) { return z_sample_loan
 inline z_loaned_query_t* z_loan_mut(z_owned_query_t& x) { return z_query_loan_mut(&x); }
 inline z_loaned_slice_t* z_loan_mut(z_owned_slice_t& x) { return z_slice_loan_mut(&x); }
 inline z_loaned_bytes_t* z_loan_mut(z_owned_bytes_t& x) { return z_bytes_loan_mut(&x); }
-inline z_loaned_bytes_writer_t* z_loan_mut(z_owned_bytes_writer_t& x) { return z_bytes_writer_loan_mut(&x); }
 inline z_loaned_encoding_t* z_loan_mut(z_owned_encoding_t& x) { return z_encoding_loan_mut(&x); }
 inline z_loaned_task_t* z_loan_mut(z_owned_task_t& x) { return z_task_loan_mut(&x); }
 inline z_loaned_mutex_t* z_loan_mut(z_owned_mutex_t& x) { return z_mutex_loan_mut(&x); }
@@ -389,7 +387,6 @@ inline void z_drop(z_owned_string_array_t* v) { z_string_array_drop(v); }
 inline void z_drop(z_owned_sample_t* v) { z_sample_drop(v); }
 inline void z_drop(z_owned_query_t* v) { z_query_drop(v); }
 inline void z_drop(z_owned_bytes_t* v) { z_bytes_drop(v); }
-inline void z_drop(z_owned_bytes_writer_t* v) { z_bytes_writer_drop(v); }
 inline void z_drop(z_owned_encoding_t* v) { z_encoding_drop(v); }
 inline void z_drop(z_owned_mutex_t* v) { z_mutex_drop(v); }
 inline void z_drop(z_owned_condvar_t* v) { z_condvar_drop(v); }
@@ -419,7 +416,6 @@ inline void z_null(z_owned_reply_t* v) { z_reply_null(v); }
 inline void z_null(z_owned_hello_t* v) { z_hello_null(v); }
 inline void z_null(z_owned_string_t* v) { z_string_null(v); }
 inline void z_null(z_owned_bytes_t* v) { z_bytes_null(v); }
-inline void z_null(z_owned_bytes_writer_t* v) { z_bytes_writer_null(v); }
 inline void z_null(z_owned_encoding_t* v) { z_encoding_null(v); }
 inline void z_null(z_owned_reply_err_t* v) { z_reply_err_null(v); }
 inline void z_null(z_owned_closure_sample_t* v) { z_closure_sample_null(v); }
@@ -449,7 +445,6 @@ inline bool z_check(const z_owned_string_t& v) { return z_string_check(&v); }
 inline bool z_check(const z_view_string_t& v) { return z_view_string_check(&v); }
 inline bool z_check(const z_owned_sample_t& v) { return z_sample_check(&v); }
 inline bool z_check(const z_owned_bytes_t& v) { return z_bytes_check(&v); }
-inline bool z_check(const z_owned_bytes_writer_t& v) { return z_bytes_writer_check(&v); }
 inline bool z_check(const z_owned_encoding_t& v) { return z_encoding_check(&v); }
 inline bool z_check(const z_owned_reply_err_t& v) { return z_reply_err_check(&v); }
 inline bool z_check(const z_owned_fifo_handler_query_t& v) { return z_fifo_handler_query_check(&v); };
@@ -559,7 +554,6 @@ inline bool z_recv(const z_loaned_ring_handler_sample_t* this_, z_owned_sample_t
 // clang-format on
 
 inline z_owned_bytes_t* z_move(z_owned_bytes_t& x) { return z_bytes_move(&x); };
-inline z_owned_bytes_writer_t* z_move(z_owned_bytes_writer_t& x) { return z_bytes_writer_move(&x); };
 inline z_owned_closure_hello_t* z_move(z_owned_closure_hello_t& closure) { return z_closure_hello_move(&closure); };
 inline z_owned_closure_query_t* z_move(z_owned_closure_query_t& closure) { return z_closure_query_move(&closure); };
 inline z_owned_closure_reply_t* z_move(z_owned_closure_reply_t& closure) { return z_closure_reply_move(&closure); };
@@ -598,14 +592,6 @@ struct z_loaned_to_owned_type_t<z_loaned_bytes_t> {
 template <>
 struct z_owned_to_loaned_type_t<z_owned_bytes_t> {
     typedef z_loaned_bytes_t type;
-};
-template <>
-struct z_loaned_to_owned_type_t<z_loaned_bytes_writer_t> {
-    typedef z_owned_bytes_writer_t type;
-};
-template <>
-struct z_owned_to_loaned_type_t<z_owned_bytes_writer_t> {
-    typedef z_loaned_bytes_writer_t type;
 };
 template <>
 struct z_loaned_to_owned_type_t<z_loaned_config_t> {

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1000,8 +1000,9 @@ z_bytes_reader_t z_bytes_get_reader(const z_loaned_bytes_t *bytes);
  *
  * Parameters:
  *  reader: Data reader to read from.
- *  dst: An uninitialized memory location where a new piece of data will be read. Note that it does not involve a copy, but only increases reference count.
- * 
+ *  dst: An uninitialized memory location where a new piece of data will be read. Note that it does not involve a copy,
+ * but only increases reference count.
+ *
  * Return:
  *  ​0​ upon success, negative error code otherwise.
  */
@@ -1070,25 +1071,26 @@ int8_t z_bytes_writer_write_all(z_bytes_writer_t *writer, const uint8_t *src, si
 
 /**
  * Appends bytes.
- * This allows to compose a serialized data out of multiple `z_owned_bytes_t` that may point to different memory regions.
- * Said in other terms, it allows to create a linear view on different memory regions without copy.
- * 
+ * This allows to compose a serialized data out of multiple `z_owned_bytes_t` that may point to different memory
+ * regions. Said in other terms, it allows to create a linear view on different memory regions without copy.
+ *
  * Parameters:
  *   writer: A data writer.
  *   bytes: A data to append.
- * 
+ *
  * Return:
  *  0 in case of success, negative error code otherwise
  */
 int8_t z_bytes_writer_append(z_bytes_writer_t *writer, z_owned_bytes_t *bytes);
 
 /**
- * Appends bytes, with boundaries information. It would allow to read the same piece of data using :c:func:`z_bytes_reader_read_bounded`.
- * 
+ * Appends bytes, with boundaries information. It would allow to read the same piece of data using
+ * :c:func:`z_bytes_reader_read_bounded`.
+ *
  * Parameters:
  *   writer: A data writer.
  *   bytes: A data to append.
- * 
+ *
  * Return:
  *  0 in case of success, negative error code otherwise
  */

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1000,6 +1000,18 @@ z_bytes_reader_t z_bytes_get_reader(const z_loaned_bytes_t *bytes);
  *
  * Parameters:
  *  reader: Data reader to read from.
+ *  dst: An uninitialized memory location where a new piece of data will be read. Note that it does not involve a copy, but only increases reference count.
+ * 
+ * Return:
+ *  ​0​ upon success, negative error code otherwise.
+ */
+int8_t z_bytes_reader_read_bounded(z_bytes_reader_t *reader, z_owned_bytes_t *dst);
+
+/**
+ * Reads data into specified destination.
+ *
+ * Parameters:
+ *  reader: Data reader to read from.
  *  dst: Buffer where the read data is written.
  *  len: Maximum number of bytes to read.
  *
@@ -1007,6 +1019,7 @@ z_bytes_reader_t z_bytes_get_reader(const z_loaned_bytes_t *bytes);
  *  Number of bytes read. If return value is smaller than `len`, it means that the end of the data was reached.
  */
 size_t z_bytes_reader_read(z_bytes_reader_t *reader, uint8_t *dst, size_t len);
+
 /**
  * Sets the `reader` position indicator for the payload to the value pointed to by offset.
  * The new position is exactly `offset` bytes measured from the beginning of the payload if origin is `SEEK_SET`,
@@ -1040,23 +1053,49 @@ int64_t z_bytes_reader_tell(z_bytes_reader_t *reader);
  *   writer: Uninitialized memory location where writer is to be constructed.
  *
  */
-void z_bytes_get_writer(z_loaned_bytes_t *bytes, z_owned_bytes_writer_t *writer);
+z_bytes_writer_t z_bytes_get_writer(z_loaned_bytes_t *bytes);
 
 /**
  * Writes `len` bytes from `src` into underlying :c:type:`z_loaned_bytes_t.
  *
  * Parameters:
- *   writer: A data writer
+ *   writer: A data writer.
  *   src: Buffer to write from.
  *   len: Number of bytes to write.
  *
  * Return:
  *   ``0`` if encode successful, ``negative value`` otherwise.
  */
-int8_t z_bytes_writer_write_all(z_loaned_bytes_writer_t *writer, const uint8_t *src, size_t len);
+int8_t z_bytes_writer_write_all(z_bytes_writer_t *writer, const uint8_t *src, size_t len);
 
 /**
- * Create timestamp
+ * Appends bytes.
+ * This allows to compose a serialized data out of multiple `z_owned_bytes_t` that may point to different memory regions.
+ * Said in other terms, it allows to create a linear view on different memory regions without copy.
+ * 
+ * Parameters:
+ *   writer: A data writer.
+ *   bytes: A data to append.
+ * 
+ * Return:
+ *  0 in case of success, negative error code otherwise
+ */
+int8_t z_bytes_writer_append(z_bytes_writer_t *writer, z_owned_bytes_t *bytes);
+
+/**
+ * Appends bytes, with boundaries information. It would allow to read the same piece of data using :c:func:`z_bytes_reader_read_bounded`.
+ * 
+ * Parameters:
+ *   writer: A data writer.
+ *   bytes: A data to append.
+ * 
+ * Return:
+ *  0 in case of success, negative error code otherwise
+ */
+int8_t z_bytes_writer_append_bounded(z_bytes_writer_t *writer, z_owned_bytes_t *bytes);
+
+/**
+ * Create timestamp.
  *
  * Parameters:
  *   ts: An uninitialized :c:type:`z_timestamp_t`.
@@ -1289,7 +1328,6 @@ _Z_OWNED_FUNCTIONS_DEF(sample)
 _Z_OWNED_FUNCTIONS_DEF(query)
 _Z_OWNED_FUNCTIONS_DEF(slice)
 _Z_OWNED_FUNCTIONS_DEF(bytes)
-_Z_OWNED_FUNCTIONS_DEF(bytes_writer)
 _Z_OWNED_FUNCTIONS_DEF(reply_err)
 _Z_OWNED_FUNCTIONS_DEF(encoding)
 

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -75,8 +75,7 @@ _Z_LOANED_TYPE(_z_bytes_t, bytes)
 /**
  * Represents a writer for serialized data.
  */
-_Z_OWNED_TYPE_VALUE(_z_bytes_writer_t, bytes_writer)
-_Z_LOANED_TYPE(_z_bytes_writer_t, bytes_writer)
+typedef _z_bytes_iterator_writer_t z_bytes_writer_t;
 
 /**
  * An iterator over multi-element serialized data.
@@ -86,7 +85,7 @@ typedef _z_bytes_iterator_t z_bytes_iterator_t;
 /**
  * A reader for serialized data.
  */
-typedef _z_bytes_reader_t z_bytes_reader_t;
+typedef _z_bytes_iterator_t z_bytes_reader_t;
 
 /**
  * Represents a string without null-terminator.

--- a/include/zenoh-pico/collections/bytes.h
+++ b/include/zenoh-pico/collections/bytes.h
@@ -106,12 +106,13 @@ typedef struct {
 
 _z_bytes_writer_t _z_bytes_get_writer(_z_bytes_t *bytes, size_t cache_size);
 int8_t _z_bytes_writer_write_all(_z_bytes_writer_t *writer, const uint8_t *src, size_t len);
+int8_t _z_bytes_writer_append(_z_bytes_writer_t *writer, _z_bytes_t *bytes);
 int8_t _z_bytes_writer_ensure_cache(_z_bytes_writer_t *writer);
 
 typedef struct {
     _z_bytes_writer_t writer;
 } _z_bytes_iterator_writer_t;
 
-_z_bytes_iterator_writer_t _z_bytes_get_iterator_writer(_z_bytes_t *bytes);
+_z_bytes_iterator_writer_t _z_bytes_get_iterator_writer(_z_bytes_t *bytes, size_t cache_size);
 int8_t _z_bytes_iterator_writer_write(_z_bytes_iterator_writer_t *writer, _z_bytes_t *bytes);
 #endif /* ZENOH_PICO_COLLECTIONS_BYTES_H */

--- a/src/collections/bytes.c
+++ b/src/collections/bytes.c
@@ -156,7 +156,7 @@ int8_t _z_bytes_append_bytes(_z_bytes_t *dst, _z_bytes_t *src) {
 
 int8_t _z_bytes_from_pair(_z_bytes_t *out, _z_bytes_t *first, _z_bytes_t *second) {
     *out = _z_bytes_null();
-    _z_bytes_iterator_writer_t writer = _z_bytes_get_iterator_writer(out);
+    _z_bytes_iterator_writer_t writer = _z_bytes_get_iterator_writer(out, 0);
     _Z_CLEAN_RETURN_IF_ERR(_z_bytes_iterator_writer_write(&writer, first), _z_bytes_drop(second));
     _Z_CLEAN_RETURN_IF_ERR(_z_bytes_iterator_writer_write(&writer, second), _z_bytes_drop(out));
 
@@ -433,8 +433,7 @@ int8_t _z_bytes_writer_ensure_cache(_z_bytes_writer_t *writer) {
     if (writer->cache != NULL) {
         _z_arc_slice_t *arc_s = _z_bytes_get_slice(writer->bytes, _z_bytes_num_slices(writer->bytes) - 1);
         if (_Z_RC_IN_VAL(&arc_s->slice)->start + arc_s->len == writer->cache) {
-            size_t remaining_in_cache = _Z_RC_IN_VAL(&arc_s->slice)->len - arc_s->len;
-            if (remaining_in_cache > 0) return _Z_RES_OK;
+            if (_Z_RC_IN_VAL(&arc_s->slice)->len > arc_s->len) return _Z_RES_OK;
         }
     }
     // otherwise we allocate a new cache
@@ -457,7 +456,7 @@ int8_t _z_bytes_writer_write_all(_z_bytes_writer_t *writer, const uint8_t *src, 
         _z_slice_t s = _z_slice_copy_from_buf(src, len);
         if (s.len != len) return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
         _z_arc_slice_t arc_s = _z_arc_slice_wrap(s, 0, len);
-        if _Z_RC_IS_NULL (&arc_s.slice) {
+        if (_Z_RC_IS_NULL(&arc_s.slice)) {
             _z_slice_clear(&s);
             return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
         }
@@ -478,14 +477,19 @@ int8_t _z_bytes_writer_write_all(_z_bytes_writer_t *writer, const uint8_t *src, 
     return _Z_RES_OK;
 }
 
-_z_bytes_iterator_writer_t _z_bytes_get_iterator_writer(_z_bytes_t *bytes) {
-    return (_z_bytes_iterator_writer_t){.writer = _z_bytes_get_writer(bytes, 0)};
+int8_t _z_bytes_writer_append(_z_bytes_writer_t *writer, _z_bytes_t *src) {
+    _Z_CLEAN_RETURN_IF_ERR(_z_bytes_append_bytes(writer->bytes, src), _z_bytes_drop(src));
+    writer->cache = NULL;
+    return _Z_RES_OK;
 }
+
+_z_bytes_iterator_writer_t _z_bytes_get_iterator_writer(_z_bytes_t *bytes, size_t cache_size) {
+    return (_z_bytes_iterator_writer_t){.writer = _z_bytes_get_writer(bytes, cache_size)};
+}
+
 int8_t _z_bytes_iterator_writer_write(_z_bytes_iterator_writer_t *writer, _z_bytes_t *src) {
     uint8_t l_buf[16];
     size_t l_len = _z_zsize_encode_buf(l_buf, _z_bytes_len(src));
     _Z_CLEAN_RETURN_IF_ERR(_z_bytes_writer_write_all(&writer->writer, l_buf, l_len), _z_bytes_drop(src));
-    _Z_CLEAN_RETURN_IF_ERR(_z_bytes_append_bytes(writer->writer.bytes, src), _z_bytes_drop(src));
-
-    return _Z_RES_OK;
+    return _z_bytes_writer_append(&writer->writer, src);
 }

--- a/tests/z_api_bytes_test.c
+++ b/tests/z_api_bytes_test.c
@@ -85,19 +85,85 @@ void test_writer(void) {
     z_owned_bytes_t payload;
     z_bytes_empty(&payload);
 
-    z_owned_bytes_writer_t writer;
-    z_bytes_get_writer(z_bytes_loan_mut(&payload), &writer);
+    z_bytes_writer_t writer = z_bytes_get_writer(z_bytes_loan_mut(&payload));
 
-    assert(z_bytes_writer_write_all(z_bytes_writer_loan_mut(&writer), data, 3) == 0);
-    assert(z_bytes_writer_write_all(z_bytes_writer_loan_mut(&writer), data + 3, 5) == 0);
-    assert(z_bytes_writer_write_all(z_bytes_writer_loan_mut(&writer), data + 8, 2) == 0);
-
-    z_bytes_writer_drop(z_bytes_writer_move(&writer));
+    assert(z_bytes_writer_write_all(&writer, data, 3) == 0);
+    assert(z_bytes_writer_write_all(&writer, data + 3, 5) == 0);
+    assert(z_bytes_writer_write_all(&writer, data + 8, 2) == 0);
 
     z_bytes_reader_t reader = z_bytes_get_reader(z_bytes_loan(&payload));
 
     assert(10 == z_bytes_reader_read(&reader, data_out, 10));
     assert(0 == memcmp(data, data_out, 10));
+
+    z_bytes_drop(z_bytes_move(&payload));
+}
+
+void test_bounded(void) {
+    uint32_t data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    uint32_t data_out[10] = {0};
+
+    z_owned_bytes_t payload;
+    z_bytes_empty(&payload);
+
+    z_bytes_writer_t writer = z_bytes_get_writer(z_bytes_loan_mut(&payload));
+    for (size_t i = 0; i < 10; ++i) {
+        z_owned_bytes_t b;
+        z_bytes_serialize_from_uint32(&b, data[i]);
+        assert(z_bytes_writer_append_bounded(&writer, z_bytes_move(&b)) == 0);
+    }
+    {
+        z_owned_bytes_t b;
+        z_bytes_serialize_from_str(&b, "test");
+        assert(z_bytes_writer_append_bounded(&writer, z_bytes_move(&b)) == 0);
+    }
+
+    z_bytes_reader_t reader = z_bytes_get_reader(z_bytes_loan(&payload));
+
+    for (size_t i = 0; i < 10; ++i) {
+        z_owned_bytes_t b;
+        assert(z_bytes_reader_read_bounded(&reader, &b) == 0);
+        assert(z_bytes_deserialize_into_uint32(z_bytes_loan(&b), &data_out[i]) == 0);
+        z_bytes_drop(z_bytes_move(&b));
+    }
+    assert(!memcmp(data, data_out, 10));
+    {
+        z_owned_string_t s;
+        z_owned_bytes_t b;
+        assert(z_bytes_reader_read_bounded(&reader, &b) == 0);
+        z_bytes_deserialize_into_string(z_bytes_loan(&b), &s);
+        assert(strncmp("test", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
+        z_bytes_drop(z_bytes_move(&b));
+        z_string_drop(z_string_move(&s));
+    }
+    uint8_t d;
+    assert(0 == z_bytes_reader_read(&reader, &d, 1));  // we reached the end of the payload
+
+    z_bytes_drop(z_bytes_move(&payload));
+}
+
+void test_append(void) {
+    uint8_t data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    uint8_t data_out[10] = {0};
+
+    z_owned_bytes_t payload;
+    z_bytes_empty(&payload);
+
+    z_bytes_writer_t writer = z_bytes_get_writer(z_bytes_loan_mut(&payload));
+    z_bytes_writer_write_all(&writer, data, 5);
+    {
+        z_owned_bytes_t b;
+        z_bytes_serialize_from_buf(&b, data + 5, 5);
+        assert(z_bytes_writer_append(&writer, z_bytes_move(&b)) == 0);
+    }
+
+    z_bytes_reader_t reader = z_bytes_get_reader(z_bytes_loan(&payload));
+    z_bytes_reader_read(&reader, data_out, 10);
+
+    assert(!memcmp(data, data_out, 10));
+
+    uint8_t d;
+    assert(0 == z_bytes_reader_read(&reader, &d, 1));  // we reached the end of the payload
 
     z_bytes_drop(z_bytes_move(&payload));
 }
@@ -239,6 +305,8 @@ int main(void) {
     test_writer();
     test_slice();
     test_arithmetic();
+    test_bounded();
+    test_append();
     test_iter();
     test_pair();
 }


### PR DESCRIPTION
Align z_bytes_reader_t and z_bytes_writer_t with Zenoh-rust.
make z_bytes_writer non-owned;
add z_bytes_writer_append(...) and z_bytes_writer append_bounded(...) (aka writer.serialize()); 
add z_bytes_reader_read_bounded(...);