### PR TITLE
Fix make_decl_queryable argument order

### DIFF
--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -105,7 +105,7 @@ _z_declaration_t _z_make_undecl_keyexpr(uint16_t id);
 _z_declaration_t _z_make_decl_subscriber(_Z_MOVE(_z_keyexpr_t) key, uint32_t id);
 _z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
-_z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint16_t distance, _Bool complete);
+_z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, _Bool complete, uint16_t distance);
 _z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
 _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id);

--- a/src/protocol/definitions/declarations.c
+++ b/src/protocol/definitions/declarations.c
@@ -74,7 +74,7 @@ _z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL const _z_key
                       ._id = id, ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(*key)}}};
 }
 
-_z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint16_t distance, _Bool complete) {
+_z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, _Bool complete, uint16_t distance) {
     return (_z_declaration_t){
         ._tag = _Z_DECL_QUERYABLE,
         ._body = {._decl_queryable = {._id = id,


### PR DESCRIPTION
There was a value mismatch between queryable distance and  queryable complete values when making the queryable declaration.

Based on @OlivierHecart, the argument order was not aligned with the rest of the codebase issue so I changed it.