### PR TITLE
Subscriber/Queryable api alignment

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -875,7 +875,6 @@ Functions
 .. autocfunction:: primitives.h::z_declare_publisher
 .. autocfunction:: primitives.h::z_publisher_put
 .. autocfunction:: primitives.h::z_publisher_delete
-.. autocfunction:: primitives.h::z_undeclare_publisher
 .. autocfunction:: primitives.h::z_publisher_keyexpr
 
 .. autocfunction:: primitives.h::z_put_options_default
@@ -916,7 +915,7 @@ Functions
 ---------
 
 .. autocfunction:: primitives.h::z_declare_subscriber
-.. autocfunction:: primitives.h::z_undeclare_subscriber
+.. autocfunction:: primitives.h::z_declare_background_subscriber
 
 .. autocfunction:: primitives.h::z_subscriber_options_default
 .. autocfunction:: primitives.h::z_subscriber_keyexpr
@@ -961,7 +960,7 @@ Option Types
 Functions
 ---------
 .. autocfunction:: primitives.h::z_declare_queryable
-.. autocfunction:: primitives.h::z_undeclare_queryable
+.. autocfunction:: primitives.h::z_declare_background_queryable
 
 .. autocfunction:: primitives.h::z_queryable_options_default
 .. autocfunction:: primitives.h::z_query_reply_options_default

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -872,7 +872,7 @@ Functions
 .. autocfunction:: primitives.h::z_put
 .. autocfunction:: primitives.h::z_delete
 
-.. autocfunction:: primitives.h::z_declare_publisher
+.. autocfunction:: primitives.h::z_publisher_declare
 .. autocfunction:: primitives.h::z_publisher_put
 .. autocfunction:: primitives.h::z_publisher_delete
 .. autocfunction:: primitives.h::z_publisher_keyexpr
@@ -914,8 +914,8 @@ Option Types
 Functions
 ---------
 
-.. autocfunction:: primitives.h::z_declare_subscriber
-.. autocfunction:: primitives.h::z_declare_background_subscriber
+.. autocfunction:: primitives.h::z_subscriber_declare
+.. autocfunction:: primitives.h::z_subscriber_declare_background
 
 .. autocfunction:: primitives.h::z_subscriber_options_default
 .. autocfunction:: primitives.h::z_subscriber_keyexpr
@@ -959,8 +959,8 @@ Option Types
 
 Functions
 ---------
