### PR TITLE
make z_undeclare_xxx functions take their argument by reference

### DIFF
--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -163,7 +163,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -178,7 +178,7 @@ void app_main() {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -185,7 +185,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -166,7 +166,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -107,7 +107,7 @@ void app_main(void) {
     }
 
     // Clean-up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -78,7 +78,7 @@ void app_main(void) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -87,7 +87,7 @@ void app_main(void) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -96,7 +96,7 @@ void app_main(void) {
         z_sleep_s(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -76,7 +76,7 @@ void app_main(void) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -76,7 +76,7 @@ void app_main(void) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 }

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
     z_session_drop(z_session_move(&s));

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_queryable_move(&qable));
+    z_queryable_drop(z_queryable_move(&qable));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_loan(s), NULL);
         zp_send_join(z_loan(s), NULL);
     }
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(p), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     z_drop(z_move(payload));
     exit(0);

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     }
 
     z_drop(z_move(handler));
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         z_drop(z_move(sample));
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_loan(s), NULL);
         zp_send_join(z_loan(s), NULL);
     }
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     exit(0);
 }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -135,8 +135,8 @@ int main(int argc, char** argv) {
     z_mutex_unlock(z_mutex_loan_mut(&mutex));
     z_free(results);
     z_free(data);
-    z_undeclare_subscriber(z_subscriber_move(&sub));
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_subscriber_drop(z_subscriber_move(&sub));
+    z_publisher_drop(z_publisher_move(&pub));
 
     z_session_drop(z_session_move(&session));
 }

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -26,7 +26,7 @@ void callback(z_loaned_sample_t* sample, void* context) {
 
 void drop(void* context) {
     z_owned_publisher_t* pub = (z_owned_publisher_t*)context;
-    z_undeclare_publisher(z_publisher_move(pub));
+    z_publisher_drop(z_publisher_move(pub));
     // A note on lifetimes:
     //  here, `sub` takes ownership of `pub` and will drop it before returning from its own `drop`,
     //  which makes passing a pointer to the stack safe as long as `sub` is dropped in a scope where `pub` is still
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     while (getchar() != 'q') {
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&session));
 }

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
     z_session_drop(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_session_loan(&s), NULL);
     }
 
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
     z_session_drop(z_session_move(&s));
     free(buf);
     return 0;

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
     z_session_drop(z_session_move(&s));

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_queryable_move(&qable));
+    z_queryable_drop(z_queryable_move(&qable));
 
     z_session_drop(z_session_move(&s));
 

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&s));
 

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_session_loan(&s), NULL);
         zp_send_join(z_session_loan(&s), NULL);
     }
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_session_drop(z_session_move(&s));
     return 0;
 }

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean-up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     zp_stop_read_task(z_loan_mut(s));
     zp_stop_lease_task(z_loan_mut(s));
     z_drop(z_move(s));

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
         Sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         Sleep(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -79,6 +79,7 @@
                   z_owned_session_t : z_session_loan_mut,                 \
                   z_owned_publisher_t : z_publisher_loan_mut,             \
                   z_owned_queryable_t : z_queryable_loan_mut,             \
+                  z_owned_subscriber_t : z_subscriber_loan_mut,           \
                   z_owned_reply_t : z_reply_loan_mut,                     \
                   z_owned_hello_t : z_hello_loan_mut,                     \
                   z_owned_string_t : z_string_loan_mut,                   \
@@ -424,6 +425,7 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& x) { return z_config_loan
 inline z_loaned_session_t* z_loan_mut(z_owned_session_t& x) { return z_session_loan_mut(&x); }
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& x) { return z_publisher_loan_mut(&x); }
 inline z_loaned_queryable_t* z_loan_mut(z_owned_queryable_t& x) { return z_queryable_loan_mut(&x); }
