### PR TITLE
_z_check/null renamed to z_internal

### DIFF
--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -141,7 +141,7 @@ extern "C" {
                            /* elem_clone_f                     */ z_##item_name##_clone,                    \
                            /* elem_move_f                     */ z_##item_name##_move,                      \
                            /* elem_drop_f                     */ z_##item_name##_drop,                      \
-                           /* elem_null                       */ _z_owned_##item_name##_null)
+                           /* elem_null                       */ z_internal_##item_name##_null)
 
 #define _Z_CHANNEL_DEFINE_DUMMY(item_name, kind_name)        \
     typedef struct {                                         \

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -138,28 +138,28 @@
  *   Returns ``true`` if valid, or ``false`` otherwise.
  */
 
-#define _z_check(x) _Generic((x), \
-                  z_owned_keyexpr_t : _z_owned_keyexpr_check,                 \
-                  z_owned_reply_err_t : _z_owned_reply_err_check,             \
-                  z_owned_config_t : _z_owned_config_check,                   \
-                  z_owned_session_t : _z_owned_session_check,                 \
-                  z_owned_subscriber_t : _z_owned_subscriber_check,           \
-                  z_owned_publisher_t : _z_owned_publisher_check,             \
-                  z_owned_queryable_t : _z_owned_queryable_check,             \
-                  z_owned_reply_t : _z_owned_reply_check,                     \
-                  z_owned_hello_t : _z_owned_hello_check,                     \
-                  z_owned_string_t : _z_owned_string_check,                   \
-                  z_owned_string_array_t : _z_owned_string_array_check,       \
-                  z_owned_closure_sample_t : _z_owned_closure_sample_check,   \
-                  z_owned_closure_query_t : _z_owned_closure_query_check,     \
-                  z_owned_closure_reply_t : _z_owned_closure_reply_check,     \
-                  z_owned_closure_hello_t : _z_owned_closure_hello_check,     \
-                  z_owned_closure_zid_t : _z_owned_closure_zid_check,         \
-                  z_owned_slice_t : _z_owned_slice_check,                     \
-                  z_owned_bytes_t : _z_owned_bytes_check,                     \
-                  z_owned_sample_t : _z_owned_sample_check,                   \
-                  z_owned_query_t : _z_owned_query_check,                     \
-                  z_owned_encoding_t : _z_owned_encoding_check                \
+#define z_internal_check(x) _Generic((x), \
+                  z_owned_keyexpr_t : z_internal_owned_keyexpr_check,                 \
+                  z_owned_reply_err_t : z_internal_owned_reply_err_check,             \
+                  z_owned_config_t : z_internal_owned_config_check,                   \
+                  z_owned_session_t : z_internal_owned_session_check,                 \
+                  z_owned_subscriber_t : z_internal_owned_subscriber_check,           \
+                  z_owned_publisher_t : z_internal_owned_publisher_check,             \
+                  z_owned_queryable_t : z_internal_owned_queryable_check,             \
+                  z_owned_reply_t : z_internal_owned_reply_check,                     \
+                  z_owned_hello_t : z_internal_owned_hello_check,                     \
+                  z_owned_string_t : z_internal_owned_string_check,                   \
+                  z_owned_string_array_t : z_internal_owned_string_array_check,       \
+                  z_owned_closure_sample_t : z_internal_owned_closure_sample_check,   \
+                  z_owned_closure_query_t : z_internal_owned_closure_query_check,     \
+                  z_owned_closure_reply_t : z_internal_owned_closure_reply_check,     \
+                  z_owned_closure_hello_t : z_internal_owned_closure_hello_check,     \
+                  z_owned_closure_zid_t : z_internal_owned_closure_zid_check,         \
+                  z_owned_slice_t : z_internal_owned_slice_check,                     \
+                  z_owned_bytes_t : z_internal_owned_bytes_check,                     \
+                  z_owned_sample_t : z_internal_owned_sample_check,                   \
+                  z_owned_query_t : z_internal_owned_query_check,                     \
+                  z_owned_encoding_t : z_internal_owned_encoding_check                \
             )(&x)
 
 /**
@@ -314,28 +314,28 @@
  * Parameters:
  *   x: The instance to nullify.
  */
-#define _z_null(x) _Generic((x), \
-                  z_owned_session_t * : _z_owned_session_null,                             \
-                  z_owned_publisher_t * : _z_owned_publisher_null,                         \
-                  z_owned_keyexpr_t * : _z_owned_keyexpr_null,                             \
-                  z_owned_config_t * : _z_owned_config_null,                               \
-                  z_owned_subscriber_t * : _z_owned_subscriber_null,                       \
-                  z_owned_queryable_t * : _z_owned_queryable_null,                         \
-                  z_owned_query_t * : _z_owned_query_null,                                 \
-                  z_owned_reply_t * : _z_owned_reply_null,                                 \
-                  z_owned_hello_t * : _z_owned_hello_null,                                 \
-                  z_owned_string_t * : _z_owned_string_null,                               \
-                  z_owned_string_array_t * : _z_owned_string_array_null,                   \
-                  z_owned_slice_t  *: _z_owned_slice_null,                                 \
-                  z_owned_bytes_t  *: _z_owned_bytes_null,                                 \
-                  z_owned_closure_sample_t * : _z_owned_closure_sample_null,               \
-                  z_owned_closure_query_t * : _z_owned_closure_query_null,                 \
-                  z_owned_closure_reply_t * : _z_owned_closure_reply_null,                 \
-                  z_owned_closure_hello_t * : _z_owned_closure_hello_null,                 \
-                  z_owned_closure_zid_t * : _z_owned_closure_zid_null,                     \
-                  z_owned_sample_t * : _z_owned_sample_null,                               \
-                  z_owned_encoding_t * : _z_owned_encoding_null,                           \
-                  z_owned_reply_err_t * : _z_owned_reply_err_null                         \
+#define z_internal_null(x) _Generic((x), \
+                  z_owned_session_t * : z_internal_owned_session_null,                             \
+                  z_owned_publisher_t * : z_internal_owned_publisher_null,                         \
+                  z_owned_keyexpr_t * : z_internal_owned_keyexpr_null,                             \
+                  z_owned_config_t * : z_internal_owned_config_null,                               \
+                  z_owned_subscriber_t * : z_internal_owned_subscriber_null,                       \
+                  z_owned_queryable_t * : z_internal_owned_queryable_null,                         \
+                  z_owned_query_t * : z_internal_owned_query_null,                                 \
+                  z_owned_reply_t * : z_internal_owned_reply_null,                                 \
+                  z_owned_hello_t * : z_internal_owned_hello_null,                                 \
+                  z_owned_string_t * : z_internal_owned_string_null,                               \
+                  z_owned_string_array_t * : z_internal_owned_string_array_null,                   \
+                  z_owned_slice_t  *: z_internal_owned_slice_null,                                 \
+                  z_owned_bytes_t  *: z_internal_owned_bytes_null,                                 \
+                  z_owned_closure_sample_t * : z_internal_owned_closure_sample_null,               \
+                  z_owned_closure_query_t * : z_internal_owned_closure_query_null,                 \
+                  z_owned_closure_reply_t * : z_internal_owned_closure_reply_null,                 \
+                  z_owned_closure_hello_t * : z_internal_owned_closure_hello_null,                 \
+                  z_owned_closure_zid_t * : z_internal_owned_closure_zid_null,                     \
+                  z_owned_sample_t * : z_internal_owned_sample_null,                               \
+                  z_owned_encoding_t * : z_internal_owned_encoding_null,                           \
+                  z_owned_reply_err_t * : z_internal_owned_reply_err_null                         \
             )(x)
 
 // clang-format on
