### PR TITLE
make z_close take session by mutable reference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -821,6 +821,7 @@ Functions
 ^^^^^^^^^
 .. autocfunction:: primitives.h::z_open
 .. autocfunction:: primitives.h::z_close
+.. autocfunction:: primitives.h::z_session_is_closed
 
 .. autocfunction:: primitives.h::z_info_zid
 .. autocfunction:: primitives.h::z_info_routers_zid

--- a/examples/arduino/z_get.ino
+++ b/examples/arduino/z_get.ino
@@ -96,7 +96,7 @@ void setup() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         Serial.println("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         while (1) {
             ;
         }

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -72,7 +72,7 @@ void setup() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         Serial.println("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         while (1) {
             ;
         }

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -73,7 +73,7 @@ void setup() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         Serial.println("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         while (1) {
             ;
         }

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -98,7 +98,7 @@ void setup() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         Serial.println("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         while (1) {
             ;
         }

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -85,7 +85,7 @@ void setup() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         Serial.println("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         while (1) {
             ;
         }

--- a/examples/espidf/z_get.c
+++ b/examples/espidf/z_get.c
@@ -180,7 +180,7 @@ void app_main() {
 
     printf("Closing Zenoh Session...");
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 }
 #else

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -165,7 +165,7 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_move(pub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 }
 #else

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -140,7 +140,7 @@ void app_main() {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
 
@@ -181,7 +181,7 @@ void app_main() {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 }
 #else

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -187,7 +187,7 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 }
 #else

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -168,7 +168,7 @@ void app_main() {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 }
 #else