+inline z_loaned_subscriber_t* z_loan_mut(z_owned_subscriber_t& x) { return z_subscriber_loan_mut(&x); }
 inline z_loaned_reply_t* z_loan_mut(z_owned_reply_t& x) { return z_reply_loan_mut(&x); }
 inline z_loaned_hello_t* z_loan_mut(z_owned_hello_t& x) { return z_hello_loan_mut(&x); }
 inline z_loaned_string_t* z_loan_mut(z_owned_string_t& x) { return z_string_loan_mut(&x); }

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1598,15 +1598,15 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**
- * Undeclares and clears the publisher.
+ * Undeclares the publisher. After this function return, all calls to publisher functions will yield an error.
  *
  * Parameters:
- *   pub: Moved :c:type:`z_owned_publisher_t` to undeclare.
+ *   pub: Loaned :c:type:`z_owned_publisher_t` to undeclare.
  *
  * Return:
  *   ``0`` if undeclare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_publisher(z_moved_publisher_t *pub);
+z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub);
 
 /**
  * Builds a :c:type:`z_publisher_put_options_t` with default values.
@@ -1746,9 +1746,6 @@ void z_queryable_options_default(z_queryable_options_t *options);
 
 /**
  * Declares a queryable for a given keyexpr.
- * Note that dropping queryable does not drop its callback, meaning that after queryable drop the messages will still
- * be receieved and processed, until the corresponding session is dropped. To disable the callback with cleanup use
- * :c:func:`z_undeclare_queryable`.
  *
  * Parameters:
  *   queryable: Pointer to an uninitialized :c:type:`z_owned_queryable_t` to contain the queryable.
@@ -1765,7 +1762,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
                                const z_queryable_options_t *options);
 
 /**
- * Undeclares and clears the queryable.
+ * Undeclares the queryable callback.
  *
  * Parameters:
  *   queryable: Moved :c:type:`z_owned_queryable_t` to undeclare.
@@ -1773,7 +1770,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
  * Return:
  *   ``0`` if undeclare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_queryable(z_moved_queryable_t *queryable);
+z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable);
 
 /**
  * Builds a :c:type:`z_query_reply_options_t` with default values.
@@ -2023,15 +2020,15 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
                                 const z_subscriber_options_t *options);
 
 /**
- * Undeclares and clears the subscriber.
+ * Undeclares the subscriber callback.
  *
  * Parameters:
- *   sub: Moved :c:type:`z_owned_subscriber_t` to undeclare.
+ *   sub: Loaned :c:type:`z_owned_subscriber_t` to undeclare.
  *
  * Return:
  *   ``0`` if undeclare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_subscriber(z_moved_subscriber_t *sub);
+z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub);
 
 /**
  * Gets the keyexpr from a subscriber.

--- a/include/zenoh-pico/net/filtering.h
+++ b/include/zenoh-pico/net/filtering.h
@@ -42,7 +42,7 @@ typedef struct _z_write_filter_t {
 typedef struct _z_publisher_t _z_publisher_t;
 
 z_result_t _z_write_filter_create(_z_publisher_t *pub);
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub);
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub);
 bool _z_write_filter_active(const _z_publisher_t *pub);
 
 #endif /* ZENOH_PICO_FILTERING_NETAPI_H */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -778,7 +778,10 @@ const z_loaned_slice_t *z_string_as_slice(const z_loaned_string_t *str) { return
 z_priority_t z_priority_default(void) { return Z_PRIORITY_DEFAULT; }
 
 #if Z_FEATURE_PUBLICATION == 1
-void _z_publisher_drop(_z_publisher_t *pub) { _z_publisher_clear(pub); }
+void _z_publisher_drop(_z_publisher_t *pub) {
+    _z_undeclare_publisher(pub);
+    _z_publisher_clear(pub);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_publisher_t, publisher, _z_publisher_check, _z_publisher_null,
                                       _z_publisher_drop)
@@ -910,10 +913,10 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_publisher(z_moved_publisher_t *pub) {
-    z_result_t ret = _z_undeclare_publisher(&pub->_this._val);
-    _z_publisher_clear(&pub->_this._val);
-    return ret;
+z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub) {
+    z_result_t res = _z_undeclare_publisher(pub);
+    _z_session_weak_drop(&pub->_zn);  // drop session to prevent publisher from being able to perform put
+    return res;
 }
 
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
@@ -1096,7 +1099,10 @@ bool z_reply_replier_id(const z_loaned_reply_t *reply, z_id_t *out_id) {
 #if Z_FEATURE_QUERYABLE == 1
 _Z_OWNED_FUNCTIONS_RC_IMPL(query)
 
-void _z_queryable_drop(_z_queryable_t *queryable) { _z_queryable_clear(queryable); }
+void _z_queryable_drop(_z_queryable_t *queryable) {
+    _z_undeclare_queryable(queryable);
+    _z_queryable_clear(queryable);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_check, _z_queryable_null,
                                       _z_queryable_drop)
@@ -1136,11 +1142,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_queryable(z_moved_queryable_t *queryable) {
-    z_result_t ret = _z_undeclare_queryable(&queryable->_this._val);
-    _z_queryable_clear(&queryable->_this._val);
-    return ret;
-}
+z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable) { return _z_undeclare_queryable(queryable); }
 
 void z_query_reply_options_default(z_query_reply_options_t *options) {
     options->encoding = NULL;
@@ -1304,7 +1306,10 @@ z_result_t z_undeclare_keyexpr(z_moved_keyexpr_t *keyexpr, const z_loaned_sessio
 }
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-void _z_subscriber_drop(_z_subscriber_t *sub) { _z_subscriber_clear(sub); }
+void _z_subscriber_drop(_z_subscriber_t *sub) {
+    _z_undeclare_subscriber(sub);
+    _z_subscriber_clear(sub);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber_check, _z_subscriber_null,
                                       _z_subscriber_drop)
@@ -1362,11 +1367,7 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
     }
 }
 
