### PR TITLE
Add Z_FEATURE_TCP_NODELAY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(Z_FEATURE_LINK_UDP_UNICAST 1 CACHE STRING "Toggle UDP unicast links")
 set(Z_FEATURE_MULTICAST_TRANSPORT 1 CACHE STRING "Toggle multicast transport")
 set(Z_FEATURE_UNICAST_TRANSPORT 1 CACHE STRING "Toggle unicast transport")
 set(Z_FEATURE_RAWETH_TRANSPORT 0 CACHE STRING "Toggle raw ethernet transport")
+set(Z_FEATURE_TCP_NODELAY 1 CACHE STRING "Toggle TCP_NODELAY")
 
 add_compile_definitions("Z_BUILD_DEBUG=$<CONFIG:Debug>")
 message(STATUS "Building with feature confing:\n\

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -41,6 +41,7 @@
 #define Z_FEATURE_UNICAST_TRANSPORT 1
 #define Z_FEATURE_FRAGMENTATION 1
 #define Z_FEATURE_ENCODING_VALUES 1
+#define Z_FEATURE_TCP_NODELAY 1
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -41,6 +41,7 @@
 #define Z_FEATURE_UNICAST_TRANSPORT @Z_FEATURE_UNICAST_TRANSPORT@
 #define Z_FEATURE_FRAGMENTATION @Z_FEATURE_FRAGMENTATION@
 #define Z_FEATURE_ENCODING_VALUES @Z_FEATURE_ENCODING_VALUES@
+#define Z_FEATURE_TCP_NODELAY @Z_FEATURE_TCP_NODELAY@
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/src/system/arduino/esp32/network.cpp
+++ b/src/system/arduino/esp32/network.cpp
@@ -64,6 +64,13 @@ z_result_t _z_open_tcp(_z_sys_net_socket_t *sock, const _z_sys_net_endpoint_t re
             ret = _Z_ERR_GENERIC;
         }
 
+#if Z_FEATURE_TCP_NODELAY == 1
+        if ((ret == _Z_RES_OK) &&
+            (setsockopt(sock->_fd, IPPROTO_TCP, TCP_NODELAY, (void *)&optflag, sizeof(optflag)) < 0)) {
+            ret = _Z_ERR_GENERIC;
+        }
+#endif
+
 #if LWIP_SO_LINGER == 1
         struct linger ling;
         ling.l_onoff = 1;

--- a/src/system/espidf/network.c
+++ b/src/system/espidf/network.c
@@ -60,6 +60,13 @@ z_result_t _z_open_tcp(_z_sys_net_socket_t *sock, const _z_sys_net_endpoint_t re
             ret = _Z_ERR_GENERIC;
         }
 
+#if Z_FEATURE_TCP_NODELAY == 1
+        if ((ret == _Z_RES_OK) &&
+            (setsockopt(sock->_fd, IPPROTO_TCP, TCP_NODELAY, (void *)&optflag, sizeof(optflag)) < 0)) {
+            ret = _Z_ERR_GENERIC;
+        }
+#endif
+
 #if LWIP_SO_LINGER == 1
         struct linger ling;
         ling.l_onoff = 1;

--- a/src/system/unix/network.c
+++ b/src/system/unix/network.c
@@ -18,6 +18,7 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
@@ -71,7 +72,12 @@ z_result_t _z_open_tcp(_z_sys_net_socket_t *sock, const _z_sys_net_endpoint_t re
             (setsockopt(sock->_fd, SOL_SOCKET, SO_KEEPALIVE, (void *)&flags, sizeof(flags)) < 0)) {
             ret = _Z_ERR_GENERIC;
         }
-
+#if Z_FEATURE_TCP_NODELAY == 1
+        if ((ret == _Z_RES_OK) &&
+            (setsockopt(sock->_fd, IPPROTO_TCP, TCP_NODELAY, (void *)&flags, sizeof(flags)) < 0)) {
+            ret = _Z_ERR_GENERIC;
+        }
+#endif
         struct linger ling;
         ling.l_onoff = 1;
         ling.l_linger = Z_TRANSPORT_LEASE / 1000;

--- a/src/system/windows/network.c
+++ b/src/system/windows/network.c
@@ -75,6 +75,13 @@ z_result_t _z_open_tcp(_z_sys_net_socket_t *sock, const _z_sys_net_endpoint_t re
             ret = _Z_ERR_GENERIC;
         }
 
+#if Z_FEATURE_TCP_NODELAY == 1
+        if ((ret == _Z_RES_OK) &&
+            (setsockopt(sock->_sock._fd, IPPROTO_TCP, TCP_NODELAY, (void *)&flags, sizeof(flags)) < 0)) {
+            ret = _Z_ERR_GENERIC;
+        }
+#endif
+
         struct linger ling;
         ling.l_onoff = 1;
         ling.l_linger = Z_TRANSPORT_LEASE / 1000;

--- a/src/system/zephyr/network.c
+++ b/src/system/zephyr/network.c
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <sys/socket.h>
+#include <zephyr/net/net_if.h>
 
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/config.h"
@@ -67,6 +68,14 @@ z_result_t _z_open_tcp(_z_sys_net_socket_t *sock, const _z_sys_net_endpoint_t re
             // FIXME: setting the setsockopt is consistently failing. Commenting it until further inspection.
             // ret = _Z_ERR_GENERIC;
         }
+
+#if Z_FEATURE_TCP_NODELAY == 1
+        int optflag = 1;
+        if ((ret == _Z_RES_OK) &&
+            (setsockopt(sock->_fd, IPPROTO_TCP, TCP_NODELAY, (void *)&optflag, sizeof(optflag)) < 0)) {
+            ret = _Z_ERR_GENERIC;
+        }
+#endif
 
 #if LWIP_SO_LINGER == 1
         struct linger ling;

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -141,6 +141,8 @@ z_result_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t 
                             if (ret == _Z_RES_OK) {
                                 ztm->_transmitted = true;  // Mark the session that we have transmitted data
                             }
+                        } else {
+                            _Z_ERROR("Fragment serialization failed with err %d", ret);
                         }
                     }
                 }

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -150,6 +150,8 @@ z_result_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n
                             if (ret == _Z_RES_OK) {
                                 ztu->_transmitted = true;  // Mark the session that we have transmitted data
                             }
+                        } else {
+                            _Z_ERROR("Fragment serialization failed with err %d", ret);
                         }
                     }
                 }


### PR DESCRIPTION
Because of the mtu changes in Zenoh 1.0 routers, zenoh-pico fell in a bad timing between the Linux tcp_ack_time and Nagle's algorithm. Since embedded is more about zero-wait tcp packets, added the default config option to remove Nagle's algorithm where applicable.

Also changes the way fragments are created to improve performance. 