### PR TITLE
Use standalone valgrind in place of snap for CI tests

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -265,7 +265,7 @@ jobs:
           echo "zenohd-pid=$!" >> $GITHUB_OUTPUT
 
       - name: Install valgrind
-        uses: taiki-e/install-action@valgrind
+        run: sudo apt install -y valgrind
 
       - name: Build project and run test
         run: |


### PR DESCRIPTION
Valgrind from snap has install issue (glibc version conflict), so we switch to valgrind for from apt