-z_result_t z_undeclare_subscriber(z_moved_subscriber_t *sub) {
-    z_result_t ret = _z_undeclare_subscriber(&sub->_this._val);
-    _z_subscriber_clear(&sub->_this._val);
-    return ret;
-}
+z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub) { return _z_undeclare_subscriber(sub); }
 
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub) {
     // Retrieve keyexpr from session

--- a/src/net/filtering.c
+++ b/src/net/filtering.c
@@ -94,13 +94,18 @@ z_result_t _z_write_filter_create(_z_publisher_t *pub) {
     return _Z_RES_OK;
 }
 
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub) {
-    _Z_RETURN_IF_ERR(_z_remove_interest(_Z_RC_IN_VAL(&pub->_zn), pub->_filter._interest_id));
-    z_free(pub->_filter.ctx);
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub) {
+    if (pub->_filter.ctx != NULL) {
+        _Z_RETURN_IF_ERR(_z_remove_interest(_Z_RC_IN_VAL(&pub->_zn), pub->_filter._interest_id));
+        z_free(pub->_filter.ctx);
+        pub->_filter.ctx = NULL;
+    }
     return _Z_RES_OK;
 }
 
-bool _z_write_filter_active(const _z_publisher_t *pub) { return (pub->_filter.ctx->state == WRITE_FILTER_ACTIVE); }
+bool _z_write_filter_active(const _z_publisher_t *pub) {
+    return pub->_filter.ctx != NULL && pub->_filter.ctx->state == WRITE_FILTER_ACTIVE;
+}
 
 #else
 z_result_t _z_write_filter_create(_z_publisher_t *pub) {
@@ -108,7 +113,7 @@ z_result_t _z_write_filter_create(_z_publisher_t *pub) {
     return _Z_RES_OK;
 }
 
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub) {
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub) {
     _ZP_UNUSED(pub);
     return _Z_RES_OK;
 }

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -20,6 +20,7 @@
 void _z_publisher_clear(_z_publisher_t *pub) {
     _z_keyexpr_clear(&pub->_key);
     _z_session_weak_drop(&pub->_zn);
+    _z_encoding_clear(&pub->_encoding);
     *pub = _z_publisher_null();
 }
 
