### PR TITLE
Remove legacy z_config_new

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -807,7 +807,6 @@ See details at :ref:`owned_types_concept`
 Functions
 ^^^^^^^^^
 
-.. autocfunction:: primitives.h::z_config_new
 .. autocfunction:: primitives.h::z_config_default
 .. autocfunction:: primitives.h::zp_config_get
 .. autocfunction:: primitives.h::zp_config_insert

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -282,15 +282,6 @@ bool z_keyexpr_intersects(const z_loaned_keyexpr_t *l, const z_loaned_keyexpr_t 
 bool z_keyexpr_equals(const z_loaned_keyexpr_t *l, const z_loaned_keyexpr_t *r);
 
 /**
- * Builds a new, zenoh-allocated, empty configuration.
- * It consists in an empty set of properties for zenoh session configuration.
- *
- * Parameters:
- *   config: Pointer to uninitialized :c:type:`z_owned_config_t`.
- */
-void z_config_new(z_owned_config_t *config);
-
-/**
  * Builds a new, zenoh-allocated, default configuration.
  * It consists in a default set of properties for zenoh session configuration.
  *

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -204,8 +204,6 @@ bool z_keyexpr_equals(const z_loaned_keyexpr_t *l, const z_loaned_keyexpr_t *r) 
     return _z_keyexpr_suffix_equals(l, r);
 }
 
-void z_config_new(z_owned_config_t *config) { config->_val = _z_config_empty(); }
-
 z_result_t z_config_default(z_owned_config_t *config) { return _z_config_default(&config->_val); }
 
 const char *zp_config_get(const z_loaned_config_t *config, uint8_t key) { return _z_config_get(config, key); }

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -165,9 +165,6 @@ int main(int argc, char **argv) {
 
     printf("Testing Configs...");
     z_owned_config_t _ret_config;
-    z_config_new(&_ret_config);
-    assert(!z_internal_check(_ret_config));  // null config corresponds to empty one
-    z_drop(z_move(_ret_config));
     z_config_default(&_ret_config);
     assert(z_internal_check(_ret_config));
 #ifdef ZENOH_PICO


### PR DESCRIPTION
This method is absent in zenoh and zenoh-c and didn't used