### PR TITLE
Fix macros

### DIFF
--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -284,29 +284,29 @@
     )(this_, x)
 
 /**
- * Defines a generic function for cloning any of the ``z_owned_X_t`` types.
+ * Defines a generic function for cloning of the ``z_owned_X_t`` types.
  *
  * Parameters:
- *   x: The clone storage.
- *   y: The instance to clone.
+ *   dst: The clone destination.
+ *   src: The instance to clone.
  *
  * Returns:
- *   Returns the cloned instance of `x`.
+ *   `0` in case of success, negative error code otherwise.
  */
-#define z_clone(x, y) _Generic((x), \
-                  z_owned_keyexpr_t : z_keyexpr_clone,                 \
-                  z_owned_query_t : z_query_clone,                     \
-                  z_owned_sample_t : z_sample_clone,                   \
-                  z_owned_bytes_t : z_bytes_clone,                     \
-                  z_owned_encoding_t : z_encoding_clone,               \
-                  z_owned_reply_err_t : z_reply_err_clone,             \
-                  z_owned_reply_t : z_reply_clone,                     \
-                  z_owned_hello_t : z_hello_clone,                     \
-                  z_owned_string_t : z_string_clone,                   \
-                  z_owned_slice_t : z_slice_clone,                     \
-                  z_owned_string_array_t : z_string_array_clone,       \
-                  z_owned_config_t : z_config_clone                    \
-            )(&x, y)
+#define z_clone(dst, src) _Generic((dst), \
+                  z_owned_keyexpr_t* : z_keyexpr_clone,                 \
+                  z_owned_query_t* : z_query_clone,                     \
+                  z_owned_sample_t* : z_sample_clone,                   \
+                  z_owned_bytes_t* : z_bytes_clone,                     \
+                  z_owned_encoding_t* : z_encoding_clone,               \
+                  z_owned_reply_err_t* : z_reply_err_clone,             \
+                  z_owned_reply_t* : z_reply_clone,                     \
+                  z_owned_hello_t* : z_hello_clone,                     \
+                  z_owned_string_t* : z_string_clone,                   \
+                  z_owned_slice_t* : z_slice_clone,                     \
+                  z_owned_string_array_t* : z_string_array_clone,       \
+                  z_owned_config_t* : z_config_clone                    \
+            )(x, y)
 
 /**
  * Defines a generic function for making null object of any of the ``z_owned_X_t`` types.
@@ -423,12 +423,12 @@ inline z_loaned_condvar_t* z_loan_mut(z_owned_condvar_t& x) { return z_condvar_l
 inline z_loaned_reply_err_t* z_loan_mut(z_owned_reply_err_t& x) { return z_reply_err_loan_mut(&x); }
 
 // z_drop definition
-inline int8_t z_drop(z_moved_session_t* v) { return z_close(v); }
-inline int8_t z_drop(z_moved_publisher_t* v) { return z_undeclare_publisher(v); }
+inline void z_drop(z_moved_session_t* v) { return z_session_drop(v); }
+inline void z_drop(z_moved_publisher_t* v) { return z_publisher_drop(v); }
 inline void z_drop(z_moved_keyexpr_t* v) { z_keyexpr_drop(v); }
 inline void z_drop(z_moved_config_t* v) { z_config_drop(v); }
-inline int8_t z_drop(z_moved_subscriber_t* v) { return z_undeclare_subscriber(v); }
-inline int8_t z_drop(z_moved_queryable_t* v) { return z_undeclare_queryable(v); }
+inline void z_drop(z_moved_subscriber_t* v) { return z_subscriber_drop(v); }
+inline void z_drop(z_moved_queryable_t* v) { return z_queryable_drop(v); }
 inline void z_drop(z_moved_reply_t* v) { z_reply_drop(v); }
 inline void z_drop(z_moved_hello_t* v) { z_hello_drop(v); }
 inline void z_drop(z_moved_string_t* v) { z_string_drop(v); }
@@ -675,6 +675,22 @@ inline void z_take(z_owned_ring_handler_reply_t* this_, z_moved_ring_handler_rep
 inline void z_take(z_owned_fifo_handler_reply_t* this_, z_moved_fifo_handler_reply_t* v) {
     z_fifo_handler_reply_take(this_, v);
 }
+
+// z_clone definition
+inline int8_t z_clone(z_owned_bytes_t* dst, z_loaned_bytes_t* this_) { return z_bytes_clone(dst, this_); };
+inline int8_t z_clone(z_owned_config_t* dst, z_loaned_config_t* this_) { return z_config_clone(dst, this_); };
+inline int8_t z_clone(z_owned_encoding_t* dst, z_loaned_encoding_t* this_) { return z_encoding_clone(dst, this_); };
+inline int8_t z_clone(z_owned_keyexpr_t* dst, z_loaned_keyexpr_t* this_) { return z_keyexpr_clone(dst, this_); };
+inline int8_t z_clone(z_owned_query_t* dst, z_loaned_query_t* this_) { return z_query_clone(dst, this_); };
+inline int8_t z_clone(z_owned_reply_t* dst, z_loaned_reply_t* this_) { return z_reply_clone(dst, this_); };
+inline int8_t z_clone(z_owned_reply_err_t* dst, z_loaned_reply_err_t* this_) { return z_reply_err_clone(dst, this_); };
+inline int8_t z_clone(z_owned_sample_t* dst, z_loaned_sample_t* this_) { return z_sample_clone(dst, this_); };
+inline int8_t z_clone(z_owned_slice_t* dst, z_loaned_slice_t* this_) { return z_slice_clone(dst, this_); };
+inline int8_t z_clone(z_owned_string_t* dst, z_loaned_string_t* this_) { return z_string_clone(dst, this_); };
+inline int8_t z_clone(z_owned_string_array_t* dst, z_loaned_string_array_t* this_) {
+    return z_string_array_clone(dst, this_);
+};
+inline int8_t z_clone(z_owned_hello_t* dst, z_loaned_hello_t* this_) { return z_hello_clone(dst, this_); };
 
 template <class T>
 struct z_loaned_to_owned_type_t {};


### PR DESCRIPTION
make z_clone macro accept owned destination as a pointer;
add z_clone overloads for cpp;
fix z_drop overloads for cpp;