@@ -38,7 +39,7 @@ bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL
 _z_publisher_t _z_publisher_null(void) {
     return (_z_publisher_t) {
         ._congestion_control = Z_CONGESTION_CONTROL_DEFAULT, ._id = 0, ._key = _z_keyexpr_null(),
-        ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_weak_null(),
+        ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_weak_null(), ._encoding = _z_encoding_null(),
 #if Z_FEATURE_INTEREST == 1
         ._filter = (_z_write_filter_t) {
             ._interest_id = 0, .ctx = NULL

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -359,16 +359,18 @@ int main(int argc, char **argv) {
     assert_eq(datas, 4);
 
     printf("Undeclaring Publisher...");
-    _ret_res = z_undeclare_publisher(z_move(_ret_pub));
+    _ret_res = z_undeclare_publisher(z_loan_mut(_ret_pub));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(_ret_pub));
     assert(!z_internal_check(_ret_pub));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);
 
     printf("Undeclaring Subscriber...");
-    _ret_res = z_undeclare_subscriber(z_move(_ret_sub));
+    _ret_res = z_undeclare_subscriber(z_loan_mut(_ret_sub));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(_ret_sub));
     assert(!z_internal_check(_ret_sub));
     printf("Ok\n");
 
@@ -415,8 +417,9 @@ int main(int argc, char **argv) {
     assert_eq(replies, 1);
 
     printf("Undeclaring Queryable...");
-    _ret_res = z_undeclare_queryable(z_move(qle));
+    _ret_res = z_undeclare_queryable(z_loan_mut(qle));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(qle));
     printf("Ok\n");
 
 #ifdef ZENOH_PICO

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {
     while (pubs1) {
         z_owned_publisher_t *pub = _z_list_head(pubs1);
         printf("Undeclared publisher on session 2: %zu\n", z_loan(*pub)->_id);
-        z_undeclare_publisher(z_move(*pub));
+        z_drop(z_move(*pub));
         pubs1 = _z_list_pop(pubs1, _z_noop_elem_free, NULL);
     }
 
@@ -362,7 +362,7 @@ int main(int argc, char **argv) {
     while (subs2) {
         z_owned_subscriber_t *sub = _z_list_head(subs2);
         printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)sub->_val._entity_id);
-        z_undeclare_subscriber(z_move(*sub));
+        z_drop(z_move(*sub));
         subs2 = _z_list_pop(subs2, _z_noop_elem_free, NULL);
     }
 
@@ -371,7 +371,7 @@ int main(int argc, char **argv) {
     while (qles2) {
         z_owned_queryable_t *qle = _z_list_head(qles2);
         printf("Undeclared queryable on session 2: %ju\n", (uintmax_t)qle->_val._entity_id);
-        z_undeclare_queryable(z_move(*qle));
+        z_drop(z_move(*qle));
         qles2 = _z_list_pop(qles2, _z_noop_elem_free, NULL);
     }
 

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
     while (subs2) {
         z_owned_subscriber_t *sub = _z_list_head(subs2);
         printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id);
-        z_undeclare_subscriber(z_move(*sub));
+        z_drop(z_move(*sub));
         subs2 = _z_list_pop(subs2, _z_noop_elem_free, NULL);
     }
 

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
     printf("End of test\n");
     z_sleep_s(1);
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     exit(0);
 }

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     zp_stop_lease_task(z_loan_mut(s));
 
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     free(value);
     exit(0);

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         (void)ret;  // Remove unused result warning
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }


### PR DESCRIPTION
make z_undeclare_publisher/subscriber/queryable take their argument by reference;
fix memory leaks in publisher due to non-cleared encoding and write_filter;