@@ -451,54 +451,54 @@ inline void z_drop(z_owned_fifo_handler_query_t* v) { z_fifo_handler_query_drop(
 inline void z_drop(z_owned_ring_handler_reply_t* v) { z_ring_handler_reply_drop(v); }
 inline void z_drop(z_owned_fifo_handler_reply_t* v) { z_fifo_handler_reply_drop(v); }
 
-// _z_null definition
-inline void _z_null(z_owned_session_t* v) { _z_owned_session_null(v); }
-inline void _z_null(z_owned_publisher_t* v) { _z_owned_publisher_null(v); }
-inline void _z_null(z_owned_keyexpr_t* v) { _z_owned_keyexpr_null(v); }
-inline void _z_null(z_owned_config_t* v) { _z_owned_config_null(v); }
-inline void _z_null(z_owned_subscriber_t* v) { _z_owned_subscriber_null(v); }
-inline void _z_null(z_owned_queryable_t* v) { _z_owned_queryable_null(v); }
-inline void _z_null(z_owned_query_t* v) { _z_owned_query_null(v); }
-inline void _z_null(z_owned_sample_t* v) { _z_owned_sample_null(v); }
-inline void _z_null(z_owned_reply_t* v) { _z_owned_reply_null(v); }
-inline void _z_null(z_owned_hello_t* v) { _z_owned_hello_null(v); }
-inline void _z_null(z_owned_string_t* v) { _z_owned_string_null(v); }
-inline void _z_null(z_owned_bytes_t* v) { _z_owned_bytes_null(v); }
-inline void _z_null(z_owned_encoding_t* v) { _z_owned_encoding_null(v); }
-inline void _z_null(z_owned_reply_err_t* v) { _z_owned_reply_err_null(v); }
-inline void _z_null(z_owned_closure_sample_t* v) { _z_owned_closure_sample_null(v); }
-inline void _z_null(z_owned_closure_query_t* v) { _z_owned_closure_query_null(v); }
-inline void _z_null(z_owned_closure_reply_t* v) { _z_owned_closure_reply_null(v); }
-inline void _z_null(z_owned_closure_hello_t* v) { _z_owned_closure_hello_null(v); }
-inline void _z_null(z_owned_closure_zid_t* v) { _z_owned_closure_zid_null(v); }
-inline void _z_null(z_owned_ring_handler_query_t* v) { return _z_owned_ring_handler_query_null(v); };
-inline void _z_null(z_owned_ring_handler_reply_t* v) { return _z_owned_ring_handler_reply_null(v); };
-inline void _z_null(z_owned_ring_handler_sample_t* v) { return _z_owned_ring_handler_sample_null(v); };
-inline void _z_null(z_owned_fifo_handler_query_t* v) { return _z_owned_fifo_handler_query_null(v); };
-inline void _z_null(z_owned_fifo_handler_reply_t* v) { return _z_owned_fifo_handler_reply_null(v); };
-inline void _z_null(z_owned_fifo_handler_sample_t* v) { return _z_owned_fifo_handler_sample_null(v); };
+// z_internal_null definition
+inline void z_internal_null(z_owned_session_t* v) { z_internal_owned_session_null(v); }
+inline void z_internal_null(z_owned_publisher_t* v) { z_internal_owned_publisher_null(v); }
+inline void z_internal_null(z_owned_keyexpr_t* v) { z_internal_owned_keyexpr_null(v); }
+inline void z_internal_null(z_owned_config_t* v) { z_internal_owned_config_null(v); }
+inline void z_internal_null(z_owned_subscriber_t* v) { z_internal_owned_subscriber_null(v); }
+inline void z_internal_null(z_owned_queryable_t* v) { z_internal_owned_queryable_null(v); }
+inline void z_internal_null(z_owned_query_t* v) { z_internal_owned_query_null(v); }
+inline void z_internal_null(z_owned_sample_t* v) { z_internal_owned_sample_null(v); }
+inline void z_internal_null(z_owned_reply_t* v) { z_internal_owned_reply_null(v); }
+inline void z_internal_null(z_owned_hello_t* v) { z_internal_owned_hello_null(v); }
+inline void z_internal_null(z_owned_string_t* v) { z_internal_owned_string_null(v); }
+inline void z_internal_null(z_owned_bytes_t* v) { z_internal_owned_bytes_null(v); }
+inline void z_internal_null(z_owned_encoding_t* v) { z_internal_owned_encoding_null(v); }
+inline void z_internal_null(z_owned_reply_err_t* v) { z_internal_owned_reply_err_null(v); }
+inline void z_internal_null(z_owned_closure_sample_t* v) { z_internal_owned_closure_sample_null(v); }
+inline void z_internal_null(z_owned_closure_query_t* v) { z_internal_owned_closure_query_null(v); }
+inline void z_internal_null(z_owned_closure_reply_t* v) { z_internal_owned_closure_reply_null(v); }
+inline void z_internal_null(z_owned_closure_hello_t* v) { z_internal_owned_closure_hello_null(v); }
+inline void z_internal_null(z_owned_closure_zid_t* v) { z_internal_owned_closure_zid_null(v); }
+inline void z_internal_null(z_owned_ring_handler_query_t* v) { return z_internal_owned_ring_handler_query_null(v); };
+inline void z_internal_null(z_owned_ring_handler_reply_t* v) { return z_internal_owned_ring_handler_reply_null(v); };
+inline void z_internal_null(z_owned_ring_handler_sample_t* v) { return z_internal_owned_ring_handler_sample_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_query_t* v) { return z_internal_owned_fifo_handler_query_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_reply_t* v) { return z_internal_owned_fifo_handler_reply_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_sample_t* v) { return z_internal_owned_fifo_handler_sample_null(v); };
 
-// _z_check definition
-inline bool _z_check(const z_owned_session_t& v) { return _z_owned_session_check(&v); }
-inline bool _z_check(const z_owned_publisher_t& v) { return _z_owned_publisher_check(&v); }
-inline bool _z_check(const z_owned_keyexpr_t& v) { return _z_owned_keyexpr_check(&v); }
-inline bool _z_check(const z_owned_config_t& v) { return _z_owned_config_check(&v); }
-inline bool _z_check(const z_owned_subscriber_t& v) { return _z_owned_subscriber_check(&v); }
-inline bool _z_check(const z_owned_queryable_t& v) { return _z_owned_queryable_check(&v); }
-inline bool _z_check(const z_owned_reply_t& v) { return _z_owned_reply_check(&v); }
-inline bool _z_check(const z_owned_query_t& v) { return _z_owned_query_check(&v); }
-inline bool _z_check(const z_owned_hello_t& v) { return _z_owned_hello_check(&v); }
-inline bool _z_check(const z_owned_string_t& v) { return _z_owned_string_check(&v); }
-inline bool _z_check(const z_owned_sample_t& v) { return _z_owned_sample_check(&v); }
-inline bool _z_check(const z_owned_bytes_t& v) { return _z_owned_bytes_check(&v); }
-inline bool _z_check(const z_owned_encoding_t& v) { return _z_owned_encoding_check(&v); }
-inline bool _z_check(const z_owned_reply_err_t& v) { return _z_owned_reply_err_check(&v); }
-inline bool _z_check(const z_owned_fifo_handler_query_t& v) { return _z_owned_fifo_handler_query_check(&v); };
-inline bool _z_check(const z_owned_fifo_handler_reply_t& v) { return _z_owned_fifo_handler_reply_check(&v); };
-inline bool _z_check(const z_owned_fifo_handler_sample_t& v) { return _z_owned_fifo_handler_sample_check(&v); };
-inline bool _z_check(const z_owned_ring_handler_query_t& v) { return _z_owned_ring_handler_query_check(&v); };
-inline bool _z_check(const z_owned_ring_handler_reply_t& v) { return _z_owned_ring_handler_reply_check(&v); };
-inline bool _z_check(const z_owned_ring_handler_sample_t& v) { return _z_owned_ring_handler_sample_check(&v); };
+// z_internal_check definition
+inline bool z_internal_check(const z_owned_session_t& v) { return z_internal_owned_session_check(&v); }
+inline bool z_internal_check(const z_owned_publisher_t& v) { return z_internal_owned_publisher_check(&v); }
+inline bool z_internal_check(const z_owned_keyexpr_t& v) { return z_internal_owned_keyexpr_check(&v); }
+inline bool z_internal_check(const z_owned_config_t& v) { return z_internal_owned_config_check(&v); }
+inline bool z_internal_check(const z_owned_subscriber_t& v) { return z_internal_owned_subscriber_check(&v); }
+inline bool z_internal_check(const z_owned_queryable_t& v) { return z_internal_owned_queryable_check(&v); }
+inline bool z_internal_check(const z_owned_reply_t& v) { return z_internal_owned_reply_check(&v); }
+inline bool z_internal_check(const z_owned_query_t& v) { return z_internal_owned_query_check(&v); }
+inline bool z_internal_check(const z_owned_hello_t& v) { return z_internal_owned_hello_check(&v); }
+inline bool z_internal_check(const z_owned_string_t& v) { return z_internal_owned_string_check(&v); }
+inline bool z_internal_check(const z_owned_sample_t& v) { return z_internal_owned_sample_check(&v); }
+inline bool z_internal_check(const z_owned_bytes_t& v) { return z_internal_owned_bytes_check(&v); }
+inline bool z_internal_check(const z_owned_encoding_t& v) { return z_internal_owned_encoding_check(&v); }
+inline bool z_internal_check(const z_owned_reply_err_t& v) { return z_internal_owned_reply_err_check(&v); }
+inline bool z_internal_check(const z_owned_fifo_handler_query_t& v) { return z_internal_owned_fifo_handler_query_check(&v); };
+inline bool z_internal_check(const z_owned_fifo_handler_reply_t& v) { return z_internal_owned_fifo_handler_reply_check(&v); };
+inline bool z_internal_check(const z_owned_fifo_handler_sample_t& v) { return z_internal_owned_fifo_handler_sample_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_query_t& v) { return z_internal_owned_ring_handler_query_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_reply_t& v) { return z_internal_owned_ring_handler_reply_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_sample_t& v) { return z_internal_owned_ring_handler_sample_check(&v); };
 
 // z_call definition
 inline void z_call(const z_loaned_closure_sample_t &closure, const z_loaned_sample_t *sample) 

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -139,27 +139,27 @@
  */
 
 #define z_internal_check(x) _Generic((x), \
-                  z_owned_keyexpr_t : z_internal_owned_keyexpr_check,                 \
-                  z_owned_reply_err_t : z_internal_owned_reply_err_check,             \
-                  z_owned_config_t : z_internal_owned_config_check,                   \
-                  z_owned_session_t : z_internal_owned_session_check,                 \
-                  z_owned_subscriber_t : z_internal_owned_subscriber_check,           \
-                  z_owned_publisher_t : z_internal_owned_publisher_check,             \
-                  z_owned_queryable_t : z_internal_owned_queryable_check,             \
-                  z_owned_reply_t : z_internal_owned_reply_check,                     \
-                  z_owned_hello_t : z_internal_owned_hello_check,                     \
-                  z_owned_string_t : z_internal_owned_string_check,                   \
-                  z_owned_string_array_t : z_internal_owned_string_array_check,       \
-                  z_owned_closure_sample_t : z_internal_owned_closure_sample_check,   \
-                  z_owned_closure_query_t : z_internal_owned_closure_query_check,     \
-                  z_owned_closure_reply_t : z_internal_owned_closure_reply_check,     \
-                  z_owned_closure_hello_t : z_internal_owned_closure_hello_check,     \
-                  z_owned_closure_zid_t : z_internal_owned_closure_zid_check,         \
-                  z_owned_slice_t : z_internal_owned_slice_check,                     \
-                  z_owned_bytes_t : z_internal_owned_bytes_check,                     \
-                  z_owned_sample_t : z_internal_owned_sample_check,                   \
-                  z_owned_query_t : z_internal_owned_query_check,                     \
-                  z_owned_encoding_t : z_internal_owned_encoding_check                \
+                  z_owned_keyexpr_t : z_internal_keyexpr_check,                 \
+                  z_owned_reply_err_t : z_internal_reply_err_check,             \
+                  z_owned_config_t : z_internal_config_check,                   \
+                  z_owned_session_t : z_internal_session_check,                 \
+                  z_owned_subscriber_t : z_internal_subscriber_check,           \
+                  z_owned_publisher_t : z_internal_publisher_check,             \
+                  z_owned_queryable_t : z_internal_queryable_check,             \
+                  z_owned_reply_t : z_internal_reply_check,                     \
+                  z_owned_hello_t : z_internal_hello_check,                     \
+                  z_owned_string_t : z_internal_string_check,                   \
+                  z_owned_string_array_t : z_internal_string_array_check,       \
+                  z_owned_closure_sample_t : z_internal_closure_sample_check,   \
+                  z_owned_closure_query_t : z_internal_closure_query_check,     \
+                  z_owned_closure_reply_t : z_internal_closure_reply_check,     \
+                  z_owned_closure_hello_t : z_internal_closure_hello_check,     \
+                  z_owned_closure_zid_t : z_internal_closure_zid_check,         \
+                  z_owned_slice_t : z_internal_slice_check,                     \
+                  z_owned_bytes_t : z_internal_bytes_check,                     \
+                  z_owned_sample_t : z_internal_sample_check,                   \
+                  z_owned_query_t : z_internal_query_check,                     \
+                  z_owned_encoding_t : z_internal_encoding_check                \
             )(&x)
 
 /**
@@ -315,27 +315,27 @@
  *   x: The instance to nullify.
  */
 #define z_internal_null(x) _Generic((x), \
-                  z_owned_session_t * : z_internal_owned_session_null,                             \
-                  z_owned_publisher_t * : z_internal_owned_publisher_null,                         \
-                  z_owned_keyexpr_t * : z_internal_owned_keyexpr_null,                             \
-                  z_owned_config_t * : z_internal_owned_config_null,                               \
-                  z_owned_subscriber_t * : z_internal_owned_subscriber_null,                       \
-                  z_owned_queryable_t * : z_internal_owned_queryable_null,                         \
-                  z_owned_query_t * : z_internal_owned_query_null,                                 \
-                  z_owned_reply_t * : z_internal_owned_reply_null,                                 \
-                  z_owned_hello_t * : z_internal_owned_hello_null,                                 \
-                  z_owned_string_t * : z_internal_owned_string_null,                               \
-                  z_owned_string_array_t * : z_internal_owned_string_array_null,                   \
-                  z_owned_slice_t  *: z_internal_owned_slice_null,                                 \
-                  z_owned_bytes_t  *: z_internal_owned_bytes_null,                                 \
-                  z_owned_closure_sample_t * : z_internal_owned_closure_sample_null,               \
-                  z_owned_closure_query_t * : z_internal_owned_closure_query_null,                 \
-                  z_owned_closure_reply_t * : z_internal_owned_closure_reply_null,                 \
-                  z_owned_closure_hello_t * : z_internal_owned_closure_hello_null,                 \
-                  z_owned_closure_zid_t * : z_internal_owned_closure_zid_null,                     \
-                  z_owned_sample_t * : z_internal_owned_sample_null,                               \
-                  z_owned_encoding_t * : z_internal_owned_encoding_null,                           \
-                  z_owned_reply_err_t * : z_internal_owned_reply_err_null                         \
+                  z_owned_session_t * : z_internal_session_null,                             \
+                  z_owned_publisher_t * : z_internal_publisher_null,                         \
+                  z_owned_keyexpr_t * : z_internal_keyexpr_null,                             \
+                  z_owned_config_t * : z_internal_config_null,                               \
+                  z_owned_subscriber_t * : z_internal_subscriber_null,                       \
+                  z_owned_queryable_t * : z_internal_queryable_null,                         \
+                  z_owned_query_t * : z_internal_query_null,                                 \
+                  z_owned_reply_t * : z_internal_reply_null,                                 \
+                  z_owned_hello_t * : z_internal_hello_null,                                 \
+                  z_owned_string_t * : z_internal_string_null,                               \
+                  z_owned_string_array_t * : z_internal_string_array_null,                   \
+                  z_owned_slice_t  *: z_internal_slice_null,                                 \
+                  z_owned_bytes_t  *: z_internal_bytes_null,                                 \
+                  z_owned_closure_sample_t * : z_internal_closure_sample_null,               \
+                  z_owned_closure_query_t * : z_internal_closure_query_null,                 \
+                  z_owned_closure_reply_t * : z_internal_closure_reply_null,                 \
+                  z_owned_closure_hello_t * : z_internal_closure_hello_null,                 \
+                  z_owned_closure_zid_t * : z_internal_closure_zid_null,                     \
+                  z_owned_sample_t * : z_internal_sample_null,                               \
+                  z_owned_encoding_t * : z_internal_encoding_null,                           \
+                  z_owned_reply_err_t * : z_internal_reply_err_null                         \
             )(x)
 
 // clang-format on
