### PR TITLE
Fix docs generation for methods which returns bool

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = ['sphinx_c_autodoc', 'sphinx_c_autodoc.napoleon']
 language = 'c'
 c_autodoc_roots = ['../include/zenoh-pico/api/']
 c_autodoc_compilation_args = [
+    "-DSPHINX_DOCS",
     "-DZ_FEATURE_UNSTABLE_API=1",
     "-DZ_FEATURE_PUBLICATION=1",
     "-DZ_FEATURE_SUBSCRIPTION=1",

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -15,7 +15,10 @@
 #ifndef INCLUDE_ZENOH_PICO_API_PRIMITIVES_H
 #define INCLUDE_ZENOH_PICO_API_PRIMITIVES_H
 
+#ifndef SPHINX_DOCS
+// For some reason sphinx/clang doesn't handle bool types correctly if stdbool.h is included
 #include <stdbool.h>
+#endif
 #include <stdint.h>
 
 #include "olv_macros.h"


### PR DESCRIPTION
Fix docs generation for methods which returns bool: e.g: `z_slice_is_empty`
![image](https://github.com/user-attachments/assets/23c0a85b-e153-4dc4-9a69-78c3174af25c)
