### PR TITLE
Set mbed CI to use ubuntu 22.04

### DIFF
--- a/.github/workflows/mbed.yaml
+++ b/.github/workflows/mbed.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 24.04 uses Python 3.12, which have module `imp` deprecated.
But platformio still use it, we switch back to ubuntu 22.04, until it will be fixed.