@@ -452,53 +452,53 @@ inline void z_drop(z_owned_ring_handler_reply_t* v) { z_ring_handler_reply_drop(
 inline void z_drop(z_owned_fifo_handler_reply_t* v) { z_fifo_handler_reply_drop(v); }
 
 // z_internal_null definition
-inline void z_internal_null(z_owned_session_t* v) { z_internal_owned_session_null(v); }
-inline void z_internal_null(z_owned_publisher_t* v) { z_internal_owned_publisher_null(v); }
-inline void z_internal_null(z_owned_keyexpr_t* v) { z_internal_owned_keyexpr_null(v); }
-inline void z_internal_null(z_owned_config_t* v) { z_internal_owned_config_null(v); }
-inline void z_internal_null(z_owned_subscriber_t* v) { z_internal_owned_subscriber_null(v); }
-inline void z_internal_null(z_owned_queryable_t* v) { z_internal_owned_queryable_null(v); }
-inline void z_internal_null(z_owned_query_t* v) { z_internal_owned_query_null(v); }
-inline void z_internal_null(z_owned_sample_t* v) { z_internal_owned_sample_null(v); }
-inline void z_internal_null(z_owned_reply_t* v) { z_internal_owned_reply_null(v); }
-inline void z_internal_null(z_owned_hello_t* v) { z_internal_owned_hello_null(v); }
-inline void z_internal_null(z_owned_string_t* v) { z_internal_owned_string_null(v); }
-inline void z_internal_null(z_owned_bytes_t* v) { z_internal_owned_bytes_null(v); }
-inline void z_internal_null(z_owned_encoding_t* v) { z_internal_owned_encoding_null(v); }
-inline void z_internal_null(z_owned_reply_err_t* v) { z_internal_owned_reply_err_null(v); }
-inline void z_internal_null(z_owned_closure_sample_t* v) { z_internal_owned_closure_sample_null(v); }
-inline void z_internal_null(z_owned_closure_query_t* v) { z_internal_owned_closure_query_null(v); }
-inline void z_internal_null(z_owned_closure_reply_t* v) { z_internal_owned_closure_reply_null(v); }
-inline void z_internal_null(z_owned_closure_hello_t* v) { z_internal_owned_closure_hello_null(v); }
-inline void z_internal_null(z_owned_closure_zid_t* v) { z_internal_owned_closure_zid_null(v); }
-inline void z_internal_null(z_owned_ring_handler_query_t* v) { return z_internal_owned_ring_handler_query_null(v); };
-inline void z_internal_null(z_owned_ring_handler_reply_t* v) { return z_internal_owned_ring_handler_reply_null(v); };
-inline void z_internal_null(z_owned_ring_handler_sample_t* v) { return z_internal_owned_ring_handler_sample_null(v); };
-inline void z_internal_null(z_owned_fifo_handler_query_t* v) { return z_internal_owned_fifo_handler_query_null(v); };
-inline void z_internal_null(z_owned_fifo_handler_reply_t* v) { return z_internal_owned_fifo_handler_reply_null(v); };
-inline void z_internal_null(z_owned_fifo_handler_sample_t* v) { return z_internal_owned_fifo_handler_sample_null(v); };
+inline void z_internal_null(z_owned_session_t* v) { z_internal_session_null(v); }
+inline void z_internal_null(z_owned_publisher_t* v) { z_internal_publisher_null(v); }
+inline void z_internal_null(z_owned_keyexpr_t* v) { z_internal_keyexpr_null(v); }
+inline void z_internal_null(z_owned_config_t* v) { z_internal_config_null(v); }
+inline void z_internal_null(z_owned_subscriber_t* v) { z_internal_subscriber_null(v); }
+inline void z_internal_null(z_owned_queryable_t* v) { z_internal_queryable_null(v); }
+inline void z_internal_null(z_owned_query_t* v) { z_internal_query_null(v); }
+inline void z_internal_null(z_owned_sample_t* v) { z_internal_sample_null(v); }
+inline void z_internal_null(z_owned_reply_t* v) { z_internal_reply_null(v); }
+inline void z_internal_null(z_owned_hello_t* v) { z_internal_hello_null(v); }
+inline void z_internal_null(z_owned_string_t* v) { z_internal_string_null(v); }
+inline void z_internal_null(z_owned_bytes_t* v) { z_internal_bytes_null(v); }
+inline void z_internal_null(z_owned_encoding_t* v) { z_internal_encoding_null(v); }
+inline void z_internal_null(z_owned_reply_err_t* v) { z_internal_reply_err_null(v); }
+inline void z_internal_null(z_owned_closure_sample_t* v) { z_internal_closure_sample_null(v); }
+inline void z_internal_null(z_owned_closure_query_t* v) { z_internal_closure_query_null(v); }
+inline void z_internal_null(z_owned_closure_reply_t* v) { z_internal_closure_reply_null(v); }
+inline void z_internal_null(z_owned_closure_hello_t* v) { z_internal_closure_hello_null(v); }
+inline void z_internal_null(z_owned_closure_zid_t* v) { z_internal_closure_zid_null(v); }
+inline void z_internal_null(z_owned_ring_handler_query_t* v) { return z_internal_ring_handler_query_null(v); };
+inline void z_internal_null(z_owned_ring_handler_reply_t* v) { return z_internal_ring_handler_reply_null(v); };
+inline void z_internal_null(z_owned_ring_handler_sample_t* v) { return z_internal_ring_handler_sample_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_query_t* v) { return z_internal_fifo_handler_query_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_reply_t* v) { return z_internal_fifo_handler_reply_null(v); };
+inline void z_internal_null(z_owned_fifo_handler_sample_t* v) { return z_internal_fifo_handler_sample_null(v); };
 
 // z_internal_check definition
-inline bool z_internal_check(const z_owned_session_t& v) { return z_internal_owned_session_check(&v); }
-inline bool z_internal_check(const z_owned_publisher_t& v) { return z_internal_owned_publisher_check(&v); }
-inline bool z_internal_check(const z_owned_keyexpr_t& v) { return z_internal_owned_keyexpr_check(&v); }
-inline bool z_internal_check(const z_owned_config_t& v) { return z_internal_owned_config_check(&v); }
-inline bool z_internal_check(const z_owned_subscriber_t& v) { return z_internal_owned_subscriber_check(&v); }
-inline bool z_internal_check(const z_owned_queryable_t& v) { return z_internal_owned_queryable_check(&v); }
-inline bool z_internal_check(const z_owned_reply_t& v) { return z_internal_owned_reply_check(&v); }
-inline bool z_internal_check(const z_owned_query_t& v) { return z_internal_owned_query_check(&v); }
-inline bool z_internal_check(const z_owned_hello_t& v) { return z_internal_owned_hello_check(&v); }
-inline bool z_internal_check(const z_owned_string_t& v) { return z_internal_owned_string_check(&v); }
-inline bool z_internal_check(const z_owned_sample_t& v) { return z_internal_owned_sample_check(&v); }
-inline bool z_internal_check(const z_owned_bytes_t& v) { return z_internal_owned_bytes_check(&v); }
-inline bool z_internal_check(const z_owned_encoding_t& v) { return z_internal_owned_encoding_check(&v); }
-inline bool z_internal_check(const z_owned_reply_err_t& v) { return z_internal_owned_reply_err_check(&v); }
-inline bool z_internal_check(const z_owned_fifo_handler_query_t& v) { return z_internal_owned_fifo_handler_query_check(&v); };
-inline bool z_internal_check(const z_owned_fifo_handler_reply_t& v) { return z_internal_owned_fifo_handler_reply_check(&v); };
-inline bool z_internal_check(const z_owned_fifo_handler_sample_t& v) { return z_internal_owned_fifo_handler_sample_check(&v); };
-inline bool z_internal_check(const z_owned_ring_handler_query_t& v) { return z_internal_owned_ring_handler_query_check(&v); };
-inline bool z_internal_check(const z_owned_ring_handler_reply_t& v) { return z_internal_owned_ring_handler_reply_check(&v); };
-inline bool z_internal_check(const z_owned_ring_handler_sample_t& v) { return z_internal_owned_ring_handler_sample_check(&v); };
+inline bool z_internal_check(const z_owned_session_t& v) { return z_internal_session_check(&v); }
+inline bool z_internal_check(const z_owned_publisher_t& v) { return z_internal_publisher_check(&v); }
+inline bool z_internal_check(const z_owned_keyexpr_t& v) { return z_internal_keyexpr_check(&v); }
+inline bool z_internal_check(const z_owned_config_t& v) { return z_internal_config_check(&v); }
+inline bool z_internal_check(const z_owned_subscriber_t& v) { return z_internal_subscriber_check(&v); }
+inline bool z_internal_check(const z_owned_queryable_t& v) { return z_internal_queryable_check(&v); }
+inline bool z_internal_check(const z_owned_reply_t& v) { return z_internal_reply_check(&v); }
+inline bool z_internal_check(const z_owned_query_t& v) { return z_internal_query_check(&v); }
+inline bool z_internal_check(const z_owned_hello_t& v) { return z_internal_hello_check(&v); }
+inline bool z_internal_check(const z_owned_string_t& v) { return z_internal_string_check(&v); }
+inline bool z_internal_check(const z_owned_sample_t& v) { return z_internal_sample_check(&v); }
+inline bool z_internal_check(const z_owned_bytes_t& v) { return z_internal_bytes_check(&v); }
+inline bool z_internal_check(const z_owned_encoding_t& v) { return z_internal_encoding_check(&v); }
+inline bool z_internal_check(const z_owned_reply_err_t& v) { return z_internal_reply_err_check(&v); }
+inline bool z_internal_check(const z_owned_fifo_handler_query_t& v) { return z_internal_fifo_handler_query_check(&v); };
+inline bool z_internal_check(const z_owned_fifo_handler_reply_t& v) { return z_internal_fifo_handler_reply_check(&v); };
+inline bool z_internal_check(const z_owned_fifo_handler_sample_t& v) { return z_internal_fifo_handler_sample_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_query_t& v) { return z_internal_ring_handler_query_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_reply_t& v) { return z_internal_ring_handler_reply_check(&v); };
+inline bool z_internal_check(const z_owned_ring_handler_sample_t& v) { return z_internal_ring_handler_sample_check(&v); };
 
 // z_call definition
 inline void z_call(const z_loaned_closure_sample_t &closure, const z_loaned_sample_t *sample) 

--- a/include/zenoh-pico/api/olv_macros.h
+++ b/include/zenoh-pico/api/olv_macros.h
@@ -56,8 +56,8 @@
     } z_view_##name##_t;
 
 #define _Z_OWNED_FUNCTIONS_DEF(name)                                                  \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj);                             \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *obj);                     \
+    void z_internal_##name##_null(z_owned_##name##_t *obj);                           \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *obj);                   \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj);        \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj);                \
     z_moved_##name##_t *z_##name##_move(z_owned_##name##_t *obj);                     \
@@ -66,8 +66,8 @@
     void z_##name##_drop(z_moved_##name##_t *obj);
 
 #define _Z_OWNED_FUNCTIONS_NO_COPY_DEF(name)                                   \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj);                      \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *obj);              \
+    void z_internal_##name##_null(z_owned_##name##_t *obj);                    \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *obj);            \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj); \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj);         \
     z_moved_##name##_t *z_##name##_move(z_owned_##name##_t *obj);              \
@@ -75,7 +75,7 @@
     void z_##name##_drop(z_moved_##name##_t *obj);
 
 #define _Z_OWNED_FUNCTIONS_SYSTEM_DEF(name)                                    \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj);                      \
+    void z_internal_##name##_null(z_owned_##name##_t *obj);                    \
     void z_##name##_take(z_owned_##name##_t *obj, z_moved_##name##_t *src);    \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj); \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj);         \
@@ -91,13 +91,13 @@
     z_moved_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return (z_moved_##name##_t *)(obj); } \
     void z_##name##_take(z_owned_##name##_t *obj, z_moved_##name##_t *src) {                             \
         *obj = src->_this;                                                                               \
-        _z_owned_##name##_null(&src->_this);                                                             \
+        z_internal_##name##_null(&src->_this);                                                           \
     }
 
 #define _Z_OWNED_FUNCTIONS_PTR_IMPL(type, name, f_copy, f_free)                                     \
     _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                         \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj) { obj->_val = NULL; }                      \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *obj) { return obj->_val != NULL; }      \