--- a/examples/freertos_plus_tcp/z_get.c
+++ b/examples/freertos_plus_tcp/z_get.c
@@ -71,7 +71,7 @@ void app_main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -100,7 +100,7 @@ void app_main(void) {
         }
     }
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -78,7 +78,7 @@ void app_main(void) {
     if (zp_start_read_task(z_loan_mut(s), &read_task_opt) < 0 ||
         zp_start_lease_task(z_loan_mut(s), &lease_task_opt) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -108,7 +108,7 @@ void app_main(void) {
 
     // Clean-up
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -80,7 +80,7 @@ void app_main(void) {
 
     z_undeclare_publisher(z_move(pub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -49,7 +49,7 @@ void app_main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -90,7 +90,7 @@ void app_main(void) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_put.c
+++ b/examples/freertos_plus_tcp/z_put.c
@@ -47,7 +47,7 @@ void app_main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -57,7 +57,7 @@ void app_main(void) {
     z_view_keyexpr_from_str_unchecked(&vke, KEYEXPR);
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return;
     }
 
@@ -79,7 +79,7 @@ void app_main(void) {
 
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -73,7 +73,7 @@ void app_main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -98,7 +98,7 @@ void app_main(void) {
 
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -57,7 +57,7 @@ void app_main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return;
     }
 
@@ -78,7 +78,7 @@ void app_main(void) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -78,7 +78,7 @@ void app_main(void) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }
 #else
 void app_main(void) {

--- a/examples/mbed/z_get.cpp
+++ b/examples/mbed/z_get.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
 
     printf("Closing Zenoh Session...");
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     printf("OK!\n");
 
     return 0;

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_publisher_move(&pub));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     printf("OK!\n");
 
     return 0;

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     printf("OK!\n");
 
     return 0;

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_queryable_move(&qable));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     printf("OK!\n");
 
     return 0;

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     printf("OK!\n");
 
     return 0;

--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_get_channel.c
+++ b/examples/unix/c11/z_get_channel.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
 
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_info.c
+++ b/examples/unix/c11/z_info.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -96,5 +96,5 @@ int main(int argc, char **argv) {
     z_closure(&callback2, print_zid);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
 
     if (zp_start_read_task(z_loan_mut(session), NULL) < 0 || zp_start_lease_task(z_loan_mut(session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_drop(z_move(session));
         return -1;
     }
 
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     z_drop(z_move(pub));
     z_drop(z_move(sub));
 
-    z_close(z_move(session), NULL);
+    z_drop(z_move(session));
 }
 
 char* getopt(int argc, char** argv, char option) {

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
 
     if (zp_start_read_task(z_loan_mut(session), NULL) < 0 || zp_start_lease_task(z_loan_mut(session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_drop(z_move(session));
         return -1;
     }
 
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
     z_drop(z_move(sub));
 
-    z_close(z_move(session), NULL);
+    z_drop(z_move(session));
 }
 #else
 int main(void) {

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return -1;
     }
     // Wait for joins in peer mode
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return -1;
     }
     // Wait for joins in peer mode
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
     // Declare publisher
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     z_drop(z_move(payload));
     exit(0);
 }

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_put.c
+++ b/examples/unix/c11/z_put.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return -1;
     }
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
     z_drop(z_move(handler));
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -168,7 +168,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
     // Declare Subscriber/resource
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     exit(0);
 }
 #else

--- a/examples/unix/c99/z_get.c
+++ b/examples/unix/c99/z_get.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_condvar_loan_mut(&cond), z_mutex_loan_mut(&mutex));
     z_mutex_unlock(z_mutex_loan_mut(&mutex));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
 
     return 0;
 }

--- a/examples/unix/c99/z_info.c
+++ b/examples/unix/c99/z_info.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -96,5 +96,5 @@ int main(int argc, char **argv) {
     z_closure_zid(&callback2, print_zid, NULL, NULL);
     z_info_peers_zid(z_session_loan(&s), z_closure_zid_move(&callback2));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
 }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
     if (zp_start_read_task(z_session_loan_mut(&session), NULL) < 0 ||
         zp_start_lease_task(z_session_loan_mut(&session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_session_drop(z_session_move(&session));
         return -1;
     }
 
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
     z_undeclare_subscriber(z_subscriber_move(&sub));
     z_undeclare_publisher(z_publisher_move(&pub));
 
-    z_close(z_session_move(&session), NULL);
+    z_session_drop(z_session_move(&session));
 }
 
 char* getopt(int argc, char** argv, char option) {

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     if (zp_start_read_task(z_session_loan_mut(&session), NULL) < 0 ||
         zp_start_lease_task(z_session_loan_mut(&session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_session_drop(z_session_move(&session));
         return -1;
     }
 
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
 
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    z_close(z_session_move(&session), NULL);
+    z_session_drop(z_session_move(&session));
 }
 #else
 int main(void) {

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_publisher(z_publisher_move(&pub));
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     return 0;
 }
 #else

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     }
 
     z_undeclare_publisher(z_publisher_move(&pub));
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     free(buf);
     return 0;
 }

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
 
     return 0;
 }

--- a/examples/unix/c99/z_put.c
+++ b/examples/unix/c99/z_put.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_session_loan(&s), z_view_keyexpr_loan(&vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_keyexpr(z_keyexpr_move(&ke), z_session_loan(&s));
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     return 0;
 }
 #else

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_queryable_move(&qable));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
 
     return 0;
 }

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_session_loan_mut(&s), NULL) < 0 || zp_start_lease_task(z_session_loan_mut(&s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_subscriber(z_subscriber_move(&sub));
 
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
 
     return 0;
 }

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_session_loan(&s), NULL);
     }
     z_undeclare_subscriber(z_subscriber_move(&sub));
-    z_close(z_session_move(&s), NULL);
+    z_session_drop(z_session_move(&s));
     return 0;
 }
 #else

--- a/examples/windows/z_get.c
+++ b/examples/windows/z_get.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
     z_condvar_wait(z_loan_mut(cond), z_loan_mut(mutex));
     z_mutex_unlock(z_loan_mut(mutex));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/windows/z_info.c
