### PR TITLE
Improve `z_sleep_*` error code handling

### DIFF
--- a/include/zenoh-pico/system/platform-common.h
+++ b/include/zenoh-pico/system/platform-common.h
@@ -132,9 +132,9 @@ z_result_t z_condvar_signal(z_loaned_condvar_t *cv);
 z_result_t z_condvar_wait(z_loaned_condvar_t *cv, z_loaned_mutex_t *m);
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time);
-int z_sleep_ms(size_t time);
-int z_sleep_s(size_t time);
+z_result_t z_sleep_us(size_t time);
+z_result_t z_sleep_ms(size_t time);
+z_result_t z_sleep_s(size_t time);
 
 /*------------------ Clock ------------------*/
 z_clock_t z_clock_now(void);

--- a/src/system/arduino/opencr/system.c
+++ b/src/system/arduino/opencr/system.c
@@ -98,17 +98,17 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return -1; }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     delay_us(time);
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     delay_ms(time);
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     z_time_t start = z_time_now();
 
     // Most sleep APIs promise to sleep at least whatever you asked them to.

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -82,17 +82,17 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { _Z_CHECK_SYS_ERR(p
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     emscripten_sleep((time / 1000) + (time % 1000 == 0 ? 0 : 1));
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     emscripten_sleep(time);
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     z_time_t start = z_time_now();
 
     // Most sleep APIs promise to sleep at least whatever you asked them to.

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -149,9 +149,9 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { _Z_CHECK_SYS_ERR(p
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) { return usleep(time); }
+z_result_t z_sleep_us(size_t time) { _Z_CHECK_SYS_ERR(usleep(time)); }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     z_time_t start = z_time_now();
 
     // Most sleep APIs promise to sleep at least whatever you asked them to.
@@ -164,7 +164,7 @@ int z_sleep_ms(size_t time) {
     return 0;
 }
 
-int z_sleep_s(size_t time) { return sleep(time); }
+z_result_t z_sleep_s(size_t time) { _Z_CHECK_SYS_ERR(sleep(time)); }
 
 /*------------------ Instant ------------------*/
 z_clock_t z_clock_now(void) {

--- a/src/system/flipper/system.c
+++ b/src/system/flipper/system.c
@@ -152,17 +152,17 @@ z_result_t _z_condvar_signal_all(_z_condvar_t* cv) { return -1; }
 z_result_t _z_condvar_wait(_z_condvar_t* cv, _z_mutex_t* m) { return -1; }
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     furi_delay_us(time);
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     furi_delay_ms(time);
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     z_time_t start = z_time_now();
 
     // Most sleep APIs promise to sleep at least whatever you asked them to.

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -161,17 +161,17 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return -1; }
 #endif  // Z_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time / 1000));
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time));
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time * 1000));
     return 0;
 }

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -114,17 +114,17 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) {
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     ThisThread::sleep_for(chrono::milliseconds(((time / 1000) + (time % 1000 == 0 ? 0 : 1))));
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     ThisThread::sleep_for(chrono::milliseconds(time));
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     ThisThread::sleep_for(chrono::seconds(time));
     return 0;
 }

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -155,9 +155,9 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) {
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) { return z_sleep_ms((time / 1000) + (time % 1000 == 0 ? 0 : 1)); }
+z_result_t z_sleep_us(size_t time) { return z_sleep_ms((time / 1000) + (time % 1000 == 0 ? 0 : 1)); }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     // Guarantees that size_t is split into DWORD segments for Sleep
     uint8_t ratio = sizeof(size_t) / sizeof(DWORD);
     DWORD ratio_time = (DWORD)((time / ratio) + (time % ratio == 0 ? 0 : 1));
@@ -167,7 +167,7 @@ int z_sleep_ms(size_t time) {
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     z_time_t start = z_time_now();
 
     // Most sleep APIs promise to sleep at least whatever you asked them to.

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -122,7 +122,7 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { _Z_CHECK_SYS_ERR(p
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
-int z_sleep_us(size_t time) {
+z_result_t z_sleep_us(size_t time) {
     int32_t rem = time;
     while (rem > 0) {
         rem = k_usleep(rem);  // This function is unlikely to work as expected without kernel tuning.
@@ -136,7 +136,7 @@ int z_sleep_us(size_t time) {
     return 0;
 }
 
-int z_sleep_ms(size_t time) {
+z_result_t z_sleep_ms(size_t time) {
     int32_t rem = time;
     while (rem > 0) {
         rem = k_msleep(rem);
@@ -145,7 +145,7 @@ int z_sleep_ms(size_t time) {
     return 0;
 }
 
-int z_sleep_s(size_t time) {
+z_result_t z_sleep_s(size_t time) {
     int32_t rem = time;
     while (rem > 0) {
         rem = k_sleep(K_SECONDS(rem));


### PR DESCRIPTION
- change z_sleep_* return type to z_result_t
- unify error processing for POSIX systems