### PR TITLE
Remove legacy z_timestamp_check

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -389,7 +389,6 @@ Functions
 ^^^^^^^^^
 .. autocfunction:: primitives.h::z_timestamp_id
 .. autocfunction:: primitives.h::z_timestamp_ntp64_time
-.. autocfunction:: primitives.h::z_timestamp_check
 
 Closures
 ========

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -863,17 +863,6 @@ uint64_t z_timestamp_ntp64_time(const z_timestamp_t *ts);
 z_id_t z_timestamp_id(const z_timestamp_t *ts);
 
 /**
- * Checks validity of a timestamp
- *
- * Parameters:
- *   ts: Timestamp value to check validity of.
- *
- * Return:
- *   ``true`` if the timestamp is valid, ``false`` otherwise.
- */
-bool z_timestamp_check(z_timestamp_t ts);
-
-/**
  * Builds a default query target.
  *
  * Return:

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -392,8 +392,6 @@ uint64_t z_timestamp_ntp64_time(const z_timestamp_t *ts) { return ts->time; }
 
 z_id_t z_timestamp_id(const z_timestamp_t *ts) { return ts->id; }
 
-bool z_timestamp_check(z_timestamp_t ts) { return _z_timestamp_check(&ts); }
-
 z_query_target_t z_query_target_default(void) { return Z_QUERY_TARGET_DEFAULT; }
 
 z_query_consolidation_t z_query_consolidation_auto(void) {


### PR DESCRIPTION
This method absent in zenoh and zenoh-c, all methods which returns z_timestamp_t returns NULL in case if timestamp not present. 