-.. autocfunction:: primitives.h::z_declare_queryable
-.. autocfunction:: primitives.h::z_declare_background_queryable
+.. autocfunction:: primitives.h::z_queryable_declare
+.. autocfunction:: primitives.h::z_queryable_declare_background
 
 .. autocfunction:: primitives.h::z_queryable_options_default
 .. autocfunction:: primitives.h::z_query_reply_options_default

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -84,7 +84,7 @@ void setup() {
     Serial.println("...");
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         Serial.println("Unable to declare publisher for key expression!");
         while (1) {
             ;

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -84,7 +84,7 @@ void setup() {
     z_ring_channel_sample_new(&closure, &handler, SIZE);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         Serial.println("Unable to declare subscriber.");
         return;

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -112,7 +112,7 @@ void setup() {
     z_closure_query(&callback, query_handler, NULL, NULL);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         Serial.println("Unable to declare queryable.");
         while (1) {

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -99,7 +99,7 @@ void setup() {
     z_closure_sample(&callback, data_handler, NULL, NULL);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         Serial.println("Unable to declare subscriber.");
         while (1) {

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -143,7 +143,7 @@ void app_main() {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -163,7 +163,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -151,7 +151,7 @@ void app_main() {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -178,7 +178,7 @@ void app_main() {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -185,7 +185,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -173,7 +173,7 @@ void app_main() {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);
     }

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -155,7 +155,7 @@ void app_main() {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -166,7 +166,7 @@ void app_main() {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -86,7 +86,7 @@ void app_main(void) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -107,7 +107,7 @@ void app_main(void) {
     }
 
     // Clean-up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -78,7 +78,7 @@ void app_main(void) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -51,7 +51,7 @@ void app_main(void) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -87,7 +87,7 @@ void app_main(void) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -60,7 +60,7 @@ void app_main(void) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -96,7 +96,7 @@ void app_main(void) {
         z_sleep_s(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -87,7 +87,7 @@ void app_main(void) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -76,7 +76,7 @@ void app_main(void) {
         z_sleep_s(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 }

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -67,7 +67,7 @@ void app_main(void) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -64,7 +64,7 @@ void app_main(void) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -76,7 +76,7 @@ void app_main(void) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 }

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
     z_session_drop(z_session_move(&s));

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_queryable_move(&qable));
+    z_queryable_drop(z_queryable_move(&qable));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&s));
     printf("OK!\n");

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
 
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
-    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+    if (z_subscriber_declare_background(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -60,16 +60,13 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
-    z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }
 
     while (getchar() != 'q') {
     }
-
-    z_drop(z_move(sub));
 
     z_drop(z_move(session));
 }

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(payload), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(payload), &options);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_loan(s), NULL);
         zp_send_join(z_loan(s), NULL);
     }
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_loan(pub), z_move(p), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     z_drop(z_move(payload));
     exit(0);

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     }
 
     z_drop(z_move(handler));
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     z_owned_ring_handler_query_t handler;
     z_ring_channel_query_new(&closure, &handler, 10);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         z_drop(z_move(sample));
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_loan(s), NULL);
         zp_send_join(z_loan(s), NULL);
     }
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, on_sample, drop_stats, (void *)context);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_background_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare_background(z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -95,10 +95,9 @@ int main(int argc, char **argv) {
     z_stats_t *context = z_stats_make();
     z_owned_closure_sample_t callback;
     z_closure(&callback, on_sample, drop_stats, (void *)context);
-    z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_background_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }
@@ -109,7 +108,6 @@ int main(int argc, char **argv) {
     }
 
     // Clean up
-    z_drop(z_move(sub));
     z_drop(z_move(s));
     exit(0);
 }

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     exit(0);
 }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -135,8 +135,8 @@ int main(int argc, char** argv) {
     z_mutex_unlock(z_mutex_loan_mut(&mutex));
     z_free(results);
     z_free(data);
-    z_undeclare_subscriber(z_subscriber_move(&sub));
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_subscriber_drop(z_subscriber_move(&sub));
+    z_publisher_drop(z_publisher_move(&pub));
 
     z_session_drop(z_session_move(&session));
 }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t ping;
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_session_loan(&session), z_view_keyexpr_loan(&ping), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&session), z_view_keyexpr_loan(&ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_session_loan(&session), z_view_keyexpr_loan(&pong),
+    if (z_subscriber_declare(&sub, z_session_loan(&session), z_view_keyexpr_loan(&pong),
                              z_closure_sample_move(&respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -26,7 +26,7 @@ void callback(z_loaned_sample_t* sample, void* context) {
 
 void drop(void* context) {
     z_owned_publisher_t* pub = (z_owned_publisher_t*)context;
-    z_undeclare_publisher(z_publisher_move(pub));
+    z_publisher_drop(z_publisher_move(pub));
     // A note on lifetimes:
     //  here, `sub` takes ownership of `pub` and will drop it before returning from its own `drop`,
     //  which makes passing a pointer to the stack safe as long as `sub` is dropped in a scope where `pub` is still
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     while (getchar() != 'q') {
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&session));
 }

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -63,17 +63,15 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, (void*)(&pub));
-    z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_session_loan(&session), z_view_keyexpr_loan(&ping),
-                             z_closure_sample_move(&respond), NULL) < 0) {
+
+    if (z_declare_background_subscriber(z_session_loan(&session), z_view_keyexpr_loan(&ping),
+                                        z_closure_sample_move(&respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }
 
     while (getchar() != 'q') {
     }
-
-    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&session));
 }

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_session_loan(&session), z_view_keyexpr_loan(&pong), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&session), z_view_keyexpr_loan(&pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, (void*)(&pub));
 
-    if (z_declare_background_subscriber(z_session_loan(&session), z_view_keyexpr_loan(&ping),
+    if (z_subscriber_declare_background(z_session_loan(&session), z_view_keyexpr_loan(&ping),
                                         z_closure_sample_move(&respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         z_publisher_put(z_publisher_loan(&pub), z_bytes_move(&payload), NULL);
     }
     // Clean up
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
     z_session_drop(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_session_loan(&s), NULL);
     }
 
-    z_undeclare_publisher(z_publisher_move(&pub));
+    z_publisher_drop(z_publisher_move(&pub));
     z_session_drop(z_session_move(&s));
     free(buf);
     return 0;

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_ring_handler_sample_drop(z_ring_handler_sample_move(&handler));
 
     z_session_drop(z_session_move(&s));

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_queryable(z_queryable_move(&qable));
+    z_queryable_drop(z_queryable_move(&qable));
 
     z_session_drop(z_session_move(&s));
 

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
 
     printf("Creating Queryable on '%s'...\n", keyexpr);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         sleep(1);
     }
 
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
 
     z_session_drop(z_session_move(&s));
 

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         zp_send_keep_alive(z_session_loan(&s), NULL);
         zp_send_join(z_session_loan(&s), NULL);
     }
-    z_undeclare_subscriber(z_subscriber_move(&sub));
+    z_subscriber_drop(z_subscriber_move(&sub));
     z_session_drop(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t ping;
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -60,17 +60,14 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
-    z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+
+    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }
 
     while (getchar() != 'q') {
     }
-
-    z_drop(z_move(sub));
-
     z_drop(z_move(session));
 }
 #else

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
 
