### PR TITLE
Fix request timeout u64 error

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -390,7 +390,7 @@ typedef struct {
     z_priority_t priority;
     _Bool is_express;
     z_query_target_t target;
-    uint32_t timeout_ms;
+    uint64_t timeout_ms;
     z_moved_bytes_t *attachment;
 } z_get_options_t;
 

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -246,7 +246,7 @@ int8_t _z_send_reply_err(const _z_query_t *query, const _z_session_rc_t *zsrc, c
  */
 int8_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
                 const z_consolidation_mode_t consolidation, const _z_value_t value, _z_reply_handler_t callback,
-                _z_drop_handler_t dropper, void *arg, uint32_t timeout_ms, const _z_bytes_t attachment,
+                _z_drop_handler_t dropper, void *arg, uint64_t timeout_ms, const _z_bytes_t attachment,
                 z_congestion_control_t cong_ctrl, z_priority_t priority, _Bool is_express);
 #endif
 

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -294,7 +294,7 @@ _Z_VEC_DEFINE(_z_network_message, _z_network_message_t)
 void _z_msg_fix_mapping(_z_zenoh_message_t *msg, uint16_t mapping);
 _z_network_message_t _z_msg_make_query(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_slice_t) parameters, _z_zint_t qid,
                                        z_consolidation_mode_t consolidation, _Z_MOVE(_z_value_t) value,
-                                       uint32_t timeout_ms, _z_bytes_t attachment, z_congestion_control_t cong_ctrl,
+                                       uint64_t timeout_ms, _z_bytes_t attachment, z_congestion_control_t cong_ctrl,
                                        z_priority_t priority, _Bool is_express);
 _z_network_message_t _z_n_msg_make_reply(_z_zint_t rid, _Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_push_body_t) body);
 _z_network_message_t _z_n_msg_make_response_final(_z_zint_t rid);

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -126,7 +126,7 @@ typedef struct {
     _z_n_qos_t _ext_qos;
     z_query_target_t _ext_target;
     uint32_t _ext_budget;
-    uint32_t _ext_timeout_ms;
+    uint64_t _ext_timeout_ms;
     enum {
         _Z_REQUEST_QUERY,
         _Z_REQUEST_PUT,

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -455,7 +455,7 @@ int8_t _z_send_reply_err(const _z_query_t *query, const _z_session_rc_t *zsrc, c
 /*------------------ Query ------------------*/
 int8_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
                 const z_consolidation_mode_t consolidation, _z_value_t value, _z_reply_handler_t callback,
-                _z_drop_handler_t dropper, void *arg, uint32_t timeout_ms, const _z_bytes_t attachment,
+                _z_drop_handler_t dropper, void *arg, uint64_t timeout_ms, const _z_bytes_t attachment,
                 z_congestion_control_t cong_ctrl, z_priority_t priority, _Bool is_express) {
     int8_t ret = _Z_RES_OK;
 

--- a/src/protocol/codec/network.c
+++ b/src/protocol/codec/network.c
@@ -195,10 +195,7 @@ int8_t _z_request_decode_extensions(_z_msg_ext_t *extension, void *ctx) {
             msg->_ext_budget = (uint32_t)extension->_body._zint._val;
         } break;
         case 0x06 | _Z_MSG_EXT_ENC_ZINT: {
-            if (extension->_body._zint._val > UINT32_MAX) {
-                return _Z_ERR_MESSAGE_DESERIALIZATION_FAILED;
-            }
-            msg->_ext_timeout_ms = (uint32_t)extension->_body._zint._val;
+            msg->_ext_timeout_ms = extension->_body._zint._val;
         } break;
         default:
             if ((extension->_header & _Z_MSG_EXT_FLAG_M) != 0) {

--- a/src/protocol/codec/network.c
+++ b/src/protocol/codec/network.c
@@ -190,7 +190,7 @@ int8_t _z_request_decode_extensions(_z_msg_ext_t *extension, void *ctx) {
         } break;
         case 0x05 | _Z_MSG_EXT_ENC_ZINT: {
             if (extension->_body._zint._val > UINT32_MAX) {
-                return _Z_ERR_MESSAGE_DESERIALIZATION_FAILED;
+                _Z_INFO("Request extension budget was truncated to u32.");
             }
             msg->_ext_budget = (uint32_t)extension->_body._zint._val;
         } break;

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -138,7 +138,7 @@ void _z_n_msg_free(_z_network_message_t **msg) {
 
 _z_zenoh_message_t _z_msg_make_query(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_slice_t) parameters, _z_zint_t qid,
                                      z_consolidation_mode_t consolidation, _Z_MOVE(_z_value_t) value,
-                                     uint32_t timeout_ms, _z_bytes_t attachment, z_congestion_control_t cong_ctrl,
+                                     uint64_t timeout_ms, _z_bytes_t attachment, z_congestion_control_t cong_ctrl,
                                      z_priority_t priority, _Bool is_express) {
     return (_z_zenoh_message_t){
         ._tag = _Z_N_REQUEST,

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1346,7 +1346,7 @@ _z_n_msg_request_t gen_request(void) {
         ._ext_timestamp = gen_bool() ? gen_timestamp() : _z_timestamp_null(),
         ._ext_target = gen_uint8() % 3,
         ._ext_budget = gen_bool() ? (uint32_t)gen_uint64() : 0,
-        ._ext_timeout_ms = gen_bool() ? (uint32_t)gen_uint64() : 0,
+        ._ext_timeout_ms = gen_bool() ? gen_uint64() : 0,
     };
     switch (gen_uint8() % 2) {
         case 0: {


### PR DESCRIPTION
When requesting with a timeout value > U32MAX, zenoh pico would close the connection due to a malformed message.

Changed internal timeout field to be u64.

Bonus: Truncate budget to u32 instead of error (rust behavior alignment).