+    void z_internal_##name##_null(z_owned_##name##_t *obj) { obj->_val = NULL; }                    \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *obj) { return obj->_val != NULL; }    \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return obj->_val; } \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return obj->_val; }         \
     int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
@@ -118,8 +118,8 @@
 
 #define _Z_OWNED_FUNCTIONS_VALUE_IMPL(type, name, f_check, f_null, f_copy, f_drop)                   \
     _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                          \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                   \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }   \
+    void z_internal_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                 \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); } \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; } \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }         \
     int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {               \
@@ -130,14 +130,14 @@
     }
 
 #define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_INNER(type, name, f_check, f_null, f_drop, attribute)                \
-    attribute void _z_owned_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                       \
-    attribute _Bool _z_owned_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }       \
+    attribute void z_internal_##name##_null(z_owned_##name##_t *obj) { obj->_val = f_null(); }                     \
+    attribute _Bool z_internal_##name##_check(const z_owned_##name##_t *obj) { return f_check((&obj->_val)); }     \
     attribute const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; }     \
     attribute z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }             \
     attribute z_moved_##name##_t *z_##name##_move(z_owned_##name##_t *obj) { return (z_moved_##name##_t *)(obj); } \
     attribute void z_##name##_take(z_owned_##name##_t *obj, z_moved_##name##_t *src) {                             \
         *obj = src->_this;                                                                                         \