-    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+    if (z_subscriber_declare_background(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean-up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     zp_stop_read_task(z_loan_mut(s));
     zp_stop_lease_task(z_loan_mut(s));
     z_drop(z_move(s));

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
         Sleep(1);
     }
 
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         Sleep(1);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         zp_send_join(z_loan(s), NULL);
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
 

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_publisher_t pub;
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(handler));
 
     z_drop(z_move(s));

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_queryable(z_move(qable));
+    z_drop(z_move(qable));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_declare_queryable(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);
     }

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Closing Zenoh Session...");
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
 
     z_drop(z_move(s));
     printf("OK!\n");

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -79,6 +79,7 @@
                   z_owned_session_t : z_session_loan_mut,                 \
                   z_owned_publisher_t : z_publisher_loan_mut,             \
                   z_owned_queryable_t : z_queryable_loan_mut,             \
+                  z_owned_subscriber_t : z_subscriber_loan_mut,           \
                   z_owned_reply_t : z_reply_loan_mut,                     \
                   z_owned_hello_t : z_hello_loan_mut,                     \
                   z_owned_string_t : z_string_loan_mut,                   \
@@ -424,6 +425,7 @@ inline z_loaned_config_t* z_loan_mut(z_owned_config_t& x) { return z_config_loan
 inline z_loaned_session_t* z_loan_mut(z_owned_session_t& x) { return z_session_loan_mut(&x); }
 inline z_loaned_publisher_t* z_loan_mut(z_owned_publisher_t& x) { return z_publisher_loan_mut(&x); }
 inline z_loaned_queryable_t* z_loan_mut(z_owned_queryable_t& x) { return z_queryable_loan_mut(&x); }
+inline z_loaned_subscriber_t* z_loan_mut(z_owned_subscriber_t& x) { return z_subscriber_loan_mut(&x); }
 inline z_loaned_reply_t* z_loan_mut(z_owned_reply_t& x) { return z_reply_loan_mut(&x); }
 inline z_loaned_hello_t* z_loan_mut(z_owned_hello_t& x) { return z_hello_loan_mut(&x); }
 inline z_loaned_string_t* z_loan_mut(z_owned_string_t& x) { return z_string_loan_mut(&x); }

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1752,7 +1752,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
                                const z_queryable_options_t *options);
 
 /**
- * Declares a background queryable for a given keyexpr. The queryable callback will be be called
+ * Declares a background queryable for a given keyexpr. The queryable callback will be called
  * to proccess incoming queries until the corresponding session is closed or dropped.
  *
  * Parameters:

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1598,17 +1598,6 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**
- * Undeclares the publisher. After this function return, all calls to publisher functions will yield an error.
- *
- * Parameters:
- *   pub: Loaned :c:type:`z_owned_publisher_t` to undeclare.
- *
- * Return:
- *   ``0`` if undeclare is successful, ``negative value`` otherwise.
- */
-z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub);
-
-/**
  * Builds a :c:type:`z_publisher_put_options_t` with default values.
  *
  * Parameters:
@@ -1746,6 +1735,7 @@ void z_queryable_options_default(z_queryable_options_t *options);
 
 /**
  * Declares a queryable for a given keyexpr.
+ * Note that dropping queryable drops its callback.
  *
  * Parameters:
  *   queryable: Pointer to an uninitialized :c:type:`z_owned_queryable_t` to contain the queryable.
@@ -1762,15 +1752,20 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
                                const z_queryable_options_t *options);
 
 /**
- * Undeclares the queryable callback.
+ * Declares a background queryable for a given keyexpr. The queryable callback will be be called
+ * to proccess incoming queries until the corresponding session is closed or dropped.
  *
  * Parameters:
- *   queryable: Moved :c:type:`z_owned_queryable_t` to undeclare.
+ *   zs: Pointer to a :c:type:`z_loaned_session_t` to declare the subscriber through.
+ *   keyexpr: Pointer to a :c:type:`z_loaned_keyexpr_t` to bind the subscriber with.
+ *   callback: Pointer to a :c:type:`z_owned_closure_query_t` callback.
+ *   options: Pointer to a :c:type:`z_queryable_options_t` to configure the declare.
  *
  * Return:
- *   ``0`` if undeclare operation is successful, ``negative value`` otherwise.
+ *   ``0`` if declare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable);
+z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+                                          z_moved_closure_query_t *callback, const z_queryable_options_t *options);
 
 /**
  * Builds a :c:type:`z_query_reply_options_t` with default values.
@@ -2001,9 +1996,7 @@ void z_subscriber_options_default(z_subscriber_options_t *options);
 
 /**
  * Declares a subscriber for a given keyexpr.
- * Note that dropping subscriber does not drop its callback, meaning that after subscriber drop the messages will still
- * be received and processed, until the corresponding session is dropped. To disable the callback with cleanup use
- * :c:func:`z_subscriber_undeclare`.
+ * Note that dropping subscriber drops its callback.
  *
  * Parameters:
  *   sub: Pointer to a :c:type:`z_owned_subscriber_t` to contain the subscriber.
@@ -2020,15 +2013,20 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
                                 const z_subscriber_options_t *options);
 
 /**
- * Undeclares the subscriber callback.
+ * Declares a background subscriber for a given keyexpr. Subscriber callback will be called to process the messages,
+ * until the corresponding session is closed or dropped.
  *
  * Parameters:
- *   sub: Loaned :c:type:`z_owned_subscriber_t` to undeclare.
+ *   zs: Pointer to a :c:type:`z_loaned_session_t` to declare the subscriber through.
+ *   keyexpr: Pointer to a :c:type:`z_loaned_keyexpr_t` to bind the subscriber with.
+ *   callback: Pointer to a`z_owned_closure_sample_t` callback.
+ *   options: Pointer to a :c:type:`z_subscriber_options_t` to configure the operation
  *
  * Return:
- *   ``0`` if undeclare is successful, ``negative value`` otherwise.
+ *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub);
+z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+                                           z_moved_closure_sample_t *callback, const z_subscriber_options_t *options);
 
 /**
  * Gets the keyexpr from a subscriber.

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1598,15 +1598,15 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**
- * Undeclares and clears the publisher.
+ * Undeclares the publisher. After this function return, all calls to publisher functions will yield an error.
  *
  * Parameters:
- *   pub: Moved :c:type:`z_owned_publisher_t` to undeclare.
+ *   pub: Loaned :c:type:`z_owned_publisher_t` to undeclare.
  *
  * Return:
  *   ``0`` if undeclare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_publisher(z_moved_publisher_t *pub);
+z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub);
 
 /**
  * Builds a :c:type:`z_publisher_put_options_t` with default values.
@@ -1746,9 +1746,6 @@ void z_queryable_options_default(z_queryable_options_t *options);
 
 /**
  * Declares a queryable for a given keyexpr.
- * Note that dropping queryable does not drop its callback, meaning that after queryable drop the messages will still
- * be receieved and processed, until the corresponding session is dropped. To disable the callback with cleanup use
- * :c:func:`z_undeclare_queryable`.
  *
  * Parameters:
  *   queryable: Pointer to an uninitialized :c:type:`z_owned_queryable_t` to contain the queryable.
@@ -1765,7 +1762,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
                                const z_queryable_options_t *options);
 
 /**
- * Undeclares and clears the queryable.
+ * Undeclares the queryable callback.
  *
  * Parameters:
  *   queryable: Moved :c:type:`z_owned_queryable_t` to undeclare.
@@ -1773,7 +1770,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
  * Return:
  *   ``0`` if undeclare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_queryable(z_moved_queryable_t *queryable);
+z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable);
 
 /**
  * Builds a :c:type:`z_query_reply_options_t` with default values.
@@ -2023,15 +2020,15 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
                                 const z_subscriber_options_t *options);
 
 /**
- * Undeclares and clears the subscriber.
+ * Undeclares the subscriber callback.
  *
  * Parameters:
- *   sub: Moved :c:type:`z_owned_subscriber_t` to undeclare.
+ *   sub: Loaned :c:type:`z_owned_subscriber_t` to undeclare.
  *
  * Return:
  *   ``0`` if undeclare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_subscriber(z_moved_subscriber_t *sub);
+z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub);
 
 /**
  * Gets the keyexpr from a subscriber.

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1594,7 +1594,7 @@ void z_publisher_options_default(z_publisher_options_t *options);
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
+z_result_t z_publisher_declare(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**
@@ -1747,7 +1747,7 @@ void z_queryable_options_default(z_queryable_options_t *options);
  * Return:
  *   ``0`` if declare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
+z_result_t z_queryable_declare(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options);
 
@@ -1764,7 +1764,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
  * Return:
  *   ``0`` if declare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_queryable_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                           z_moved_closure_query_t *callback, const z_queryable_options_t *options);
 
 /**
@@ -2008,7 +2008,7 @@ void z_subscriber_options_default(z_subscriber_options_t *options);
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
+z_result_t z_subscriber_declare(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options);
 
@@ -2025,7 +2025,7 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_subscriber_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                            z_moved_closure_sample_t *callback, const z_subscriber_options_t *options);
 
 /**

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -138,7 +138,7 @@ _Z_OWNED_TYPE_VALUE(_z_encoding_t, encoding)
 _Z_OWNED_TYPE_VALUE(_z_value_t, reply_err)
 
 /**
- * Represents the configuration used to configure a subscriber upon declaration :c:func:`z_declare_subscriber`.
+ * Represents the configuration used to configure a subscriber upon declaration :c:func:`z_subscriber_declare`.
  */
 typedef struct {
     uint8_t __dummy;  // Just to avoid empty structures that might cause undefined behavior
@@ -169,7 +169,7 @@ typedef struct {
 } z_query_consolidation_t;
 
 /**
- * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_declare_publisher`.
+ * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_publisher_declare`.
  *
  * Members:
  *   z_owned_encoding_t *encoding: Default encoding for messages put by this publisher.
@@ -190,7 +190,7 @@ typedef struct {
 } z_publisher_options_t;
 
 /**
- * Represents the configuration used to configure a queryable upon declaration :c:func:`z_declare_queryable`.
+ * Represents the configuration used to configure a queryable upon declaration :c:func:`z_queryable_declare`.
  *
  * Members:
  *   bool complete: The completeness of the queryable.
@@ -386,7 +386,7 @@ typedef struct {
 } zp_send_join_options_t;
 
 /**
- * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_declare_publisher`.
+ * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_publisher_declare`.
  *
  * Members:
  *   uint64_t timeout_ms: The maximum duration in ms the scouting can take.

--- a/include/zenoh-pico/net/filtering.h
+++ b/include/zenoh-pico/net/filtering.h
@@ -42,7 +42,7 @@ typedef struct _z_write_filter_t {
 typedef struct _z_publisher_t _z_publisher_t;
 
 z_result_t _z_write_filter_create(_z_publisher_t *pub);
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub);
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub);
 bool _z_write_filter_active(const _z_publisher_t *pub);
 
 #endif /* ZENOH_PICO_FILTERING_NETAPI_H */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -871,7 +871,7 @@ void z_publisher_options_default(z_publisher_options_t *options) {
 #endif
 }
 
-z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
+z_result_t z_publisher_declare(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options) {
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
     _z_keyexpr_t key = keyexpr_aliased;
@@ -1103,15 +1103,15 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_ch
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
 
-z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_queryable_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                           z_moved_closure_query_t *callback, const z_queryable_options_t *options) {
     z_owned_queryable_t qle;
-    _Z_RETURN_IF_ERR(z_declare_queryable(&qle, zs, keyexpr, callback, options));
+    _Z_RETURN_IF_ERR(z_queryable_declare(&qle, zs, keyexpr, callback, options));
     _z_queryable_clear(&qle._val);
     return _Z_RES_OK;
 }
 
-z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
+z_result_t z_queryable_declare(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options) {
     void *ctx = callback->_this._val.context;
@@ -1316,15 +1316,15 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber
 
 void z_subscriber_options_default(z_subscriber_options_t *options) { options->__dummy = 0; }
 
-z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_subscriber_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                            z_moved_closure_sample_t *callback, const z_subscriber_options_t *options) {
     z_owned_subscriber_t sub;
-    _Z_RETURN_IF_ERR(z_declare_subscriber(&sub, zs, keyexpr, callback, options));
+    _Z_RETURN_IF_ERR(z_subscriber_declare(&sub, zs, keyexpr, callback, options));
     _z_subscriber_clear(&sub._val);
     return _Z_RES_OK;
 }
 
-z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
+z_result_t z_subscriber_declare(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options) {
     _ZP_UNUSED(options);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -913,12 +913,6 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub) {
-    z_result_t res = _z_undeclare_publisher(pub);
-    _z_session_weak_drop(&pub->_zn);  // drop session to prevent publisher from being able to perform put
-    return res;
-}
-
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
     options->encoding = NULL;
     options->attachment = NULL;
@@ -1109,6 +1103,14 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_ch
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
 
+z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+                                          z_moved_closure_query_t *callback, const z_queryable_options_t *options) {
+    z_owned_queryable_t qle;
+    _Z_RETURN_IF_ERR(z_declare_queryable(&qle, zs, keyexpr, callback, options));
+    _z_queryable_clear(&qle._val);
+    return _Z_RES_OK;
+}
+
 z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options) {
@@ -1141,8 +1143,6 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
     z_internal_closure_query_null(&callback->_this);
     return _Z_RES_OK;
 }
