### PR TITLE
Fix config segfault

### DIFF
--- a/include/zenoh-pico/link/config/raweth.h
+++ b/include/zenoh-pico/link/config/raweth.h
@@ -26,6 +26,7 @@ z_result_t _z_endpoint_raweth_valid(_z_endpoint_t *endpoint);
 z_result_t _z_new_link_raweth(_z_link_t *zl, _z_endpoint_t endpoint);
 size_t _z_raweth_config_strlen(const _z_str_intmap_t *s);
 char *_z_raweth_config_to_str(const _z_str_intmap_t *s);
+z_result_t _z_raweth_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
 z_result_t _z_raweth_config_from_str(_z_str_intmap_t *strint, const char *s);
 
 #endif /* ZENOH_PICO_LINK_CONFIG_RAWETH_H */

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -288,42 +288,43 @@ z_result_t _z_endpoint_config_from_string(_z_str_intmap_t *strint, _z_string_t *
     char *p_start = (char *)memchr(_z_string_data(str), ENDPOINT_CONFIG_SEPARATOR, _z_string_len(str));
     if (p_start != NULL) {
         p_start = _z_ptr_char_offset(p_start, 1);
+        size_t cfg_size = _z_string_len(str) - _z_ptr_char_diff(_z_string_data(str), p_start);
 
         // Call the right configuration parser depending on the protocol
         _z_string_t cmp_str = _z_string_null();
 #if Z_FEATURE_LINK_TCP == 1
         cmp_str = _z_string_alias_str(TCP_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_tcp_config_from_str(strint, p_start);
+            return _z_tcp_config_from_strn(strint, p_start, cfg_size);
         }
 #endif
 #if Z_FEATURE_LINK_UDP_UNICAST == 1 || Z_FEATURE_LINK_UDP_MULTICAST == 1
         cmp_str = _z_string_alias_str(UDP_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_udp_config_from_str(strint, p_start);
+            return _z_udp_config_from_strn(strint, p_start, cfg_size);
         }
 #endif
 #if Z_FEATURE_LINK_BLUETOOTH == 1
         cmp_str = _z_string_alias_str(BT_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_bt_config_from_str(strint, p_start);
+            return _z_bt_config_from_strn(strint, p_start, cfg_size);
         }
 #endif
 #if Z_FEATURE_LINK_SERIAL == 1
         cmp_str = _z_string_alias_str(SERIAL_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_serial_config_from_str(strint, p_start);
+            return _z_serial_config_from_strn(strint, p_start, cfg_size);
         }
 #endif
 #if Z_FEATURE_LINK_WS == 1
         cmp_str = _z_string_alias_str(WS_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_ws_config_from_str(strint, p_start);
+            return _z_ws_config_from_strn(strint, p_start, cfg_size);
         }
 #endif
         cmp_str = _z_string_alias_str(RAWETH_SCHEMA);
         if (_z_string_equals(proto, &cmp_str)) {
-            return _z_raweth_config_from_str(strint, p_start);
+            return _z_raweth_config_from_strn(strint, p_start, cfg_size);
         }
     }
     return _Z_RES_OK;

--- a/src/protocol/iobuf.c
+++ b/src/protocol/iobuf.c
@@ -223,7 +223,7 @@ void _z_zbuf_clear(_z_zbuf_t *zbf) { _z_iosli_clear(&zbf->_ios); }
 void _z_zbuf_compact(_z_zbuf_t *zbf) {
     if ((zbf->_ios._r_pos != 0) || (zbf->_ios._w_pos != 0)) {
         size_t len = _z_iosli_readable(&zbf->_ios);
-        (void)memcpy(zbf->_ios._buf, _z_zbuf_get_rptr(zbf), len);
+        (void)memmove(zbf->_ios._buf, _z_zbuf_get_rptr(zbf), len);
         _z_zbuf_set_rpos(zbf, 0);
         _z_zbuf_set_wpos(zbf, len);
     }

--- a/src/transport/raweth/link.c
+++ b/src/transport/raweth/link.c
@@ -500,9 +500,13 @@ char *_z_raweth_config_to_str(const _z_str_intmap_t *s) {
     return _z_str_intmap_to_str(s, RAWETH_CONFIG_ARGC, args);
 }
 
-z_result_t _z_raweth_config_from_str(_z_str_intmap_t *strint, const char *s) {
+z_result_t _z_raweth_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n) {
     RAWETH_CONFIG_MAPPING_BUILD
-    return _z_str_intmap_from_strn(strint, s, RAWETH_CONFIG_ARGC, args, strlen(s));
+    return _z_str_intmap_from_strn(strint, s, RAWETH_CONFIG_ARGC, args, n);
+}
+
+z_result_t _z_raweth_config_from_str(_z_str_intmap_t *strint, const char *s) {
+    return _z_raweth_config_from_strn(strint, s, strlen(s));
 }
 
 #else
@@ -521,9 +525,17 @@ size_t _z_raweth_config_strlen(const _z_str_intmap_t *s) {
     _ZP_UNUSED(s);
     return 0;
 }
+
 char *_z_raweth_config_to_str(const _z_str_intmap_t *s) {
     _ZP_UNUSED(s);
     return NULL;
+}
+
+z_result_t _z_raweth_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n) {
+    _ZP_UNUSED(strint);
+    _ZP_UNUSED(s);
+    _ZP_UNUSED(n);
+    return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 
 z_result_t _z_raweth_config_from_str(_z_str_intmap_t *strint, const char *s) {


### PR DESCRIPTION
Fix a segfault related to config (strlen used on `_z_string_t`) and a `memcpy-param-overlap` error