### PR TITLE
Fix arduino examples

### DIFF
--- a/examples/arduino/z_get.ino
+++ b/examples/arduino/z_get.ino
@@ -21,16 +21,12 @@
 #define SSID "SSID"
 #define PASS "PASS"
 
-#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
-#if CLIENT_OR_PEER == 0
+// Client mode values (comment/uncomment as needed)
 #define MODE "client"
 #define CONNECT ""  // If empty, it will scout
-#elif CLIENT_OR_PEER == 1
-#define MODE "peer"
-#define CONNECT "udp/224.0.0.225:7447#iface=en0"
-#else
-#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
-#endif
+// Peer mode values (comment/uncomment as needed)
+// #define MODE "peer"
+// #define CONNECT "udp/224.0.0.225:7447#iface=en0"
 
 #define KEYEXPR "demo/example/**"
 #define VALUE ""

--- a/examples/arduino/z_get.ino
+++ b/examples/arduino/z_get.ino
@@ -93,10 +93,14 @@ void setup() {
     }
     Serial.println("OK");
 
-    // Start the receive and the session lease loop for zenoh-pico
-    zp_start_read_task(z_session_loan_mut(&s), NULL);
-    zp_start_lease_task(z_session_loan_mut(&s), NULL);
-
+    // Start read and lease tasks for zenoh-pico
+    if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
+        Serial.println("Unable to start read and lease tasks\n");
+        z_close(z_session_move(&s), NULL);
+        while (1) {
+            ;
+        }
+    }
     Serial.println("Zenoh setup finished!");
 
     delay(300);

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -69,9 +69,14 @@ void setup() {
     }
     Serial.println("OK");
 
-    // Start the receive and the session lease loop for zenoh-pico
-    zp_start_read_task(z_session_loan_mut(&s), NULL);
-    zp_start_lease_task(z_session_loan_mut(&s), NULL);
+    // Start read and lease tasks for zenoh-pico
+    if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
+        Serial.println("Unable to start read and lease tasks\n");
+        z_close(z_session_move(&s), NULL);
+        while (1) {
+            ;
+        }
+    }
 
     // Declare Zenoh publisher
     Serial.print("Declaring publisher for ");

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -21,16 +21,12 @@
 #define SSID "SSID"
 #define PASS "PASS"
 
-#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
-#if CLIENT_OR_PEER == 0
+// Client mode values (comment/uncomment as needed)
 #define MODE "client"
 #define CONNECT ""  // If empty, it will scout
-#elif CLIENT_OR_PEER == 1
-#define MODE "peer"
-#define CONNECT "udp/224.0.0.225:7447#iface=en0"
-#else
-#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
-#endif
+// Peer mode values (comment/uncomment as needed)
+// #define MODE "peer"
+// #define CONNECT "udp/224.0.0.225:7447#iface=en0"
 
 #define KEYEXPR "demo/example/zenoh-pico-pub"
 #define VALUE "[ARDUINO]{ESP32} Publication from Zenoh-Pico!"

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -31,6 +31,7 @@
 #define KEYEXPR "demo/example/zenoh-pico-pub"
 #define VALUE "[ARDUINO]{ESP32} Publication from Zenoh-Pico!"
 
+z_owned_session_t s;
 z_owned_publisher_t pub;
 static int idx = 0;
 