-
-z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable) { return _z_undeclare_queryable(queryable); }
 
 void z_query_reply_options_default(z_query_reply_options_t *options) {
     options->encoding = NULL;
@@ -1316,6 +1316,14 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber
 
 void z_subscriber_options_default(z_subscriber_options_t *options) { options->__dummy = 0; }
 
+z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+                                           z_moved_closure_sample_t *callback, const z_subscriber_options_t *options) {
+    z_owned_subscriber_t sub;
+    _Z_RETURN_IF_ERR(z_declare_subscriber(&sub, zs, keyexpr, callback, options));
+    _z_subscriber_clear(&sub._val);
+    return _Z_RES_OK;
+}
+
 z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options) {
@@ -1366,8 +1374,6 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
         return _Z_RES_OK;
     }
 }
-
-z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub) { return _z_undeclare_subscriber(sub); }
 
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub) {
     // Retrieve keyexpr from session

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -778,7 +778,10 @@ const z_loaned_slice_t *z_string_as_slice(const z_loaned_string_t *str) { return
 z_priority_t z_priority_default(void) { return Z_PRIORITY_DEFAULT; }
 
 #if Z_FEATURE_PUBLICATION == 1
-void _z_publisher_drop(_z_publisher_t *pub) { _z_publisher_clear(pub); }
+void _z_publisher_drop(_z_publisher_t *pub) {
+    _z_undeclare_publisher(pub);
+    _z_publisher_clear(pub);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_publisher_t, publisher, _z_publisher_check, _z_publisher_null,
                                       _z_publisher_drop)
@@ -910,10 +913,10 @@ z_result_t z_declare_publisher(z_owned_publisher_t *pub, const z_loaned_session_
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_publisher(z_moved_publisher_t *pub) {
-    z_result_t ret = _z_undeclare_publisher(&pub->_this._val);
-    _z_publisher_clear(&pub->_this._val);
-    return ret;
+z_result_t z_undeclare_publisher(z_loaned_publisher_t *pub) {
+    z_result_t res = _z_undeclare_publisher(pub);
+    _z_session_weak_drop(&pub->_zn);  // drop session to prevent publisher from being able to perform put
+    return res;
 }
 
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
@@ -1096,7 +1099,10 @@ bool z_reply_replier_id(const z_loaned_reply_t *reply, z_id_t *out_id) {
 #if Z_FEATURE_QUERYABLE == 1
 _Z_OWNED_FUNCTIONS_RC_IMPL(query)
 
-void _z_queryable_drop(_z_queryable_t *queryable) { _z_queryable_clear(queryable); }
+void _z_queryable_drop(_z_queryable_t *queryable) {
+    _z_undeclare_queryable(queryable);
+    _z_queryable_clear(queryable);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_check, _z_queryable_null,
                                       _z_queryable_drop)
@@ -1136,11 +1142,7 @@ z_result_t z_declare_queryable(z_owned_queryable_t *queryable, const z_loaned_se
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_queryable(z_moved_queryable_t *queryable) {
-    z_result_t ret = _z_undeclare_queryable(&queryable->_this._val);
-    _z_queryable_clear(&queryable->_this._val);
-    return ret;
-}
+z_result_t z_undeclare_queryable(z_loaned_queryable_t *queryable) { return _z_undeclare_queryable(queryable); }
 
 void z_query_reply_options_default(z_query_reply_options_t *options) {
     options->encoding = NULL;
@@ -1304,7 +1306,10 @@ z_result_t z_undeclare_keyexpr(z_moved_keyexpr_t *keyexpr, const z_loaned_sessio
 }
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-void _z_subscriber_drop(_z_subscriber_t *sub) { _z_subscriber_clear(sub); }
+void _z_subscriber_drop(_z_subscriber_t *sub) {
+    _z_undeclare_subscriber(sub);
+    _z_subscriber_clear(sub);
+}
 
 _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber_check, _z_subscriber_null,
                                       _z_subscriber_drop)
@@ -1362,11 +1367,7 @@ z_result_t z_declare_subscriber(z_owned_subscriber_t *sub, const z_loaned_sessio
     }
 }
 
-z_result_t z_undeclare_subscriber(z_moved_subscriber_t *sub) {
-    z_result_t ret = _z_undeclare_subscriber(&sub->_this._val);
-    _z_subscriber_clear(&sub->_this._val);
-    return ret;
-}
+z_result_t z_undeclare_subscriber(z_loaned_subscriber_t *sub) { return _z_undeclare_subscriber(sub); }
 
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub) {
     // Retrieve keyexpr from session

--- a/src/net/filtering.c
+++ b/src/net/filtering.c
@@ -94,13 +94,18 @@ z_result_t _z_write_filter_create(_z_publisher_t *pub) {
     return _Z_RES_OK;
 }
 
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub) {
-    _Z_RETURN_IF_ERR(_z_remove_interest(_Z_RC_IN_VAL(&pub->_zn), pub->_filter._interest_id));
-    z_free(pub->_filter.ctx);
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub) {
+    if (pub->_filter.ctx != NULL) {
+        _Z_RETURN_IF_ERR(_z_remove_interest(_Z_RC_IN_VAL(&pub->_zn), pub->_filter._interest_id));
+        z_free(pub->_filter.ctx);
+        pub->_filter.ctx = NULL;
+    }
     return _Z_RES_OK;
 }
 
-bool _z_write_filter_active(const _z_publisher_t *pub) { return (pub->_filter.ctx->state == WRITE_FILTER_ACTIVE); }
+bool _z_write_filter_active(const _z_publisher_t *pub) {
+    return pub->_filter.ctx != NULL && pub->_filter.ctx->state == WRITE_FILTER_ACTIVE;
+}
 
 #else
 z_result_t _z_write_filter_create(_z_publisher_t *pub) {
@@ -108,7 +113,7 @@ z_result_t _z_write_filter_create(_z_publisher_t *pub) {
     return _Z_RES_OK;
 }
 
-z_result_t _z_write_filter_destroy(const _z_publisher_t *pub) {
+z_result_t _z_write_filter_destroy(_z_publisher_t *pub) {
     _ZP_UNUSED(pub);
     return _Z_RES_OK;
 }

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -20,6 +20,7 @@
 void _z_publisher_clear(_z_publisher_t *pub) {
     _z_keyexpr_clear(&pub->_key);
     _z_session_weak_drop(&pub->_zn);
+    _z_encoding_clear(&pub->_encoding);
     *pub = _z_publisher_null();
 }
 
@@ -38,7 +39,7 @@ bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL
 _z_publisher_t _z_publisher_null(void) {
     return (_z_publisher_t) {
         ._congestion_control = Z_CONGESTION_CONTROL_DEFAULT, ._id = 0, ._key = _z_keyexpr_null(),
-        ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_weak_null(),
+        ._priority = Z_PRIORITY_DEFAULT, ._zn = _z_session_weak_null(), ._encoding = _z_encoding_null(),
 #if Z_FEATURE_INTEREST == 1
         ._filter = (_z_write_filter_t) {
             ._interest_id = 0, .ctx = NULL

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -268,7 +268,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr_str);
     z_owned_subscriber_t _ret_sub;
-    _ret_res = z_declare_subscriber(&_ret_sub, z_loan(s2), z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
+    _ret_res = z_subscriber_declare(&_ret_sub, z_loan(s2), z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
     assert(_ret_res == _Z_RES_OK);
     printf("Ok\n");
 
@@ -328,7 +328,7 @@ int main(int argc, char **argv) {
     _ret_pub_opt.encoding = z_move(encoding);
     _ret_pub_opt.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
     z_owned_publisher_t _ret_pub;
-    _ret_res = z_declare_publisher(&_ret_pub, z_loan(s1), z_loan(s1_key), &_ret_pub_opt);
+    _ret_res = z_publisher_declare(&_ret_pub, z_loan(s1), z_loan(s1_key), &_ret_pub_opt);
     assert(_ret_res == _Z_RES_OK);
     assert(!z_internal_check(encoding));
     printf("Ok\n");
@@ -378,7 +378,7 @@ int main(int argc, char **argv) {
     z_queryable_options_t _ret_qle_opt;
     z_queryable_options_default(&_ret_qle_opt);
     z_owned_queryable_t qle;
-    assert(z_declare_queryable(&qle, z_loan(s1), z_loan(s1_key), z_move(_ret_closure_query), &_ret_qle_opt) ==
+    assert(z_queryable_declare(&qle, z_loan(s1), z_loan(s1_key), z_move(_ret_closure_query), &_ret_qle_opt) ==
            _Z_RES_OK);
     printf("Ok\n");
 

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -359,8 +359,6 @@ int main(int argc, char **argv) {
     assert_eq(datas, 4);
 
     printf("Undeclaring Publisher...");
-    _ret_res = z_undeclare_publisher(z_loan_mut(_ret_pub));
-    assert_eq(_ret_res, 0);
     z_drop(z_move(_ret_pub));
     assert(!z_internal_check(_ret_pub));
     printf("Ok\n");
@@ -368,8 +366,6 @@ int main(int argc, char **argv) {
     z_sleep_s(SLEEP);
 
     printf("Undeclaring Subscriber...");
-    _ret_res = z_undeclare_subscriber(z_loan_mut(_ret_sub));
-    assert_eq(_ret_res, 0);
     z_drop(z_move(_ret_sub));
     assert(!z_internal_check(_ret_sub));
     printf("Ok\n");
@@ -417,8 +413,6 @@ int main(int argc, char **argv) {
     assert_eq(replies, 1);
 
     printf("Undeclaring Queryable...");
-    _ret_res = z_undeclare_queryable(z_loan_mut(qle));
-    assert_eq(_ret_res, 0);
     z_drop(z_move(qle));
     printf("Ok\n");
 

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -359,16 +359,18 @@ int main(int argc, char **argv) {
     assert_eq(datas, 4);
 
     printf("Undeclaring Publisher...");
-    _ret_res = z_undeclare_publisher(z_move(_ret_pub));
+    _ret_res = z_undeclare_publisher(z_loan_mut(_ret_pub));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(_ret_pub));
     assert(!z_internal_check(_ret_pub));
     printf("Ok\n");
 
     z_sleep_s(SLEEP);
 
     printf("Undeclaring Subscriber...");
-    _ret_res = z_undeclare_subscriber(z_move(_ret_sub));
+    _ret_res = z_undeclare_subscriber(z_loan_mut(_ret_sub));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(_ret_sub));
     assert(!z_internal_check(_ret_sub));
     printf("Ok\n");
 
@@ -415,8 +417,9 @@ int main(int argc, char **argv) {
     assert_eq(replies, 1);
 
     printf("Undeclaring Queryable...");
-    _ret_res = z_undeclare_queryable(z_move(qle));
+    _ret_res = z_undeclare_queryable(z_loan_mut(qle));
     assert_eq(_ret_res, 0);
+    z_drop(z_move(qle));
     printf("Ok\n");
 
 #ifdef ZENOH_PICO

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
         z_owned_closure_sample_t callback;
         z_closure(&callback, data_handler, NULL, &idx[i]);
         z_owned_subscriber_t *sub = (z_owned_subscriber_t *)z_malloc(sizeof(z_owned_subscriber_t));
-        z_result_t res = z_declare_subscriber(sub, z_loan(s2), z_loan(rids2[i]), z_move(callback), NULL);
+        z_result_t res = z_subscriber_declare(sub, z_loan(s2), z_loan(rids2[i]), z_move(callback), NULL);
         assert(res == _Z_RES_OK);
         printf("Declared subscription on session 2: %ju %u %s\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id,
                z_loan(rids2[i])->_id, "");
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
         z_owned_queryable_t *qle = (z_owned_queryable_t *)z_malloc(sizeof(z_owned_queryable_t));
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
-        assert(z_declare_queryable(qle, z_loan(s2), z_loan(ke), z_move(callback), NULL) == _Z_RES_OK);
+        assert(z_queryable_declare(qle, z_loan(s2), z_loan(ke), z_move(callback), NULL) == _Z_RES_OK);
         printf("Declared queryable on session 2: %ju %zu %s\n", (uintmax_t)qle->_val._entity_id, (z_zint_t)0, s1_res);
         qles2 = _z_list_push(qles2, qle);
     }
@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
     // Declare publisher on first session
     for (unsigned int i = 0; i < SET; i++) {
         z_owned_publisher_t *pub = (z_owned_publisher_t *)z_malloc(sizeof(z_owned_publisher_t));
-        if (z_declare_publisher(pub, z_loan(s1), z_loan(rids1[i]), NULL) < 0) {
+        if (z_publisher_declare(pub, z_loan(s1), z_loan(rids1[i]), NULL) < 0) {
             printf("Declared publisher on session 1: %zu\n", z_loan(*pub)->_id);
         }
         pubs1 = _z_list_push(pubs1, pub);

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {
     while (pubs1) {
         z_owned_publisher_t *pub = _z_list_head(pubs1);
         printf("Undeclared publisher on session 2: %zu\n", z_loan(*pub)->_id);
-        z_undeclare_publisher(z_move(*pub));
+        z_drop(z_move(*pub));
         pubs1 = _z_list_pop(pubs1, _z_noop_elem_free, NULL);
     }
 
@@ -362,7 +362,7 @@ int main(int argc, char **argv) {
     while (subs2) {
         z_owned_subscriber_t *sub = _z_list_head(subs2);
         printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)sub->_val._entity_id);
-        z_undeclare_subscriber(z_move(*sub));
+        z_drop(z_move(*sub));
         subs2 = _z_list_pop(subs2, _z_noop_elem_free, NULL);
     }
 
@@ -371,7 +371,7 @@ int main(int argc, char **argv) {
     while (qles2) {
         z_owned_queryable_t *qle = _z_list_head(qles2);
         printf("Undeclared queryable on session 2: %ju\n", (uintmax_t)qle->_val._entity_id);
-        z_undeclare_queryable(z_move(*qle));
+        z_drop(z_move(*qle));
         qles2 = _z_list_pop(qles2, _z_noop_elem_free, NULL);
     }
 

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
     while (subs2) {
         z_owned_subscriber_t *sub = _z_list_head(subs2);
         printf("Undeclared subscriber on session 2: %ju\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id);
-        z_undeclare_subscriber(z_move(*sub));
+        z_drop(z_move(*sub));
         subs2 = _z_list_pop(subs2, _z_noop_elem_free, NULL);
     }
 

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
         z_owned_subscriber_t *sub = (z_owned_subscriber_t *)z_malloc(sizeof(z_owned_subscriber_t));
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
-        z_result_t res = z_declare_subscriber(sub, z_loan(s2), z_loan(ke), z_move(callback), NULL);
+        z_result_t res = z_subscriber_declare(sub, z_loan(s2), z_loan(ke), z_move(callback), NULL);
         assert(res == _Z_RES_OK);
         printf("Declared subscription on session 2: %ju %zu %s\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id,
                (z_zint_t)0, s1_res);

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
     printf("End of test\n");
     z_sleep_s(1);
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     exit(0);
 }

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_publisher(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     zp_stop_lease_task(z_loan_mut(s));
 
     // Clean up
-    z_undeclare_publisher(z_move(pub));
+    z_drop(z_move(pub));
     z_drop(z_move(s));
     free(value);
     exit(0);

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_declare_subscriber(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         (void)ret;  // Remove unused result warning
     }
     // Clean up
-    z_undeclare_subscriber(z_move(sub));
+    z_drop(z_move(sub));
     z_drop(z_move(s));
     return 0;
 }


### PR DESCRIPTION
remove z_undeclare_subscriber/publisher/queryable;
make z_subscriber/publisher/queryable_drop automatically undeclare corresponding entities;
add z_declare_background_subscriber/queryable functions, that do not return an entity, but rather register the corresponding callbacks until the session is closed/dropped;
fix memory leaks in publisher due to non-cleared encoding and write_filter;