+++ b/examples/windows/z_info.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -69,5 +69,5 @@ int main(int argc, char **argv) {
     z_closure(&callback2, print_zid);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
 
     if (zp_start_read_task(z_loan_mut(session), NULL) < 0 || zp_start_lease_task(z_loan_mut(session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_drop(z_move(session));
         return -1;
     }
 
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     z_drop(z_move(pub));
     z_drop(z_move(sub));
 
-    z_close(z_move(session), NULL);
+    z_drop(z_move(session));
 }
 
 char* getopt(int argc, char** argv, char option) {

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
 
     if (zp_start_read_task(z_loan_mut(session), NULL) < 0 || zp_start_lease_task(z_loan_mut(session), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&session), NULL);
+        z_drop(z_move(session));
         return -1;
     }
 
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
     z_drop(z_move(sub));
 
-    z_close(z_move(session), NULL);
+    z_drop(z_move(session));
 }
 #else
 int main(void) {

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return -1;
     }
 
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     z_undeclare_publisher(z_move(pub));
     zp_stop_read_task(z_loan_mut(s));
     zp_stop_lease_task(z_loan_mut(s));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     free(buf);
     return 0;
 }

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_publisher(z_move(pub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     free(buf);
     return 0;

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/windows/z_put.c
+++ b/examples/windows/z_put.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     z_owned_keyexpr_t ke;
     if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
-        z_close(z_move(s), NULL);
+        z_drop(z_move(s));
         return -1;
     }
 
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_keyexpr(z_move(ke), z_loan(s));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 
     return 0;
 }