-        _z_owned_##name##_null(&src->_this);                                                                       \
+        z_internal_##name##_null(&src->_this);                                                                     \
     }                                                                                                              \
     attribute void z_##name##_drop(z_moved_##name##_t *obj) {                                                      \
         if (obj != NULL) f_drop((&obj->_this._val));                                                               \
@@ -151,29 +151,29 @@
 #define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_INLINE_IMPL(type, name, f_check, f_null, f_drop) \
     _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_INNER(type, name, f_check, f_null, f_drop, static inline)
 
-#define _Z_OWNED_FUNCTIONS_RC_IMPL(name)                                                               \
-    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                            \
-    void _z_owned_##name##_null(z_owned_##name##_t *val) { val->_rc = _z_##name##_rc_null(); }         \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *val) { return !_Z_RC_IS_NULL(&val->_rc); } \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; }    \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }            \
-    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {                 \
-        int8_t ret = _Z_RES_OK;                                                                        \
-        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                   \
-        if (_Z_RC_IS_NULL(&obj->_rc)) {                                                                \
-            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                         \
-        }                                                                                              \
-        return ret;                                                                                    \
-    }                                                                                                  \
-    void z_##name##_drop(z_moved_##name##_t *obj) {                                                    \
-        if (!_Z_RC_IS_NULL(&obj->_this._rc)) {                                                         \
-            _z_##name##_rc_drop(&obj->_this._rc);                                                      \
-        }                                                                                              \
+#define _Z_OWNED_FUNCTIONS_RC_IMPL(name)                                                                 \
+    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                              \
+    void z_internal_##name##_null(z_owned_##name##_t *val) { val->_rc = _z_##name##_rc_null(); }         \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *val) { return !_Z_RC_IS_NULL(&val->_rc); } \
+    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; }      \
+    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }              \
+    int8_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {                   \
+        int8_t ret = _Z_RES_OK;                                                                          \
+        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                     \
+        if (_Z_RC_IS_NULL(&obj->_rc)) {                                                                  \
+            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                           \
+        }                                                                                                \
+        return ret;                                                                                      \
+    }                                                                                                    \
+    void z_##name##_drop(z_moved_##name##_t *obj) {                                                      \
+        if (!_Z_RC_IS_NULL(&obj->_this._rc)) {                                                           \
+            _z_##name##_rc_drop(&obj->_this._rc);                                                        \
+        }                                                                                                \
     }
 
 #define _Z_OWNED_FUNCTIONS_SYSTEM_IMPL(type, name)                                                   \
     _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                          \
