### PR TITLE
Remove z_null and z_check for system owned types + cleanup

### DIFF
--- a/include/zenoh-pico/api/olv_macros.h
+++ b/include/zenoh-pico/api/olv_macros.h
@@ -27,18 +27,6 @@
 //
 // !!! FOR INTERNAL USAGE ONLY !!!
 
-// For pointer types
-#define _Z_OWNED_TYPE_PTR(type, name) \
-    typedef struct {                  \
-        type *_val;                   \
-    } z_owned_##name##_t;
-
-// For value types
-#define _Z_OWNED_TYPE_VALUE(type, name) \
-    typedef struct {                    \
-        type _val;                      \
-    } z_owned_##name##_t;
-
 // For value types
 #define _Z_OWNED_TYPE_VALUE(type, name) \
     typedef struct {                    \
@@ -76,39 +64,15 @@
     void z_##name##_null(z_owned_##name##_t *obj);
 
 #define _Z_OWNED_FUNCTIONS_SYSTEM_DEF(name)                                    \
-    _Bool z_##name##_check(const z_owned_##name##_t *obj);                     \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj); \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj);         \
-    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj);              \
-    void z_##name##_null(z_owned_##name##_t *obj);
+    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj);
 
 #define _Z_VIEW_FUNCTIONS_DEF(name)                                                 \
     _Bool z_view_##name##_check(const z_view_##name##_t *obj);                      \
     const z_loaned_##name##_t *z_view_##name##_loan(const z_view_##name##_t *name); \
     z_loaned_##name##_t *z_view_##name##_loan_mut(z_view_##name##_t *name);         \
     void z_view_##name##_null(z_view_##name##_t *name);
-
-#define _Z_OWNED_FUNCTIONS_PTR_IMPL(type, name, f_copy, f_free)                                     \
-    _Bool z_##name##_check(const z_owned_##name##_t *obj) { return obj->_val != NULL; }             \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return obj->_val; } \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return obj->_val; }         \
-    void z_##name##_null(z_owned_##name##_t *obj) { obj->_val = NULL; }                             \
-    z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }                    \
-    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
-        int8_t ret = _Z_RES_OK;                                                                     \
-        obj->_val = (type *)z_malloc(sizeof(type));                                                 \
-        if (obj->_val != NULL) {                                                                    \
-            f_copy(obj->_val, src);                                                                 \
-        } else {                                                                                    \
-            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                      \
-        }                                                                                           \
-        return ret;                                                                                 \
-    }                                                                                               \
-    void z_##name##_drop(z_owned_##name##_t *obj) {                                                 \
-        if ((obj != NULL) && (obj->_val != NULL)) {                                                 \
-            f_free(&obj->_val);                                                                     \
-        }                                                                                           \
-    }
 
 #define _Z_OWNED_FUNCTIONS_VALUE_IMPL(type, name, f_check, f_null, f_copy, f_drop)                   \
     _Bool z_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }          \
@@ -161,10 +125,8 @@
     }
 
 #define _Z_OWNED_FUNCTIONS_SYSTEM_IMPL(type, name)                                                   \
-    _Bool z_##name##_check(const z_owned_##name##_t *obj) { return obj != NULL; }                    \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; } \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }         \
-    void z_##name##_null(z_owned_##name##_t *obj) { (void)obj; }                                     \
     z_owned_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return obj; }
 
 #define _Z_VIEW_FUNCTIONS_IMPL(type, name, f_check)                                                      \


### PR DESCRIPTION
- Remove z_null and z_check for system owned types, because they make no sense.
- olv_macros.h cleanup (_Z_OWNED_TYPE_VALUE - duplicate, _Z_OWNED_TYPE_PTR - no more used)

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/579