@@ -60,7 +61,6 @@ void setup() {
 
     // Open Zenoh session
     Serial.print("Opening Zenoh Session...");
-    z_owned_session_t s;
     if (z_open(&s, z_config_move(&config), NULL) < 0) {
         Serial.println("Unable to open session!");
         while (1) {

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -32,7 +32,8 @@
 
 const size_t INTERVAL = 5000;
 const size_t SIZE = 3;
-
+z_owned_session_t s;
+z_owned_subscriber_t sub;
 z_owned_ring_handler_sample_t handler;
 
 void setup() {
@@ -61,7 +62,6 @@ void setup() {
 
     // Open Zenoh session
     Serial.print("Opening Zenoh Session...");
-    z_owned_session_t s;
     if (z_open(&s, z_config_move(&config), NULL) < 0) {
         Serial.println("Unable to open session!");
         while (1) {
@@ -82,7 +82,6 @@ void setup() {
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     z_owned_closure_sample_t closure;
     z_ring_channel_sample_new(&closure, &handler, SIZE);
-    z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -21,16 +21,12 @@
 #define SSID "SSID"
 #define PASS "PASS"
 
-#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
-#if CLIENT_OR_PEER == 0
+// Client mode values (comment/uncomment as needed)
 #define MODE "client"
 #define CONNECT ""  // If empty, it will scout
-#elif CLIENT_OR_PEER == 1
-#define MODE "peer"
-#define CONNECT "udp/224.0.0.225:7447#iface=en0"
-#else
-#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
-#endif
+// Peer mode values (comment/uncomment as needed)
+// #define MODE "peer"
+// #define CONNECT "udp/224.0.0.225:7447#iface=en0"
 
 #define KEYEXPR "demo/example/**"
 

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -70,10 +70,13 @@ void setup() {
     }
     Serial.println("OK");
 
+    // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
-        printf("Unable to start read and lease tasks\n");
+        Serial.println("Unable to start read and lease tasks\n");
         z_close(z_session_move(&s), NULL);
-        return;
+        while (1) {
+            ;
+        }
     }
 
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -93,9 +93,14 @@ void setup() {
     }
     Serial.println("OK");
 
-    // Start the receive and the session lease loop for zenoh-pico
-    zp_start_read_task(z_session_loan_mut(&s), NULL);
-    zp_start_lease_task(z_session_loan_mut(&s), NULL);
+    // Start read and lease tasks for zenoh-pico
+    if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
+        Serial.println("Unable to start read and lease tasks\n");
+        z_close(z_session_move(&s), NULL);
+        while (1) {
+            ;
+        }
+    }
 
     // Declare Zenoh queryable
     Serial.print("Declaring Queryable on ");

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -21,16 +21,12 @@
 #define SSID "SSID"
 #define PASS "PASS"
 
-#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
-#if CLIENT_OR_PEER == 0
+// Client mode values (comment/uncomment as needed)
 #define MODE "client"
 #define CONNECT ""  // If empty, it will scout
-#elif CLIENT_OR_PEER == 1
-#define MODE "peer"
-#define CONNECT "udp/224.0.0.225:7447#iface=en0"
-#else
-#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
-#endif
+// Peer mode values (comment/uncomment as needed)
+// #define MODE "peer"
+// #define CONNECT "udp/224.0.0.225:7447#iface=en0"
 
 #define KEYEXPR "demo/example/zenoh-pico-queryable"
 #define VALUE "[ARDUINO]{ESP32} Queryable from Zenoh-Pico!"

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -31,6 +31,9 @@
 #define KEYEXPR "demo/example/zenoh-pico-queryable"
 #define VALUE "[ARDUINO]{ESP32} Queryable from Zenoh-Pico!"
 
+z_owned_session_t s;
+z_owned_queryable_t qable;
+
 void query_handler(const z_loaned_query_t *query, void *arg) {
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_query_keyexpr(query), &keystr);
@@ -84,7 +87,6 @@ void setup() {
 
     // Open Zenoh session
     Serial.print("Opening Zenoh Session...");
-    z_owned_session_t s;
     if (z_open(&s, z_config_move(&config), NULL) < 0) {
         Serial.println("Unable to open session!");
         while (1) {
@@ -108,7 +110,6 @@ void setup() {
     Serial.println(" ...");
     z_owned_closure_query_t callback;
     z_closure_query(&callback, query_handler, NULL, NULL);
-    z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -30,6 +30,9 @@
 
 #define KEYEXPR "demo/example/**"
 
+z_owned_session_t s;
+z_owned_subscriber_t sub;
+
 void data_handler(const z_loaned_sample_t *sample, void *arg) {
     z_view_string_t keystr;
     z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
@@ -71,7 +74,6 @@ void setup() {
 
     // Open Zenoh session
     Serial.print("Opening Zenoh Session...");
-    z_owned_session_t s;
     if (z_open(&s, z_config_move(&config), NULL) < 0) {
         Serial.println("Unable to open session!");
         while (1) {
@@ -95,7 +97,6 @@ void setup() {
     Serial.println(" ...");
     z_owned_closure_sample_t callback;
     z_closure_sample(&callback, data_handler, NULL, NULL);
-    z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -80,9 +80,14 @@ void setup() {
     }
     Serial.println("OK");
 
-    // Start the receive and the session lease loop for zenoh-pico
-    zp_start_read_task(z_session_loan_mut(&s), NULL);
-    zp_start_lease_task(z_session_loan_mut(&s), NULL);
+    // Start read and lease tasks for zenoh-pico
+    if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
+        Serial.println("Unable to start read and lease tasks\n");
+        z_close(z_session_move(&s), NULL);
+        while (1) {
+            ;
+        }
+    }
 
     // Declare Zenoh subscriber
     Serial.print("Declaring Subscriber on ");

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -21,16 +21,12 @@
 #define SSID "SSID"
 #define PASS "PASS"
 
-#define CLIENT_OR_PEER 0  // 0: Client mode; 1: Peer mode
-#if CLIENT_OR_PEER == 0
+// Client mode values (comment/uncomment as needed)
 #define MODE "client"
 #define CONNECT ""  // If empty, it will scout
-#elif CLIENT_OR_PEER == 1
-#define MODE "peer"
-#define CONNECT "udp/224.0.0.225:7447#iface=en0"
-#else
-#error "Unknown Zenoh operation mode. Check CLIENT_OR_PEER value."
-#endif
+// Peer mode values (comment/uncomment as needed)
+// #define MODE "peer"
+// #define CONNECT "udp/224.0.0.225:7447#iface=en0"
 
 #define KEYEXPR "demo/example/**"
 


### PR DESCRIPTION
Closes #649 and brushes up the arduino examples a little.

The issue itself was due to owned_entities declared as local variables that went out of scope at the end of `setup()` and were overwritten in the `loop()` phase, causing a segault.