-    void _z_owned_##name##_null(z_owned_##name##_t *obj) { (void)obj; }                              \
+    void z_internal_##name##_null(z_owned_##name##_t *obj) { (void)obj; }                            \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *obj) { return &obj->_val; } \
     z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *obj) { return &obj->_val; }
 
@@ -184,36 +184,36 @@
     void z_view_##name##_empty(z_view_##name##_t *obj) { obj->_val = f_null(); }
 
 #define _Z_OWNED_FUNCTIONS_CLOSURE_DEF(name)                                \
-    void _z_owned_##name##_null(z_owned_##name##_t *name);                  \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *val);           \
+    void z_internal_##name##_null(z_owned_##name##_t *name);                \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *val);         \
     z_moved_##name##_t *z_##name##_move(z_owned_##name##_t *val);           \
     void z_##name##_take(z_owned_##name##_t *obj, z_moved_##name##_t *src); \
     void z_##name##_drop(z_moved_##name##_t *obj);                          \
     const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val);
 
-#define _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(name, f_call, f_drop)                                        \
-    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                          \
-    void _z_owned_##name##_null(z_owned_##name##_t *val) {                                           \
-        val->_val.call = NULL;                                                                       \
-        val->_val.drop = NULL;                                                                       \
-        val->_val.context = NULL;                                                                    \
-    }                                                                                                \
-    _Bool _z_owned_##name##_check(const z_owned_##name##_t *val) { return val->_val.call != NULL; }  \
-    void z_##name##_drop(z_moved_##name##_t *obj) {                                                  \
-        if (obj->_this._val.drop != NULL) {                                                          \
-            (obj->_this._val.drop)(obj->_this._val.context);                                         \
-            obj->_this._val.drop = NULL;                                                             \
-        }                                                                                            \
-        obj->_this._val.call = NULL;                                                                 \
-        obj->_this._val.context = NULL;                                                              \
-    }                                                                                                \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_val; } \
-    int8_t z_##name(z_owned_##name##_t *closure, f_call call, f_drop drop, void *context) {          \
-        closure->_val.call = call;                                                                   \
-        closure->_val.drop = drop;                                                                   \
-        closure->_val.context = context;                                                             \
-                                                                                                     \
-        return _Z_RES_OK;                                                                            \
+#define _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(name, f_call, f_drop)                                         \
+    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                           \
+    void z_internal_##name##_null(z_owned_##name##_t *val) {                                          \
+        val->_val.call = NULL;                                                                        \
+        val->_val.drop = NULL;                                                                        \
+        val->_val.context = NULL;                                                                     \
+    }                                                                                                 \
+    _Bool z_internal_##name##_check(const z_owned_##name##_t *val) { return val->_val.call != NULL; } \
+    void z_##name##_drop(z_moved_##name##_t *obj) {                                                   \
+        if (obj->_this._val.drop != NULL) {                                                           \
+            (obj->_this._val.drop)(obj->_this._val.context);                                          \
+            obj->_this._val.drop = NULL;                                                              \
+        }                                                                                             \
+        obj->_this._val.call = NULL;                                                                  \
+        obj->_this._val.context = NULL;                                                               \
+    }                                                                                                 \
+    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_val; }  \
+    int8_t z_##name(z_owned_##name##_t *closure, f_call call, f_drop drop, void *context) {           \
+        closure->_val.call = call;                                                                    \
+        closure->_val.drop = drop;                                                                    \
+        closure->_val.context = context;                                                              \
+                                                                                                      \
+        return _Z_RES_OK;                                                                             \
     }
 
 #endif /* INCLUDE_ZENOH_PICO_API_OLV_MACROS_H */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1306,7 +1306,8 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
     z_bytes_drop(opt.payload);
     z_encoding_drop(opt.encoding);
     z_bytes_drop(opt.attachment);