--- a/examples/zephyr/z_get.c
+++ b/examples/zephyr/z_get.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
     printf("Closing Zenoh Session...");
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 
     return 0;

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_publisher(z_move(pub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 
     return 0;

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
 
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     z_undeclare_subscriber(z_move(sub));
     z_drop(z_move(handler));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 
     return 0;

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_queryable(z_move(qable));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 
     return 0;

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     printf("Closing Zenoh Session...");
     z_undeclare_subscriber(z_move(sub));
 
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     printf("OK!\n");
 
     return 0;

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1287,12 +1287,23 @@ z_result_t z_open(z_owned_session_t *zs, z_moved_config_t *config, const z_open_
  * Closes a Zenoh session.
  *
  * Parameters:
- *   zs: Moved :c:type:`z_owned_session_t` to close.
+ *   zs: Loaned :c:type:`z_owned_session_t` to close.
  *
  * Return:
  *   ``0`` if close successful, ``negative value`` otherwise.
  */
-z_result_t z_close(z_moved_session_t *zs, const z_close_options_t *options);
+z_result_t z_close(z_loaned_session_t *zs, const z_close_options_t *options);
+
+/**
+ * Checks if Zenoh session is closed.
+ *
+ * Parameters:
+ *   zs: Loaned :c:type:`z_owned_session_t`.
+ *
+ * Return:
+ *   ``true`` if session is closed, ``false`` otherwise.
+ */
+bool z_session_is_closed(const z_loaned_session_t *zs);
 
 /**
  * Fetches Zenoh IDs of all connected peers.

--- a/include/zenoh-pico/collections/refcount.h
+++ b/include/zenoh-pico/collections/refcount.h
@@ -128,12 +128,17 @@ size_t _z_rc_strong_count(void *cnt);
         return false;                                                                                                \
     }                                                                                                                \
     static inline bool name##_rc_drop(name##_rc_t *p) {                                                              \
+        if (p == NULL) {                                                                                             \
+            return false;                                                                                            \
+        }                                                                                                            \
+        bool res = false;                                                                                            \
         if (name##_rc_decr(p) && p->_val != NULL) {                                                                  \
             type##_clear(p->_val);                                                                                   \
             z_free(p->_val);                                                                                         \
-            return true;                                                                                             \
+            res = true;                                                                                              \
         }                                                                                                            \
-        return false;                                                                                                \
+        *p = name##_rc_null();                                                                                       \
+        return res;                                                                                                  \
     }                                                                                                                \
     static inline name##_weak_t name##_weak_clone(const name##_weak_t *p) {                                          \
         name##_weak_t c = name##_weak_null();                                                                        \
@@ -158,10 +163,12 @@ size_t _z_rc_strong_count(void *cnt);
         if ((p == NULL) || (p->_cnt == NULL)) {                                                                      \
             return false;                                                                                            \
         }                                                                                                            \
+        bool res = false;                                                                                            \
         if (_z_rc_decrease_weak(&p->_cnt)) {                                                                         \
-            return true;                                                                                             \
+            res = true;                                                                                              \
         }                                                                                                            \
-        return false;                                                                                                \
+        *p = name##_weak_null();                                                                                     \
+        return res;                                                                                                  \
     }                                                                                                                \
     static inline size_t name##_rc_size(name##_rc_t *p) {                                                            \
         _ZP_UNUSED(p);                                                                                               \

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -95,6 +95,16 @@ z_result_t _z_open(_z_session_rc_t *zn, _z_config_t *config);
 void _z_close(_z_session_t *session);
 
 /**
+ * Return true is session and all associated transports were closed.
+ */
+bool _z_session_is_closed(const _z_session_t *session);
+
+/**
+ * Upgrades weak session session, than resets it to null if session is closed.
+ */
+_z_session_rc_t _z_session_weak_upgrade_if_open(const _z_session_weak_t *session);
+
+/**
  * Get informations about an zenoh-net session.
  *
  * Parameters:

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -154,11 +154,7 @@ typedef struct {
         _z_transport_multicast_t _raweth;
     } _transport;
 
-    enum {
-        _Z_TRANSPORT_UNICAST_TYPE,
-        _Z_TRANSPORT_MULTICAST_TYPE,
-        _Z_TRANSPORT_RAWETH_TYPE,
-    } _type;
+    enum { _Z_TRANSPORT_UNICAST_TYPE, _Z_TRANSPORT_MULTICAST_TYPE, _Z_TRANSPORT_RAWETH_TYPE, _Z_TRANSPORT_NONE } _type;
 } _z_transport_t;
 
 _Z_ELEM_DEFINE(_z_transport, _z_transport_t, _z_noop_size, _z_noop_clear, _z_noop_copy)

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -645,7 +645,6 @@ z_result_t z_open(z_owned_session_t *zs, z_moved_config_t *config, const z_open_
     }
     zs->_rc = zsrc;
     // Open session
-
     z_result_t ret = _z_open(&zs->_rc, &config->_this._val);
     if (ret != _Z_RES_OK) {
         _z_session_rc_decr(&zs->_rc);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -645,6 +645,7 @@ z_result_t z_open(z_owned_session_t *zs, z_moved_config_t *config, const z_open_
     }
     zs->_rc = zsrc;
     // Open session
+
     z_result_t ret = _z_open(&zs->_rc, &config->_this._val);
     if (ret != _Z_RES_OK) {
         _z_session_rc_decr(&zs->_rc);
@@ -660,14 +661,16 @@ z_result_t z_open(z_owned_session_t *zs, z_moved_config_t *config, const z_open_
 
 void z_close_options_default(z_close_options_t *options) { options->__dummy = 0; }
 
-z_result_t z_close(z_moved_session_t *zs, const z_close_options_t *options) {
+z_result_t z_close(z_loaned_session_t *zs, const z_close_options_t *options) {
     _ZP_UNUSED(options);
-    if (zs == NULL || !z_internal_session_check(&zs->_this)) {
+    if (_Z_RC_IS_NULL(zs)) {
         return _Z_RES_OK;
     }
-    z_session_drop(zs);
+    _z_session_clear(_Z_RC_IN_VAL(zs));
     return _Z_RES_OK;
 }
+
+bool z_session_is_closed(const z_loaned_session_t *zs) { return _z_session_is_closed(_Z_RC_IN_VAL(zs)); }
 
 z_result_t z_info_peers_zid(const z_loaned_session_t *zs, z_moved_closure_zid_t *callback) {
     // Call transport function
@@ -946,7 +949,8 @@ z_result_t z_publisher_put(const z_loaned_publisher_t *pub, z_moved_bytes_t *pay
     _z_keyexpr_t pub_keyexpr = _z_keyexpr_alias_from_user_defined(pub->_key, true);
 
     // Try to upgrade session rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&pub->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&pub->_zn);
+
     if (!_Z_RC_IS_NULL(&sess_rc)) {
         // Check if write filter is active before writing
         if (!_z_write_filter_active(pub)) {
@@ -988,7 +992,7 @@ z_result_t z_publisher_delete(const z_loaned_publisher_t *pub, const z_publisher
     _z_keyexpr_t pub_keyexpr = _z_keyexpr_alias_from_user_defined(pub->_key, true);
 
     // Try to upgrade session rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&pub->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&pub->_zn);
     if (_Z_RC_IS_NULL(&sess_rc)) {
         return _Z_ERR_SESSION_CLOSED;
     }
@@ -1151,7 +1155,7 @@ void z_query_reply_options_default(z_query_reply_options_t *options) {
 z_result_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *keyexpr, z_moved_bytes_t *payload,
                          const z_query_reply_options_t *options) {
     // Try upgrading session weak to rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&_Z_RC_IN_VAL(query)->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&_Z_RC_IN_VAL(query)->_zn);
     if (_Z_RC_IS_NULL(&sess_rc)) {
         return _Z_ERR_SESSION_CLOSED;
     }
@@ -1189,7 +1193,7 @@ void z_query_reply_del_options_default(z_query_reply_del_options_t *options) {
 z_result_t z_query_reply_del(const z_loaned_query_t *query, const z_loaned_keyexpr_t *keyexpr,
                              const z_query_reply_del_options_t *options) {
     // Try upgrading session weak to rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&_Z_RC_IN_VAL(query)->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&_Z_RC_IN_VAL(query)->_zn);
     if (_Z_RC_IS_NULL(&sess_rc)) {
         return _Z_ERR_SESSION_CLOSED;
     }
@@ -1217,7 +1221,7 @@ void z_query_reply_err_options_default(z_query_reply_err_options_t *options) { o
 z_result_t z_query_reply_err(const z_loaned_query_t *query, z_moved_bytes_t *payload,
                              const z_query_reply_err_options_t *options) {
     // Try upgrading session weak to rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&_Z_RC_IN_VAL(query)->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&_Z_RC_IN_VAL(query)->_zn);
     if (_Z_RC_IS_NULL(&sess_rc)) {
         return _Z_ERR_SESSION_CLOSED;
     }

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -38,7 +38,7 @@ void _z_query_clear_inner(_z_query_t *q) {
 
 void _z_query_clear(_z_query_t *q) {
     // Try to upgrade session weak to rc
-    _z_session_rc_t sess_rc = _z_session_weak_upgrade(&q->_zn);
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&q->_zn);
     if (!_Z_RC_IS_NULL(&sess_rc)) {
         // Send REPLY_FINAL message
         _z_zenoh_message_t z_msg = _z_n_msg_make_response_final(q->_request_id);

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -57,6 +57,7 @@ z_result_t __z_open_inner(_z_session_rc_t *zn, _z_string_t *locator, z_whatami_t
 
 z_result_t _z_open(_z_session_rc_t *zn, _z_config_t *config) {
     z_result_t ret = _Z_RES_OK;
+    _Z_RC_IN_VAL(zn)->_tp._type = _Z_TRANSPORT_NONE;
 
     _z_id_t zid = _z_id_empty();
     char *opt_as_str = _z_config_get(config, Z_CONFIG_SESSION_ZID_KEY);
@@ -150,6 +151,16 @@ z_result_t _z_open(_z_session_rc_t *zn, _z_config_t *config) {
 }
 
 void _z_close(_z_session_t *zn) { _z_session_close(zn, _Z_CLOSE_GENERIC); }
+
+bool _z_session_is_closed(const _z_session_t *session) { return session->_tp._type == _Z_TRANSPORT_NONE; }
+
+_z_session_rc_t _z_session_weak_upgrade_if_open(const _z_session_weak_t *session) {
+    _z_session_rc_t sess_rc = _z_session_weak_upgrade(session);
+    if (!_Z_RC_IS_NULL(&sess_rc) && _z_session_is_closed(_Z_RC_IN_VAL(&sess_rc))) {
+        _z_session_rc_drop(&sess_rc);
+    }
+    return sess_rc;
+}
 
 _z_config_t *_z_info(const _z_session_t *zn) {
     _z_config_t *ps = (_z_config_t *)z_malloc(sizeof(_z_config_t));

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -97,6 +97,9 @@ z_result_t _z_session_init(_z_session_rc_t *zsrc, _z_id_t *zid) {
 }
 
 void _z_session_clear(_z_session_t *zn) {
+    if (_z_session_is_closed(zn)) {
+        return;
+    }
 #if Z_FEATURE_MULTI_THREAD == 1
     _zp_stop_read_task(zn);
     _zp_stop_lease_task(zn);

--- a/src/transport/transport.c
+++ b/src/transport/transport.c
@@ -64,6 +64,7 @@ void _z_transport_clear(_z_transport_t *zt) {
         default:
             break;
     }
+    zt->_type = _Z_TRANSPORT_NONE;
 }
 
 void _z_transport_free(_z_transport_t **zt) {

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -425,15 +425,17 @@ int main(int argc, char **argv) {
 #endif
 
     printf("Close sessions...");
-    _ret_res = z_close(z_move(s1), NULL);
+    _ret_res = z_close(z_loan_mut(s1), NULL);
     assert_eq(_ret_res, 0);
+    z_drop(z_move(s1));
 
 #ifdef ZENOH_PICO
     zp_stop_read_task(z_loan_mut(s2));
     zp_stop_lease_task(z_loan_mut(s2));
 #endif
-    _ret_res = z_close(z_move(s2), NULL);
+    _ret_res = z_close(z_loan_mut(s2), NULL);
     assert_eq(_ret_res, 0);
+    z_drop(z_move(s2));
     printf("Ok\n");
 
     z_sleep_s(SLEEP * 5);

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -401,12 +401,12 @@ int main(int argc, char **argv) {
 
     // Close both sessions
     printf("Closing session 1\n");
-    z_close(z_move(s1), NULL);
+    z_drop(z_move(s1));
 
     z_sleep_s(SLEEP);
 
     printf("Closing session 2\n");
-    z_close(z_move(s2), NULL);
+    z_drop(z_move(s2));
 
     z_free((uint8_t *)value);
     value = NULL;

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -185,12 +185,12 @@ int main(int argc, char **argv) {
 
     // Close both sessions
     printf("Closing session 1\n");
-    z_close(z_move(s1), NULL);
+    z_drop(z_move(s1));
 
     z_sleep_s(SLEEP);
 
     printf("Closing session 2\n");
-    z_close(z_move(s2), NULL);
+    z_drop(z_move(s2));
 
     z_free((uint8_t *)value);
     value = NULL;

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
     // Declare Subscriber/resource
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     z_sleep_s(1);
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     exit(0);
 }
 #else

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         exit(-1);
     }
     // Declare publisher
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
 
     // Clean up
     z_undeclare_publisher(z_move(pub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     free(value);
     exit(0);
 }

--- a/tests/z_session_test.c
+++ b/tests/z_session_test.c
@@ -37,7 +37,7 @@ int main(void) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
 
@@ -49,5 +49,5 @@ int main(void) {
     zp_stop_lease_task(z_loan_mut(s));
 
     // Immediately close the session
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
 }

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
     // Declare subscriber
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     }
     // Clean up
     z_undeclare_subscriber(z_move(sub));
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     return 0;
 }
 #else

--- a/tests/z_test_fragment_tx.c
+++ b/tests/z_test_fragment_tx.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     // Start read and lease tasks for zenoh-pico
     if (zp_start_read_task(z_loan_mut(s), NULL) < 0 || zp_start_lease_task(z_loan_mut(s), NULL) < 0) {
         printf("Unable to start read and lease tasks\n");
-        z_close(z_session_move(&s), NULL);
+        z_session_drop(z_session_move(&s));
         return -1;
     }
     // Wait for joins
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
         z_sleep_s(1);
     }
     // Clean up
-    z_close(z_move(s), NULL);
+    z_drop(z_move(s));
     free(value);
     return 0;
 }

--- a/zenohpico.pc
+++ b/zenohpico.pc
@@ -3,6 +3,6 @@ prefix=/usr/local
 Name: zenohpico
 Description: 
 URL: 
-Version: 1.0.20240930dev
+Version: 1.0.20241004dev
 Cflags: -I${prefix}/include
 Libs: -L${prefix}/lib -lzenohpico


### PR DESCRIPTION
make z_close take session by mutable reference as it is done in rust;
session info methods can still be used on session after close (although with the exception of z_info_zid, they will return nothing);