### PR TITLE
Add background declaration

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1053,14 +1053,7 @@ bool z_string_is_empty(const z_loaned_string_t *str) { return _z_string_is_empty
 const z_loaned_slice_t *z_string_as_slice(const z_loaned_string_t *str) { return &str->_slice; }
 
 #if Z_FEATURE_PUBLICATION == 1
-int8_t _z_undeclare_and_clear_publisher(_z_publisher_t *pub) {
-    int8_t ret = _Z_RES_OK;
-    ret = _z_undeclare_publisher(pub);
-    _z_publisher_clear(pub);
-    return ret;
-}
-
-void _z_publisher_drop(_z_publisher_t *pub) { _z_undeclare_and_clear_publisher(pub); }
+void _z_publisher_drop(_z_publisher_t *pub) { _z_publisher_clear(pub); }
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_publisher_t, publisher, _z_publisher_check, _z_publisher_null,
                                       _z_publisher_drop)
@@ -1191,7 +1184,11 @@ int8_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *z
     return _Z_RES_OK;
 }
 
-int8_t z_undeclare_publisher(z_moved_publisher_t *pub) { return _z_undeclare_and_clear_publisher(&pub->_this._val); }
+int8_t z_undeclare_publisher(z_moved_publisher_t *pub) {
+    int8_t ret = _z_undeclare_publisher(&pub->_this._val);
+    _z_publisher_clear(&pub->_this._val);
+    return ret;
+}
 
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
     options->encoding = NULL;
@@ -1372,15 +1369,7 @@ _Bool z_reply_replier_id(const z_loaned_reply_t *reply, z_id_t *out_id) {
 #if Z_FEATURE_QUERYABLE == 1
 _Z_OWNED_FUNCTIONS_RC_IMPL(query)
 
-int8_t _z_undeclare_and_clear_queryable(_z_queryable_t *queryable) {
-    int8_t ret = _Z_RES_OK;
-
-    ret = _z_undeclare_queryable(queryable);
-    _z_queryable_clear(queryable);
-    return ret;
-}
-
-void _z_queryable_drop(_z_queryable_t *queryable) { _z_undeclare_and_clear_queryable(queryable); }
+void _z_queryable_drop(_z_queryable_t *queryable) { _z_queryable_clear(queryable); }
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_check, _z_queryable_null,
                                       _z_queryable_drop)
@@ -1421,7 +1410,9 @@ int8_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_sessio
 }
 
 int8_t z_undeclare_queryable(z_moved_queryable_t *queryable) {
-    return _z_undeclare_and_clear_queryable(&queryable->_this._val);
+    int8_t ret = _z_undeclare_queryable(&queryable->_this._val);
+    _z_queryable_clear(&queryable->_this._val);
+    return ret;
 }
 
 void z_query_reply_options_default(z_query_reply_options_t *options) {
@@ -1585,14 +1576,7 @@ int8_t z_undeclare_keyexpr(z_moved_keyexpr_t *keyexpr, const z_loaned_session_t 
 }
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-int8_t _z_undeclare_and_clear_subscriber(_z_subscriber_t *sub) {
-    int8_t ret = _Z_RES_OK;
-    ret = _z_undeclare_subscriber(sub);
-    _z_subscriber_clear(sub);
-    return ret;
-}
-
-void _z_subscriber_drop(_z_subscriber_t *sub) { _z_undeclare_and_clear_subscriber(sub); }
+void _z_subscriber_drop(_z_subscriber_t *sub) { _z_subscriber_clear(sub); }
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber_check, _z_subscriber_null,
                                       _z_subscriber_drop)
@@ -1649,7 +1633,11 @@ int8_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t 
     }
 }
 
-int8_t z_undeclare_subscriber(z_moved_subscriber_t *sub) { return _z_undeclare_and_clear_subscriber(&sub->_this._val); }
+int8_t z_undeclare_subscriber(z_moved_subscriber_t *sub) {
+    int8_t ret = _z_undeclare_subscriber(&sub->_this._val);
+    _z_subscriber_clear(&sub->_this._val);
+    return ret;
+}
 
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub) {
     // Retrieve keyexpr from session

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -126,7 +126,6 @@ int8_t _z_undeclare_publisher(_z_publisher_t *pub) {
     // Clear publisher
     _z_write_filter_destroy(pub);
     _z_undeclare_resource(_Z_RC_IN_VAL(&pub->_zn), pub->_key._id);
-    _z_session_weak_drop(&pub->_zn);
     return _Z_RES_OK;
 }
 
@@ -250,7 +249,6 @@ int8_t _z_undeclare_subscriber(_z_subscriber_t *sub) {
     // Only if message is successfully send, local subscription state can be removed
     _z_undeclare_resource(_Z_RC_IN_VAL(&sub->_zn), _Z_RC_IN_VAL(s)->_key_id);
     _z_unregister_subscription(_Z_RC_IN_VAL(&sub->_zn), _Z_RESOURCE_IS_LOCAL, s);
-    _z_session_weak_drop(&sub->_zn);
     return _Z_RES_OK;
 }
 #endif
@@ -313,7 +311,6 @@ int8_t _z_undeclare_queryable(_z_queryable_t *qle) {
     _z_n_msg_clear(&n_msg);
     // Only if message is successfully send, local queryable state can be removed
     _z_unregister_session_queryable(_Z_RC_IN_VAL(&qle->_zn), q);
-    _z_session_weak_drop(&qle->_zn);
     return _Z_RES_OK;
 }
 

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -19,6 +19,7 @@
 #if Z_FEATURE_PUBLICATION == 1
 void _z_publisher_clear(_z_publisher_t *pub) {
     _z_keyexpr_clear(&pub->_key);
+    _z_session_weak_drop(&pub->_zn);
     *pub = _z_publisher_null();
 }
 

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -104,7 +104,7 @@ _z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){._entity_id = 0
 _Bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 
 void _z_queryable_clear(_z_queryable_t *qbl) {
-    // Nothing to clear
+    _z_session_weak_drop(&qbl->_zn);
     *qbl = _z_queryable_null();
 }
 

--- a/src/net/subscribe.c
+++ b/src/net/subscribe.c
@@ -16,8 +16,7 @@
 #if Z_FEATURE_SUBSCRIPTION == 1
 
 void _z_subscriber_clear(_z_subscriber_t *sub) {
-    // Nothing to clear
-    (void)(sub);
+    _z_session_weak_drop(&sub->_zn);
     *sub = _z_subscriber_null();
 }
 


### PR DESCRIPTION
Closes #626.

Drop entity functions now clears up the memory without undeclaring.