### PR TITLE
Remove config token duplicate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,6 @@ set(Z_FEATURE_LINK_UDP_UNICAST 1 CACHE STRING "Toggle UDP unicast links")
 set(Z_FEATURE_MULTICAST_TRANSPORT 1 CACHE STRING "Toggle multicast transport")
 set(Z_FEATURE_UNICAST_TRANSPORT 1 CACHE STRING "Toggle unicast transport")
 set(Z_FEATURE_RAWETH_TRANSPORT 0 CACHE STRING "Toggle raw ethernet transport")
-set(Z_FEATURE_INTEREST 1 CACHE STRING "Toggle interest feature")
 
 add_compile_definitions("Z_BUILD_DEBUG=$<CONFIG:Debug>")
 message(STATUS "Building with feature confing:\n\


### PR DESCRIPTION
Apparently we had a duplicate on `Z_FEATURE_INTEREST` in the CMake