-    z_internal_closure_reply_null(&callback->_this);  // call and drop passed to _z_query, so we nullify the closure here
+    z_internal_closure_reply_null(
+        &callback->_this);  // call and drop passed to _z_query, so we nullify the closure here
     return ret;
 }
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -95,7 +95,7 @@ int8_t z_keyexpr_as_view_string(const z_loaned_keyexpr_t *keyexpr, z_view_string
 }
 
 int8_t z_keyexpr_concat(z_owned_keyexpr_t *key, const z_loaned_keyexpr_t *left, const char *right, size_t len) {
-    _z_owned_keyexpr_null(key);
+    z_internal_keyexpr_null(key);
     if (len == 0) {
         return z_keyexpr_clone(key, left);
     } else if (right == NULL) {
@@ -124,7 +124,7 @@ int8_t z_keyexpr_concat(z_owned_keyexpr_t *key, const z_loaned_keyexpr_t *left, 
 }
 
 int8_t z_keyexpr_join(z_owned_keyexpr_t *key, const z_loaned_keyexpr_t *left, const z_loaned_keyexpr_t *right) {
-    _z_owned_keyexpr_null(key);
+    z_internal_keyexpr_null(key);
 
     size_t left_len = strlen(left->_suffix);
     size_t right_len = strlen(right->_suffix);
@@ -376,7 +376,7 @@ _Z_OWNED_FUNCTIONS_VALUE_IMPL(_z_encoding_t, encoding, _z_encoding_check, _z_enc
 
 int8_t z_encoding_from_str(z_owned_encoding_t *encoding, const char *s) {
     // Init owned encoding
-    _z_owned_encoding_null(encoding);
+    z_internal_encoding_null(encoding);
     // Convert string to encoding
     if (s != NULL) {
         return _z_encoding_convert_from_substr(encoding, s, strlen(s));
@@ -386,7 +386,7 @@ int8_t z_encoding_from_str(z_owned_encoding_t *encoding, const char *s) {
 
 int8_t z_encoding_from_substr(z_owned_encoding_t *encoding, const char *s, size_t len) {
     // Init owned encoding
-    _z_owned_encoding_null(encoding);
+    z_internal_encoding_null(encoding);
     // Convert string to encoding
     if (s != NULL) {
         return _z_encoding_convert_from_substr(encoding, s, len);
@@ -411,7 +411,7 @@ int8_t z_encoding_set_schema_from_substr(z_loaned_encoding_t *encoding, const ch
 
 int8_t z_encoding_to_string(const z_loaned_encoding_t *encoding, z_owned_string_t *s) {
     // Init owned string
-    _z_owned_string_null(s);
+    z_internal_string_null(s);
     // Convert encoding to string
     _z_encoding_convert_into_string(encoding, s);
     return _Z_RES_OK;
@@ -487,7 +487,7 @@ int8_t z_bytes_deserialize_into_slice(const z_loaned_bytes_t *bytes, z_owned_sli
 
 int8_t z_bytes_deserialize_into_string(const z_loaned_bytes_t *bytes, z_owned_string_t *s) {
     // Init owned string
-    _z_owned_string_null(s);
+    z_internal_string_null(s);
     // Convert bytes to string
     size_t len = _z_bytes_len(bytes);
     s->_val = _z_string_preallocate(len);
@@ -912,13 +912,13 @@ int8_t z_scout(z_moved_config_t *config, z_moved_closure_hello_t *callback, cons
     } else {
         ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }
-    _z_owned_closure_hello_null(&callback->_this);
+    z_internal_closure_hello_null(&callback->_this);
 
     return ret;
 }
 
 int8_t z_open(z_owned_session_t *zs, z_moved_config_t *config) {
-    _z_owned_session_null(zs);
+    z_internal_session_null(zs);
     _z_session_t *s = z_malloc(sizeof(_z_session_t));
     if (s == NULL) {
         z_config_drop(config);
@@ -937,7 +937,7 @@ int8_t z_open(z_owned_session_t *zs, z_moved_config_t *config) {
     int8_t ret = _z_open(&zs->_rc, &config->_this._val);
     if (ret != _Z_RES_OK) {
         _z_session_rc_decr(&zs->_rc);
-        _z_owned_session_null(zs);
+        z_internal_session_null(zs);
         z_config_drop(config);
         return ret;
     }
@@ -947,7 +947,7 @@ int8_t z_open(z_owned_session_t *zs, z_moved_config_t *config) {
 }
 
 int8_t z_close(z_moved_session_t *zs) {
-    if (zs == NULL || !_z_owned_session_check(&zs->_this)) {
+    if (zs == NULL || !z_internal_session_check(&zs->_this)) {
         return _Z_RES_OK;
     }
     z_session_drop(zs);
@@ -971,7 +971,7 @@ int8_t z_info_peers_zid(const z_loaned_session_t *zs, z_moved_closure_zid_t *cal
     if (callback->_this._val.drop != NULL) {
         callback->_this._val.drop(ctx);
     }
-    _z_owned_closure_zid_null(&callback->_this);
+    z_internal_closure_zid_null(&callback->_this);
     return 0;
 }
 
@@ -991,7 +991,7 @@ int8_t z_info_routers_zid(const z_loaned_session_t *zs, z_moved_closure_zid_t *c
     if (callback->_this._val.drop != NULL) {
         callback->_this._val.drop(ctx);
     }
-    _z_owned_closure_zid_null(&callback->_this);
+    z_internal_closure_zid_null(&callback->_this);
     return 0;
 }
 
@@ -1306,7 +1306,7 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
     z_bytes_drop(opt.payload);
     z_encoding_drop(opt.encoding);
     z_bytes_drop(opt.attachment);
-    _z_owned_closure_reply_null(&callback->_this);  // call and drop passed to _z_query, so we nullify the closure here
+    z_internal_closure_reply_null(&callback->_this);  // call and drop passed to _z_query, so we nullify the closure here
     return ret;
 }
 
@@ -1372,7 +1372,7 @@ int8_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_sessio
     queryable->_val =
         _z_declare_queryable(zs, key, opt.complete, callback->_this._val.call, callback->_this._val.drop, ctx);
 
-    _z_owned_closure_query_null(&callback->_this);
+    z_internal_closure_query_null(&callback->_this);
     return _Z_RES_OK;
 }
 
@@ -1486,7 +1486,7 @@ int8_t z_keyexpr_from_str_autocanonize(z_owned_keyexpr_t *key, const char *name)
 }
 
 int8_t z_keyexpr_from_substr_autocanonize(z_owned_keyexpr_t *key, const char *name, size_t *len) {
-    _z_owned_keyexpr_null(key);
+    z_internal_keyexpr_null(key);
     char *name_copy = _z_str_n_clone(name, *len);
     if (name_copy == NULL) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
@@ -1504,7 +1504,7 @@ int8_t z_keyexpr_from_str(z_owned_keyexpr_t *key, const char *name) {
 }
 
 int8_t z_keyexpr_from_substr(z_owned_keyexpr_t *key, const char *name, size_t len) {
-    _z_owned_keyexpr_null(key);
+    z_internal_keyexpr_null(key);
     char *name_copy = _z_str_n_clone(name, len);
     if (name_copy == NULL) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
@@ -1605,7 +1605,7 @@ int8_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t 
     if (suffix != NULL) {
         z_free(suffix);
     }
-    _z_owned_closure_sample_null(&callback->_this);
+    z_internal_closure_sample_null(&callback->_this);
     sub->_val = int_sub;
 
     if (!_z_subscriber_check(&sub->_val)) {

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -186,10 +186,10 @@ int main(int argc, char **argv) {
     printf("Testing Configs...");
     z_owned_config_t _ret_config;
     z_config_new(&_ret_config);
-    assert(!_z_check(_ret_config));  // null config corresponds to empty one
+    assert(!z_internal_check(_ret_config));  // null config corresponds to empty one
     z_drop(z_move(_ret_config));
     z_config_default(&_ret_config);
-    assert(_z_check(_ret_config));
+    assert(z_internal_check(_ret_config));
 #ifdef ZENOH_PICO
     _ret_int8 = zp_config_insert(z_loan_mut(_ret_config), Z_CONFIG_CONNECT_KEY, argv[1]);
     assert_eq(_ret_int8, 0);
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
 
     z_owned_config_t _ret_sconfig;
     z_config_default(&_ret_sconfig);
-    assert(_z_check(_ret_sconfig));
+    assert(z_internal_check(_ret_sconfig));
 
     printf("Ok\n");
     z_sleep_s(SLEEP);
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
 
     z_owned_session_t s1;
     z_open(&s1, z_move(_ret_config));
-    assert(_z_check(s1));
+    assert(z_internal_check(s1));
     z_id_t _ret_zid = z_info_zid(z_loan(s1));
     printf("Session 1 with PID: 0x");
     for (unsigned long i = 0; i < sizeof(_ret_zid); i++) {
@@ -263,7 +263,7 @@ int main(int argc, char **argv) {
 
     z_owned_session_t s2;
     z_open(&s2, z_move(_ret_config));
-    assert(_z_check(s2));
+    assert(z_internal_check(s2));
     _ret_zid = z_info_zid(z_loan(s2));
     printf("Session 2 with PID: 0x");
     for (unsigned long i = 0; i < sizeof(_ret_zid); i++) {
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_from_str(&s1_key, s1_res);
     z_owned_keyexpr_t _ret_expr;
     z_declare_keyexpr(&_ret_expr, z_loan(s1), z_loan(s1_key));
-    assert(_z_check(_ret_expr));
+    assert(z_internal_check(_ret_expr));
     printf("Ok\n");
 
     printf("Session Put...");
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
 
     _ret_int8 = z_put(z_loan(s1), z_loan(_ret_expr), z_move(payload), &_ret_put_opt);
     assert_eq(_ret_int8, 0);
-    assert(!_z_check(encoding));
+    assert(!z_internal_check(encoding));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);
@@ -338,7 +338,7 @@ int main(int argc, char **argv) {
     _ret_int8 = z_undeclare_keyexpr(z_move(_ret_expr), z_loan(s1));
     printf(" %02x\n", _ret_int8);
     assert_eq(_ret_int8, 0);
-    assert(!_z_check(_ret_expr));
+    assert(!z_internal_check(_ret_expr));
     printf("Ok\n");
 
     printf("Declaring Publisher...");
@@ -350,7 +350,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t _ret_pub;
     _ret_int8 = z_declare_publisher(&_ret_pub, z_loan(s1), z_loan(s1_key), &_ret_pub_opt);
     assert(_ret_int8 == _Z_RES_OK);
-    assert(!_z_check(encoding));
+    assert(!z_internal_check(encoding));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);
@@ -381,7 +381,7 @@ int main(int argc, char **argv) {
     printf("Undeclaring Publisher...");
     _ret_int8 = z_undeclare_publisher(z_move(_ret_pub));
     assert_eq(_ret_int8, 0);
-    assert(!_z_check(_ret_pub));
+    assert(!z_internal_check(_ret_pub));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);
@@ -389,7 +389,7 @@ int main(int argc, char **argv) {
     printf("Undeclaring Subscriber...");
     _ret_int8 = z_undeclare_subscriber(z_move(_ret_sub));
     assert_eq(_ret_int8, 0);
-    assert(!_z_check(_ret_sub));
+    assert(!z_internal_check(_ret_sub));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);

--- a/tests/z_api_bytes_test.c
+++ b/tests/z_api_bytes_test.c
@@ -205,14 +205,14 @@ void test_slice(void) {
     z_owned_slice_t s;
     z_slice_copy_from_buf(&s, data, 10);
     z_bytes_serialize_from_slice(&payload2, z_slice_loan(&s));
-    assert(_z_owned_slice_check(&s));
+    assert(z_internal_slice_check(&s));
     z_slice_drop(z_slice_move(&s));
     assert(z_check_and_drop_payload(&payload2, data, 10));
 
     z_owned_bytes_t payload3;
     z_slice_copy_from_buf(&s, data, 10);
     z_bytes_from_slice(&payload3, z_slice_move(&s));
-    assert(!_z_owned_slice_check(&s));
+    assert(!z_internal_slice_check(&s));
     assert(z_check_and_drop_payload(&payload3, data, 10));
 
     z_owned_bytes_t payload4;

--- a/tests/z_api_config_test.c
+++ b/tests/z_api_config_test.c
@@ -25,7 +25,7 @@ void config_client(void) {
     const char *locator = "tcp/127.0.0.1";
     z_owned_config_t config;
     assert(0 == z_config_client(&config, locator));
-    assert(_z_owned_config_check(&config));
+    assert(z_internal_config_check(&config));
     assert(strcmp(zp_config_get(z_config_loan(&config), Z_CONFIG_MODE_KEY), Z_CONFIG_MODE_CLIENT) == 0);
     assert(strcmp(zp_config_get(z_config_loan(&config), Z_CONFIG_CONNECT_KEY), locator) == 0);
     z_config_drop(z_config_move(&config));
@@ -35,12 +35,12 @@ void config_peer(void) {
     const char *locator = "udp/228.0.0.4:7447#iface=en0";
     z_owned_config_t config;
     assert(0 == z_config_peer(&config, locator));
-    assert(_z_owned_config_check(&config));
+    assert(z_internal_config_check(&config));
     assert(strcmp(zp_config_get(z_config_loan(&config), Z_CONFIG_MODE_KEY), Z_CONFIG_MODE_PEER) == 0);
     assert(strcmp(zp_config_get(z_config_loan(&config), Z_CONFIG_CONNECT_KEY), locator) == 0);
     z_config_drop(z_config_move(&config));
     assert(0 != z_config_peer(&config, NULL));
-    assert(!_z_owned_config_check(&config));
+    assert(!z_internal_config_check(&config));
 }
 
 int main(void) {

--- a/tests/z_api_double_drop_test.c
+++ b/tests/z_api_double_drop_test.c
@@ -25,21 +25,21 @@
 void test_keyexpr(void) {
     z_owned_keyexpr_t keyexpr;
     z_keyexpr_from_str(&keyexpr, URL);
-    assert(_z_check(keyexpr));
+    assert(z_internal_check(keyexpr));
     z_drop(z_move(keyexpr));
-    assert(!_z_check(keyexpr));
+    assert(!z_internal_check(keyexpr));
     z_drop(z_move(keyexpr));
-    assert(!_z_check(keyexpr));
+    assert(!z_internal_check(keyexpr));
 }
 
 void test_config(void) {
     z_owned_config_t config;
     z_config_default(&config);
-    assert(_z_check(config));
+    assert(z_internal_check(config));
     z_drop(z_move(config));
-    assert(!_z_check(config));
+    assert(!z_internal_check(config));
     z_drop(z_move(config));
-    assert(!_z_check(config));
+    assert(!z_internal_check(config));
 }
 
 int main(void) {

--- a/tests/z_api_encoding_test.c
+++ b/tests/z_api_encoding_test.c
@@ -10,15 +10,15 @@
 
 void test_null_encoding(void) {
     z_owned_encoding_t e;
-    _z_owned_encoding_null(&e);
-    assert(!_z_owned_encoding_check(&e));
+    z_internal_encoding_null(&e);
+    assert(!z_internal_encoding_check(&e));
     z_encoding_drop(z_encoding_move(&e));
 }
 
 void test_encoding_without_id(void) {
     z_owned_encoding_t e1;
     z_encoding_from_str(&e1, "my_encoding");
-    assert(_z_owned_encoding_check(&e1));
+    assert(z_internal_encoding_check(&e1));
     z_owned_string_t s;
     z_encoding_to_string(z_encoding_loan(&e1), &s);
     assert(strncmp("zenoh/bytes;my_encoding", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
@@ -27,7 +27,7 @@ void test_encoding_without_id(void) {
 
     z_owned_encoding_t e2;
     z_encoding_from_substr(&e2, "my_encoding", 4);
-    assert(_z_owned_encoding_check(&e2));
+    assert(z_internal_encoding_check(&e2));
 
     z_encoding_to_string(z_encoding_loan(&e2), &s);
     assert(strncmp("zenoh/bytes;my_e", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
@@ -38,7 +38,7 @@ void test_encoding_without_id(void) {
 void test_encoding_with_id(void) {
     z_owned_encoding_t e1;
     z_encoding_from_str(&e1, "zenoh/string;utf8");
-    assert(_z_owned_encoding_check(&e1));
+    assert(z_internal_encoding_check(&e1));
     z_owned_string_t s;
     z_encoding_to_string(z_encoding_loan(&e1), &s);
     assert(strncmp("zenoh/string;utf8", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
@@ -47,7 +47,7 @@ void test_encoding_with_id(void) {
 
     z_owned_encoding_t e2;
     z_encoding_from_substr(&e2, "zenoh/string;utf8", 15);
-    assert(_z_owned_encoding_check(&e2));
+    assert(z_internal_encoding_check(&e2));
 
     z_encoding_to_string(z_encoding_loan(&e2), &s);
     assert(strncmp("zenoh/string;utf8", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) == 0);
@@ -56,7 +56,7 @@ void test_encoding_with_id(void) {
 
     z_owned_encoding_t e3;
     z_encoding_from_str(&e3, "custom_id;custom_schema");
-    assert(_z_owned_encoding_check(&e3));
+    assert(z_internal_encoding_check(&e3));
 
     z_encoding_to_string(z_encoding_loan(&e3), &s);
     assert(strncmp("zenoh/bytes;custom_id;custom_schema", z_string_data(z_string_loan(&s)),
@@ -66,7 +66,7 @@ void test_encoding_with_id(void) {
 
     z_owned_encoding_t e4;
     z_encoding_from_substr(&e4, "custom_id;custom_schema", 16);
-    assert(_z_owned_encoding_check(&e2));
+    assert(z_internal_encoding_check(&e2));
 
     z_encoding_to_string(z_encoding_loan(&e4), &s);
     assert(strncmp("zenoh/bytes;custom_id;custom", z_string_data(z_string_loan(&s)), z_string_len(z_string_loan(&s))) ==
@@ -77,7 +77,7 @@ void test_encoding_with_id(void) {
 
 void test_with_schema(void) {
     z_owned_encoding_t e;
-    _z_owned_encoding_null(&e);
+    z_internal_encoding_null(&e);
     z_encoding_set_schema_from_str(z_encoding_loan_mut(&e), "my_schema");
 
     z_owned_string_t s;

--- a/tests/z_api_null_drop_test.c
+++ b/tests/z_api_null_drop_test.c
@@ -30,19 +30,19 @@
 // set v1 to null
 // move v to v1
 // make sure that v is null now
-#define TEST(name)                 \
-    {                              \
-        z_owned_##name##_t v;      \
-        memset(&v, -1, sizeof(v)); \
-        _z_null(&v);               \
-        assert(!_z_check(v));      \
-        z_drop(z_move(v));         \
-        z_drop(z_move(v));         \
-        z_owned_##name##_t v1;     \
-        _z_null(&v1);              \
-        memset(&v, -1, sizeof(v)); \
-        z_take(&v1, z_move(v));    \
-        assert(!_z_check(v));      \
+#define TEST(name)                    \
+    {                                 \
+        z_owned_##name##_t v;         \
+        memset(&v, -1, sizeof(v));    \
+        z_internal_null(&v);          \
+        assert(!z_internal_check(v)); \
+        z_drop(z_move(v));            \
+        z_drop(z_move(v));            \
+        z_owned_##name##_t v1;        \
+        z_internal_null(&v1);         \
+        memset(&v, -1, sizeof(v));    \
+        z_take(&v1, z_move(v));       \
+        assert(!z_internal_check(v)); \
     }
 
 int main(void) {

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
 
     z_owned_session_t s2;
     assert(z_open(&s2, z_move(config)) == Z_OK);
-    assert(_z_check(s2));
+    assert(z_internal_check(s2));
     _z_string_t zid2 = format_id(&(_Z_RC_IN_VAL(z_loan(s2))->_local_zid));
     printf("Session 2 with PID: %s\n", _z_string_data(&zid2));
     _z_string_clear(&zid2);

--- a/tests/z_keyexpr_test.c
+++ b/tests/z_keyexpr_test.c
@@ -469,7 +469,7 @@ void test_concat(void) {
     z_keyexpr_drop(z_keyexpr_move(&ke2));
 
     assert(0 != z_keyexpr_concat(&ke2, z_keyexpr_loan(&ke1), "*/e/*", 3));
-    assert(!_z_owned_keyexpr_check(&ke2));
+    assert(!z_internal_keyexpr_check(&ke2));
 
     z_keyexpr_drop(z_keyexpr_move(&ke1));
 }


### PR DESCRIPTION
renamed `_z_check` / `_z_null` to `z_internal` to make API consistent with zenoh-c
See https://github.com/eclipse-zenoh/zenoh-c/pull/605