### PR TITLE
Improve throughput performance (trigger local subscriber focus)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ set(Z_FEATURE_MULTICAST_TRANSPORT 1 CACHE STRING "Toggle multicast transport")
 set(Z_FEATURE_UNICAST_TRANSPORT 1 CACHE STRING "Toggle unicast transport")
 set(Z_FEATURE_RAWETH_TRANSPORT 0 CACHE STRING "Toggle raw ethernet transport")
 set(Z_FEATURE_TCP_NODELAY 1 CACHE STRING "Toggle TCP_NODELAY")
+set(Z_FEATURE_LOCAL_SUBSCRIBER 0 CACHE STRING "Toggle local subscriptions")
 
 add_compile_definitions("Z_BUILD_DEBUG=$<CONFIG:Debug>")
 message(STATUS "Building with feature confing:\n\

--- a/include/zenoh-pico/collections/bytes.h
+++ b/include/zenoh-pico/collections/bytes.h
@@ -46,7 +46,7 @@ typedef struct {
 } _z_bytes_t;
 
 bool _z_bytes_check(const _z_bytes_t *bytes);
-_z_bytes_t _z_bytes_null(void);
+static inline _z_bytes_t _z_bytes_null(void) { return (_z_bytes_t){0}; }
 z_result_t _z_bytes_append_bytes(_z_bytes_t *dst, _z_bytes_t *src);
 z_result_t _z_bytes_append_slice(_z_bytes_t *dst, _z_arc_slice_t *s);
 z_result_t _z_bytes_copy(_z_bytes_t *dst, const _z_bytes_t *src);

--- a/include/zenoh-pico/collections/bytes.h
+++ b/include/zenoh-pico/collections/bytes.h
@@ -45,8 +45,9 @@ typedef struct {
     _z_arc_slice_svec_t _slices;
 } _z_bytes_t;
 
-bool _z_bytes_check(const _z_bytes_t *bytes);
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_bytes_t _z_bytes_null(void) { return (_z_bytes_t){0}; }
+bool _z_bytes_check(const _z_bytes_t *bytes);
 z_result_t _z_bytes_append_bytes(_z_bytes_t *dst, _z_bytes_t *src);
 z_result_t _z_bytes_append_slice(_z_bytes_t *dst, _z_arc_slice_t *s);
 z_result_t _z_bytes_copy(_z_bytes_t *dst, const _z_bytes_t *src);

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -26,9 +26,7 @@ typedef struct {
     void *context;
 } _z_delete_context_t;
 
-static inline _z_delete_context_t _z_delete_context_null(void) {
-    return (_z_delete_context_t){.deleter = NULL, .context = NULL};
-}
+static inline _z_delete_context_t _z_delete_context_null(void) { return (_z_delete_context_t){0}; }
 
 static inline _z_delete_context_t _z_delete_context_create(void (*deleter)(void *context, void *data), void *context) {
     return (_z_delete_context_t){.deleter = deleter, .context = context};
@@ -52,9 +50,7 @@ typedef struct {
     _z_delete_context_t _delete_context;
 } _z_slice_t;
 
-static inline _z_slice_t _z_slice_empty(void) {
-    return (_z_slice_t){.start = NULL, .len = 0, ._delete_context = _z_delete_context_null()};
-}
+static inline _z_slice_t _z_slice_empty(void) { return (_z_slice_t){0}; }
 static inline bool _z_slice_is_empty(const _z_slice_t *bs) { return bs->len == 0; }
 static inline bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity);

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -26,9 +26,12 @@ typedef struct {
     void *context;
 } _z_delete_context_t;
 
-_z_delete_context_t _z_delete_context_null(void);
+static inline _z_delete_context_t _z_delete_context_null(void) { return (_z_delete_context_t){.deleter = NULL, .context = NULL}; }
+
+static inline _z_delete_context_t _z_delete_context_create(void (*deleter)(void *context, void *data), void *context) {
+    return (_z_delete_context_t){.deleter = deleter, .context = context};
+}
 bool _z_delete_context_is_null(const _z_delete_context_t *c);
-_z_delete_context_t _z_delete_context_create(void (*deleter)(void *context, void *data), void *context);
 _z_delete_context_t _z_delete_context_default(void);
 void _z_delete_context_delete(_z_delete_context_t *c, void *data);
 
@@ -47,8 +50,10 @@ typedef struct {
     _z_delete_context_t _delete_context;
 } _z_slice_t;
 
-_z_slice_t _z_slice_empty(void);
-inline static bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
+static inline _z_slice_t _z_slice_empty(void) {
+    return (_z_slice_t){.start = NULL, .len = 0, ._delete_context = _z_delete_context_null()};
+}
+static inline bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity);
 _z_slice_t _z_slice_make(size_t capacity);
 _z_slice_t _z_slice_alias_buf(const uint8_t *bs, size_t len);

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -26,6 +26,7 @@ typedef struct {
     void *context;
 } _z_delete_context_t;
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_delete_context_t _z_delete_context_null(void) { return (_z_delete_context_t){0}; }
 
 static inline _z_delete_context_t _z_delete_context_create(void (*deleter)(void *context, void *data), void *context) {

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -26,7 +26,9 @@ typedef struct {
     void *context;
 } _z_delete_context_t;
 
-static inline _z_delete_context_t _z_delete_context_null(void) { return (_z_delete_context_t){.deleter = NULL, .context = NULL}; }
+static inline _z_delete_context_t _z_delete_context_null(void) {
+    return (_z_delete_context_t){.deleter = NULL, .context = NULL};
+}
 
 static inline _z_delete_context_t _z_delete_context_create(void (*deleter)(void *context, void *data), void *context) {
     return (_z_delete_context_t){.deleter = deleter, .context = context};
@@ -53,6 +55,7 @@ typedef struct {
 static inline _z_slice_t _z_slice_empty(void) {
     return (_z_slice_t){.start = NULL, .len = 0, ._delete_context = _z_delete_context_null()};
 }
+static inline bool _z_slice_is_empty(const _z_slice_t *bs) { return bs->len == 0; }
 static inline bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity);
 _z_slice_t _z_slice_make(size_t capacity);
@@ -66,7 +69,6 @@ z_result_t _z_slice_n_copy(_z_slice_t *dst, const _z_slice_t *src, size_t offset
 _z_slice_t _z_slice_duplicate(const _z_slice_t *src);
 void _z_slice_move(_z_slice_t *dst, _z_slice_t *src);
 void _z_slice_reset(_z_slice_t *bs);
-bool _z_slice_is_empty(const _z_slice_t *bs);
 bool _z_slice_eq(const _z_slice_t *left, const _z_slice_t *right);
 void _z_slice_clear(_z_slice_t *bs);
 void _z_slice_free(_z_slice_t **bs);

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -53,13 +53,15 @@ typedef struct {
 static inline _z_slice_t _z_slice_empty(void) { return (_z_slice_t){0}; }
 static inline bool _z_slice_is_empty(const _z_slice_t *bs) { return bs->len == 0; }
 static inline bool _z_slice_check(const _z_slice_t *slice) { return slice->start != NULL; }
+static inline _z_slice_t _z_slice_alias(const _z_slice_t bs) {
+    return (_z_slice_t){.len = bs.len, .start = bs.start, ._delete_context = _z_delete_context_null()};
+}
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity);
 _z_slice_t _z_slice_make(size_t capacity);
 _z_slice_t _z_slice_alias_buf(const uint8_t *bs, size_t len);
 _z_slice_t _z_slice_from_buf_custom_deleter(const uint8_t *p, size_t len, _z_delete_context_t dc);
 _z_slice_t _z_slice_copy_from_buf(const uint8_t *bs, size_t len);
 _z_slice_t _z_slice_steal(_z_slice_t *b);
-_z_slice_t _z_slice_alias(const _z_slice_t *bs);
 z_result_t _z_slice_copy(_z_slice_t *dst, const _z_slice_t *src);
 z_result_t _z_slice_n_copy(_z_slice_t *dst, const _z_slice_t *src, size_t offset, size_t len);
 _z_slice_t _z_slice_duplicate(const _z_slice_t *src);

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -68,6 +68,9 @@ typedef struct {
 
 static inline _z_string_t _z_string_null(void) { return (_z_string_t){0}; }
 static inline bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
+static inline _z_string_t _z_string_alias(const _z_string_t str) {
+    return (_z_string_t){._slice = _z_slice_alias(str._slice)};
+}
 
 _z_string_t _z_string_copy_from_str(const char *value);
 _z_string_t _z_string_copy_from_substr(const char *value, size_t len);
@@ -85,7 +88,6 @@ z_result_t _z_string_copy(_z_string_t *dst, const _z_string_t *src);
 z_result_t _z_string_copy_substring(_z_string_t *dst, const _z_string_t *src, size_t offset, size_t len);
 void _z_string_move(_z_string_t *dst, _z_string_t *src);
 _z_string_t _z_string_steal(_z_string_t *str);
-_z_string_t _z_string_alias(const _z_string_t *str);
 void _z_string_move_str(_z_string_t *dst, char *src);
 void _z_string_clear(_z_string_t *s);
 void _z_string_free(_z_string_t **s);

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -66,6 +66,7 @@ typedef struct {
     _z_slice_t _slice;
 } _z_string_t;
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_string_t _z_string_null(void) { return (_z_string_t){0}; }
 static inline bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
 static inline _z_string_t _z_string_alias(const _z_string_t str) {

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -66,7 +66,7 @@ typedef struct {
     _z_slice_t _slice;
 } _z_string_t;
 
-static inline _z_string_t _z_string_null(void) { return (_z_string_t){._slice = _z_slice_empty()}; }
+static inline _z_string_t _z_string_null(void) { return (_z_string_t){0}; }
 static inline bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
 
 _z_string_t _z_string_copy_from_str(const char *value);

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -66,7 +66,7 @@ typedef struct {
     _z_slice_t _slice;
 } _z_string_t;
 
-_z_string_t _z_string_null(void);
+static inline _z_string_t _z_string_null(void) { return (_z_string_t){._slice = _z_slice_empty()}; }
 bool _z_string_check(const _z_string_t *value);
 _z_string_t _z_string_copy_from_str(const char *value);
 _z_string_t _z_string_copy_from_substr(const char *value, size_t len);

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -67,7 +67,8 @@ typedef struct {
 } _z_string_t;
 
 static inline _z_string_t _z_string_null(void) { return (_z_string_t){._slice = _z_slice_empty()}; }
-bool _z_string_check(const _z_string_t *value);
+static inline bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
+
 _z_string_t _z_string_copy_from_str(const char *value);
 _z_string_t _z_string_copy_from_substr(const char *value, size_t len);
 _z_string_t *_z_string_copy_from_str_as_ptr(const char *value);

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -42,6 +42,7 @@
 #define Z_FEATURE_FRAGMENTATION 1
 #define Z_FEATURE_ENCODING_VALUES 1
 #define Z_FEATURE_TCP_NODELAY 1
+#define Z_FEATURE_LOCAL_SUBSCRIBER 0
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -42,6 +42,7 @@
 #define Z_FEATURE_FRAGMENTATION @Z_FEATURE_FRAGMENTATION@
 #define Z_FEATURE_ENCODING_VALUES @Z_FEATURE_ENCODING_VALUES@
 #define Z_FEATURE_TCP_NODELAY @Z_FEATURE_TCP_NODELAY@
+#define Z_FEATURE_LOCAL_SUBSCRIBER @Z_FEATURE_LOCAL_SUBSCRIBER@
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/include/zenoh-pico/net/encoding.h
+++ b/include/zenoh-pico/net/encoding.h
@@ -26,6 +26,8 @@ typedef struct _z_encoding_t {
     _z_string_t schema;
     uint16_t id;
 } _z_encoding_t;
+
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_encoding_t _z_encoding_null(void) { return (_z_encoding_t){0}; }
 static inline bool _z_encoding_check(const _z_encoding_t *encoding) {
     return ((encoding->id != _Z_ENCODING_ID_DEFAULT) || _z_string_check(&encoding->schema));

--- a/include/zenoh-pico/net/encoding.h
+++ b/include/zenoh-pico/net/encoding.h
@@ -27,10 +27,12 @@ typedef struct _z_encoding_t {
     uint16_t id;
 } _z_encoding_t;
 static inline _z_encoding_t _z_encoding_null(void) { return (_z_encoding_t){0}; }
-
+static inline bool _z_encoding_check(const _z_encoding_t *encoding) {
+    return ((encoding->id != _Z_ENCODING_ID_DEFAULT) || _z_string_check(&encoding->schema));
+}
+_z_encoding_t _z_encoding_wrap(uint16_t id, const char *schema);
 z_result_t _z_encoding_make(_z_encoding_t *encoding, uint16_t id, const char *schema, size_t len);
 void _z_encoding_clear(_z_encoding_t *encoding);
-bool _z_encoding_check(const _z_encoding_t *encoding);
 z_result_t _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src);
 void _z_encoding_move(_z_encoding_t *dst, _z_encoding_t *src);
 _z_encoding_t _z_encoding_steal(_z_encoding_t *val);

--- a/include/zenoh-pico/net/encoding.h
+++ b/include/zenoh-pico/net/encoding.h
@@ -26,10 +26,9 @@ typedef struct _z_encoding_t {
     _z_string_t schema;
     uint16_t id;
 } _z_encoding_t;
+static inline _z_encoding_t _z_encoding_null(void) { return (_z_encoding_t){0}; }
 
 z_result_t _z_encoding_make(_z_encoding_t *encoding, uint16_t id, const char *schema, size_t len);
-_z_encoding_t _z_encoding_wrap(uint16_t id, const char *schema);
-_z_encoding_t _z_encoding_null(void);
 void _z_encoding_clear(_z_encoding_t *encoding);
 bool _z_encoding_check(const _z_encoding_t *encoding);
 z_result_t _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src);

--- a/include/zenoh-pico/net/publish.h
+++ b/include/zenoh-pico/net/publish.h
@@ -37,10 +37,11 @@ typedef struct _z_publisher_t {
 } _z_publisher_t;
 
 #if Z_FEATURE_PUBLICATION == 1
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_publisher_t _z_publisher_null(void) { return (_z_publisher_t){0}; }
+static inline bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
 void _z_publisher_clear(_z_publisher_t *pub);
 void _z_publisher_free(_z_publisher_t **pub);
-static inline bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
-static inline _z_publisher_t _z_publisher_null(void) { return (_z_publisher_t){0}; }
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PUBLISH_H */

--- a/include/zenoh-pico/net/publish.h
+++ b/include/zenoh-pico/net/publish.h
@@ -39,10 +39,8 @@ typedef struct _z_publisher_t {
 #if Z_FEATURE_PUBLICATION == 1
 void _z_publisher_clear(_z_publisher_t *pub);
 void _z_publisher_free(_z_publisher_t **pub);
-bool _z_publisher_check(const _z_publisher_t *publisher);
-static inline _z_publisher_t _z_publisher_null(void) {
-    return (_z_publisher_t) {0};
-}
+static inline bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
+static inline _z_publisher_t _z_publisher_null(void) { return (_z_publisher_t){0}; }
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PUBLISH_H */

--- a/include/zenoh-pico/net/publish.h
+++ b/include/zenoh-pico/net/publish.h
@@ -40,7 +40,9 @@ typedef struct _z_publisher_t {
 void _z_publisher_clear(_z_publisher_t *pub);
 void _z_publisher_free(_z_publisher_t **pub);
 bool _z_publisher_check(const _z_publisher_t *publisher);
-_z_publisher_t _z_publisher_null(void);
+static inline _z_publisher_t _z_publisher_null(void) {
+    return (_z_publisher_t) {0};
+}
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PUBLISH_H */

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -34,7 +34,9 @@ typedef struct _z_query_t {
     bool _anyke;
 } _z_query_t;
 
-_z_query_t _z_query_null(void);
+static inline _z_query_t _z_query_null(void) {
+    return (_z_query_t){0};
+}
 void _z_query_clear(_z_query_t *q);
 z_result_t _z_query_copy(_z_query_t *dst, const _z_query_t *src);
 void _z_query_free(_z_query_t **query);
@@ -54,7 +56,10 @@ _z_query_t _z_query_create(_z_value_t *value, _z_keyexpr_t *key, const _z_slice_
                            uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
-_z_queryable_t _z_queryable_null(void);
+static inline _z_queryable_t _z_queryable_null(void) {
+    return (_z_queryable_t){._entity_id = 0, ._zn = _z_session_weak_null()};
+}
+
 bool _z_queryable_check(const _z_queryable_t *queryable);
 #endif
 

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -34,9 +34,7 @@ typedef struct _z_query_t {
     bool _anyke;
 } _z_query_t;
 
-static inline _z_query_t _z_query_null(void) {
-    return (_z_query_t){0};
-}
+static inline _z_query_t _z_query_null(void) { return (_z_query_t){0}; }
 void _z_query_clear(_z_query_t *q);
 z_result_t _z_query_copy(_z_query_t *dst, const _z_query_t *src);
 void _z_query_free(_z_query_t **query);
@@ -59,8 +57,8 @@ void _z_queryable_free(_z_queryable_t **qbl);
 static inline _z_queryable_t _z_queryable_null(void) {
     return (_z_queryable_t){._entity_id = 0, ._zn = _z_session_weak_null()};
 }
+static inline bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 
-bool _z_queryable_check(const _z_queryable_t *queryable);
 #endif
 
 #endif /* ZENOH_PICO_QUERY_NETAPI_H */

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -34,6 +34,7 @@ typedef struct _z_query_t {
     bool _anyke;
 } _z_query_t;
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_query_t _z_query_null(void) { return (_z_query_t){0}; }
 void _z_query_clear(_z_query_t *q);
 z_result_t _z_query_copy(_z_query_t *dst, const _z_query_t *src);
@@ -50,12 +51,13 @@ typedef struct {
 } _z_queryable_t;
 
 #if Z_FEATURE_QUERYABLE == 1
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){0}; }
+static inline bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 _z_query_t _z_query_create(_z_value_t *value, _z_keyexpr_t *key, const _z_slice_t *parameters, _z_session_rc_t *zn,
                            uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
-static inline _z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){0}; }
-static inline bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 
 #endif
 

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -54,9 +54,7 @@ _z_query_t _z_query_create(_z_value_t *value, _z_keyexpr_t *key, const _z_slice_
                            uint32_t request_id, const _z_bytes_t attachment);
 void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
-static inline _z_queryable_t _z_queryable_null(void) {
-    return (_z_queryable_t){._entity_id = 0, ._zn = _z_session_weak_null()};
-}
+static inline _z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){0}; }
 static inline bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 
 #endif

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -57,6 +57,9 @@ typedef struct _z_reply_data_t {
     _z_reply_tag_t _tag;
 } _z_reply_data_t;
 
+static inline _z_reply_data_t _z_reply_data_null(void) {
+    return (_z_reply_data_t){.replier_id = {.id = {0}}, ._result.sample = _z_sample_null(), ._tag = _Z_REPLY_TAG_NONE};
+}
 void _z_reply_data_clear(_z_reply_data_t *rd);
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
 
@@ -77,8 +80,7 @@ typedef struct _z_reply_t {
 } _z_reply_t;
 
 _z_reply_t _z_reply_move(_z_reply_t *src_reply);
-
-_z_reply_t _z_reply_null(void);
+static inline _z_reply_t _z_reply_null(void) { return (_z_reply_t){.data = _z_reply_data_null()}; }
 void _z_reply_clear(_z_reply_t *src);
 void _z_reply_free(_z_reply_t **hello);
 z_result_t _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -57,6 +57,7 @@ typedef struct _z_reply_data_t {
     _z_reply_tag_t _tag;
 } _z_reply_data_t;
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_reply_data_t _z_reply_data_null(void) { return (_z_reply_data_t){0}; }
 void _z_reply_data_clear(_z_reply_data_t *rd);
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
@@ -77,8 +78,9 @@ typedef struct _z_reply_t {
     _z_reply_data_t data;
 } _z_reply_t;
 
-_z_reply_t _z_reply_move(_z_reply_t *src_reply);
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_reply_t _z_reply_null(void) { return (_z_reply_t){0}; }
+_z_reply_t _z_reply_move(_z_reply_t *src_reply);
 void _z_reply_clear(_z_reply_t *src);
 void _z_reply_free(_z_reply_t **hello);
 z_result_t _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -57,9 +57,7 @@ typedef struct _z_reply_data_t {
     _z_reply_tag_t _tag;
 } _z_reply_data_t;
 
-static inline _z_reply_data_t _z_reply_data_null(void) {
-    return (_z_reply_data_t){.replier_id = {.id = {0}}, ._result.sample = _z_sample_null(), ._tag = _Z_REPLY_TAG_NONE};
-}
+static inline _z_reply_data_t _z_reply_data_null(void) { return (_z_reply_data_t){0}; }
 void _z_reply_data_clear(_z_reply_data_t *rd);
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
 
@@ -80,7 +78,7 @@ typedef struct _z_reply_t {
 } _z_reply_t;
 
 _z_reply_t _z_reply_move(_z_reply_t *src_reply);
-static inline _z_reply_t _z_reply_null(void) { return (_z_reply_t){.data = _z_reply_data_null()}; }
+static inline _z_reply_t _z_reply_null(void) { return (_z_reply_t){0}; }
 void _z_reply_clear(_z_reply_t *src);
 void _z_reply_free(_z_reply_t **hello);
 z_result_t _z_reply_copy(_z_reply_t *dst, const _z_reply_t *src);

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -59,6 +59,11 @@ typedef struct _z_reply_data_t {
 
 // Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_reply_data_t _z_reply_data_null(void) { return (_z_reply_data_t){0}; }
+static inline _z_reply_data_t _z_reply_data_init(void) {
+    _z_reply_data_t reply_data = _z_reply_data_null();
+    reply_data._tag = _Z_REPLY_TAG_NONE;
+    return reply_data;
+}
 void _z_reply_data_clear(_z_reply_data_t *rd);
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src);
 

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -40,10 +40,11 @@ typedef struct _z_sample_t {
 } _z_sample_t;
 void _z_sample_clear(_z_sample_t *sample);
 
-static inline _z_sample_t _z_sample_null(void) {
-    return (_z_sample_t){0};
+static inline _z_sample_t _z_sample_null(void) { return (_z_sample_t){0}; }
+static inline bool _z_sample_check(const _z_sample_t *sample) {
+    return _z_keyexpr_check(&sample->keyexpr) || _z_encoding_check(&sample->encoding) ||
+           _z_bytes_check(&sample->payload) || _z_bytes_check(&sample->attachment);
 }
-bool _z_sample_check(const _z_sample_t *sample);
 void _z_sample_move(_z_sample_t *dst, _z_sample_t *src);
 
 /**

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -40,7 +40,9 @@ typedef struct _z_sample_t {
 } _z_sample_t;
 void _z_sample_clear(_z_sample_t *sample);
 
-_z_sample_t _z_sample_null(void);
+static inline _z_sample_t _z_sample_null(void) {
+    return (_z_sample_t){0};
+}
 bool _z_sample_check(const _z_sample_t *sample);
 void _z_sample_move(_z_sample_t *dst, _z_sample_t *src);
 

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -40,6 +40,7 @@ typedef struct _z_sample_t {
 } _z_sample_t;
 void _z_sample_clear(_z_sample_t *sample);
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_sample_t _z_sample_null(void) { return (_z_sample_t){0}; }
 static inline bool _z_sample_check(const _z_sample_t *sample) {
     return _z_keyexpr_check(&sample->keyexpr) || _z_encoding_check(&sample->encoding) ||

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -32,7 +32,7 @@ typedef struct {
 
 void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
-bool _z_subscriber_check(const _z_subscriber_t *subscriber);
+static inline bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
 static inline _z_subscriber_t _z_subscriber_null(void) {
     return (_z_subscriber_t){._entity_id = 0, ._zn = _z_session_weak_null()};
 }

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -29,11 +29,11 @@ typedef struct {
 } _z_subscriber_t;
 
 #if Z_FEATURE_SUBSCRIPTION == 1
-
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_subscriber_t _z_subscriber_null(void) { return (_z_subscriber_t){0}; }
+static inline bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
 void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
-static inline bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
-static inline _z_subscriber_t _z_subscriber_null(void) { return (_z_subscriber_t){0}; }
 
 #endif
 

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -33,7 +33,10 @@ typedef struct {
 void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
 bool _z_subscriber_check(const _z_subscriber_t *subscriber);
-_z_subscriber_t _z_subscriber_null(void);
+static inline _z_subscriber_t _z_subscriber_null(void) {
+    return (_z_subscriber_t){._entity_id = 0, ._zn = _z_session_weak_null()};
+}
+
 #endif
 
 #endif /* ZENOH_PICO_SUBSCRIBE_NETAPI_H */

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -33,9 +33,7 @@ typedef struct {
 void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
 static inline bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
-static inline _z_subscriber_t _z_subscriber_null(void) {
-    return (_z_subscriber_t){._entity_id = 0, ._zn = _z_session_weak_null()};
-}
+static inline _z_subscriber_t _z_subscriber_null(void) { return (_z_subscriber_t){0}; }
 
 #endif
 

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -66,8 +66,9 @@ typedef struct {
     uint64_t time;
 } _z_timestamp_t;
 
-_z_timestamp_t _z_timestamp_duplicate(const _z_timestamp_t *tstamp);
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_timestamp_t _z_timestamp_null(void) { return (_z_timestamp_t){0}; }
+_z_timestamp_t _z_timestamp_duplicate(const _z_timestamp_t *tstamp);
 void _z_timestamp_clear(_z_timestamp_t *tstamp);
 bool _z_timestamp_check(const _z_timestamp_t *stamp);
 uint64_t _z_timestamp_ntp64_from_time(uint32_t seconds, uint32_t nanos);
@@ -163,8 +164,9 @@ typedef struct {
     _z_bytes_t payload;
     _z_encoding_t encoding;
 } _z_value_t;
-static inline _z_value_t _z_value_null(void) { return (_z_value_t){0}; }
 
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_value_t _z_value_null(void) { return (_z_value_t){0}; }
 _z_value_t _z_value_steal(_z_value_t *value);
 z_result_t _z_value_copy(_z_value_t *dst, const _z_value_t *src);
 void _z_value_move(_z_value_t *dst, _z_value_t *src);
@@ -185,10 +187,12 @@ typedef struct {
     z_whatami_t _whatami;
     uint8_t _version;
 } _z_hello_t;
+
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_hello_t _z_hello_null(void) { return (_z_hello_t){0}; }
 void _z_hello_clear(_z_hello_t *src);
 void _z_hello_free(_z_hello_t **hello);
 z_result_t _z_hello_copy(_z_hello_t *dst, const _z_hello_t *src);
-static inline _z_hello_t _z_hello_null(void) { return (_z_hello_t){0}; }
 
 bool _z_hello_check(const _z_hello_t *hello);
 
@@ -204,6 +208,8 @@ typedef struct {
     uint32_t _entity_id;
     uint32_t _source_sn;
 } _z_source_info_t;
+
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_source_info_t _z_source_info_null(void) { return (_z_source_info_t){0}; }
 
 typedef struct {

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -67,7 +67,7 @@ typedef struct {
 } _z_timestamp_t;
 
 _z_timestamp_t _z_timestamp_duplicate(const _z_timestamp_t *tstamp);
-_z_timestamp_t _z_timestamp_null(void);
+static inline _z_timestamp_t _z_timestamp_null(void) { return (_z_timestamp_t){.id = _z_id_empty(), .time = 0}; }
 void _z_timestamp_clear(_z_timestamp_t *tstamp);
 bool _z_timestamp_check(const _z_timestamp_t *stamp);
 uint64_t _z_timestamp_ntp64_from_time(uint32_t seconds, uint32_t nanos);
@@ -163,7 +163,10 @@ typedef struct {
     _z_bytes_t payload;
     _z_encoding_t encoding;
 } _z_value_t;
-_z_value_t _z_value_null(void);
+static inline _z_value_t _z_value_null(void) {
+    return (_z_value_t){.payload = _z_bytes_null(), .encoding = _z_encoding_null()};
+}
+
 _z_value_t _z_value_steal(_z_value_t *value);
 z_result_t _z_value_copy(_z_value_t *dst, const _z_value_t *src);
 void _z_value_move(_z_value_t *dst, _z_value_t *src);
@@ -187,7 +190,10 @@ typedef struct {
 void _z_hello_clear(_z_hello_t *src);
 void _z_hello_free(_z_hello_t **hello);
 z_result_t _z_hello_copy(_z_hello_t *dst, const _z_hello_t *src);
-_z_hello_t _z_hello_null(void);
+static inline _z_hello_t _z_hello_null(void) {
+    return (_z_hello_t){._zid = _z_id_empty(), ._version = 0, ._whatami = 0x0, ._locators = _z_string_svec_make(0)};
+}
+
 bool _z_hello_check(const _z_hello_t *hello);
 
 _Z_ELEM_DEFINE(_z_hello, _z_hello_t, _z_noop_size, _z_hello_clear, _z_noop_copy)
@@ -202,7 +208,9 @@ typedef struct {
     uint32_t _entity_id;
     uint32_t _source_sn;
 } _z_source_info_t;
-_z_source_info_t _z_source_info_null(void);
+static inline _z_source_info_t _z_source_info_null(void) {
+    return (_z_source_info_t){._source_sn = 0, ._entity_id = 0, ._id = _z_id_empty()};
+}
 
 typedef struct {
     uint32_t _request_id;

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -67,7 +67,7 @@ typedef struct {
 } _z_timestamp_t;
 
 _z_timestamp_t _z_timestamp_duplicate(const _z_timestamp_t *tstamp);
-static inline _z_timestamp_t _z_timestamp_null(void) { return (_z_timestamp_t){.id = _z_id_empty(), .time = 0}; }
+static inline _z_timestamp_t _z_timestamp_null(void) { return (_z_timestamp_t){0}; }
 void _z_timestamp_clear(_z_timestamp_t *tstamp);
 bool _z_timestamp_check(const _z_timestamp_t *stamp);
 uint64_t _z_timestamp_ntp64_from_time(uint32_t seconds, uint32_t nanos);
@@ -163,9 +163,7 @@ typedef struct {
     _z_bytes_t payload;
     _z_encoding_t encoding;
 } _z_value_t;
-static inline _z_value_t _z_value_null(void) {
-    return (_z_value_t){.payload = _z_bytes_null(), .encoding = _z_encoding_null()};
-}
+static inline _z_value_t _z_value_null(void) { return (_z_value_t){0}; }
 
 _z_value_t _z_value_steal(_z_value_t *value);
 z_result_t _z_value_copy(_z_value_t *dst, const _z_value_t *src);
@@ -190,9 +188,7 @@ typedef struct {
 void _z_hello_clear(_z_hello_t *src);
 void _z_hello_free(_z_hello_t **hello);
 z_result_t _z_hello_copy(_z_hello_t *dst, const _z_hello_t *src);
-static inline _z_hello_t _z_hello_null(void) {
-    return (_z_hello_t){._zid = _z_id_empty(), ._version = 0, ._whatami = 0x0, ._locators = _z_string_svec_make(0)};
-}
+static inline _z_hello_t _z_hello_null(void) { return (_z_hello_t){0}; }
 
 bool _z_hello_check(const _z_hello_t *hello);
 
@@ -208,9 +204,7 @@ typedef struct {
     uint32_t _entity_id;
     uint32_t _source_sn;
 } _z_source_info_t;
-static inline _z_source_info_t _z_source_info_null(void) {
-    return (_z_source_info_t){._source_sn = 0, ._entity_id = 0, ._id = _z_id_empty()};
-}
+static inline _z_source_info_t _z_source_info_null(void) { return (_z_source_info_t){0}; }
 
 typedef struct {
     uint32_t _request_id;

--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -24,21 +24,25 @@ typedef struct {
     uint16_t _id;
     _z_keyexpr_t _keyexpr;
 } _z_decl_kexpr_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_decl_kexpr_t _z_decl_kexpr_null(void) { return (_z_decl_kexpr_t){0}; }
 typedef struct {
     uint16_t _id;
 } _z_undecl_kexpr_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_undecl_kexpr_t _z_undecl_kexpr_null(void) { return (_z_undecl_kexpr_t){0}; }
 
 typedef struct {
     _z_keyexpr_t _keyexpr;
     uint32_t _id;
 } _z_decl_subscriber_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_decl_subscriber_t _z_decl_subscriber_null(void) { return (_z_decl_subscriber_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_subscriber_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_undecl_subscriber_t _z_undecl_subscriber_null(void) { return (_z_undecl_subscriber_t){0}; }
 
 typedef struct {
@@ -49,27 +53,32 @@ typedef struct {
         uint16_t _distance;
     } _ext_queryable_info;
 } _z_decl_queryable_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_decl_queryable_t _z_decl_queryable_null(void) { return (_z_decl_queryable_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_queryable_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_undecl_queryable_t _z_undecl_queryable_null(void) { return (_z_undecl_queryable_t){0}; }
 
 typedef struct {
     _z_keyexpr_t _keyexpr;
     uint32_t _id;
 } _z_decl_token_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_decl_token_t _z_decl_token_null(void) { return (_z_decl_token_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_token_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_undecl_token_t _z_undecl_token_null(void) { return (_z_undecl_token_t){0}; }
 
 typedef struct {
     bool _placeholder;  // In case we add extensions
 } _z_decl_final_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_decl_final_t _z_decl_final_null(void) { return (_z_decl_final_t){0}; }
 
 typedef struct {

--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -24,22 +24,22 @@ typedef struct {
     uint16_t _id;
     _z_keyexpr_t _keyexpr;
 } _z_decl_kexpr_t;
-_z_decl_kexpr_t _z_decl_kexpr_null(void);
+static inline _z_decl_kexpr_t _z_decl_kexpr_null(void) { return (_z_decl_kexpr_t){0}; }
 typedef struct {
     uint16_t _id;
 } _z_undecl_kexpr_t;
-_z_undecl_kexpr_t _z_undecl_kexpr_null(void);
+static inline _z_undecl_kexpr_t _z_undecl_kexpr_null(void) { return (_z_undecl_kexpr_t){0}; }
 
 typedef struct {
     _z_keyexpr_t _keyexpr;
     uint32_t _id;
 } _z_decl_subscriber_t;
-_z_decl_subscriber_t _z_decl_subscriber_null(void);
+static inline _z_decl_subscriber_t _z_decl_subscriber_null(void) { return (_z_decl_subscriber_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_subscriber_t;
-_z_undecl_subscriber_t _z_undecl_subscriber_null(void);
+static inline _z_undecl_subscriber_t _z_undecl_subscriber_null(void) { return (_z_undecl_subscriber_t){0}; }
 
 typedef struct {
     _z_keyexpr_t _keyexpr;
@@ -49,28 +49,28 @@ typedef struct {
         uint16_t _distance;
     } _ext_queryable_info;
 } _z_decl_queryable_t;
-_z_decl_queryable_t _z_decl_queryable_null(void);
+static inline _z_decl_queryable_t _z_decl_queryable_null(void) { return (_z_decl_queryable_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_queryable_t;
-_z_undecl_queryable_t _z_undecl_queryable_null(void);
+static inline _z_undecl_queryable_t _z_undecl_queryable_null(void) { return (_z_undecl_queryable_t){0}; }
 
 typedef struct {
     _z_keyexpr_t _keyexpr;
     uint32_t _id;
 } _z_decl_token_t;
-_z_decl_token_t _z_decl_token_null(void);
+static inline _z_decl_token_t _z_decl_token_null(void) { return (_z_decl_token_t){0}; }
 typedef struct {
     uint32_t _id;
     _z_keyexpr_t _ext_keyexpr;
 } _z_undecl_token_t;
-_z_undecl_token_t _z_undecl_token_null(void);
+static inline _z_undecl_token_t _z_undecl_token_null(void) { return (_z_undecl_token_t){0}; }
 
 typedef struct {
     bool _placeholder;  // In case we add extensions
 } _z_decl_final_t;
-_z_decl_final_t _z_decl_final_null(void);
+static inline _z_decl_final_t _z_decl_final_null(void) { return (_z_decl_final_t){0}; }
 
 typedef struct {
     enum {

--- a/include/zenoh-pico/protocol/definitions/interest.h
+++ b/include/zenoh-pico/protocol/definitions/interest.h
@@ -36,9 +36,10 @@ typedef struct {
     uint32_t _id;
     uint8_t flags;
 } _z_interest_t;
+
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_interest_t _z_interest_null(void) { return (_z_interest_t){0}; }
 void _z_interest_clear(_z_interest_t* decl);
-
 _z_interest_t _z_make_interest(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint8_t flags);
 _z_interest_t _z_make_interest_final(uint32_t id);
 

--- a/include/zenoh-pico/protocol/definitions/interest.h
+++ b/include/zenoh-pico/protocol/definitions/interest.h
@@ -36,8 +36,7 @@ typedef struct {
     uint32_t _id;
     uint8_t flags;
 } _z_interest_t;
-_z_interest_t _z_interest_null(void);
-
+static inline _z_interest_t _z_interest_null(void) { return (_z_interest_t){0}; }
 void _z_interest_clear(_z_interest_t* decl);
 
 _z_interest_t _z_make_interest(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint8_t flags);

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -149,7 +149,12 @@ _z_n_msg_request_exts_t _z_n_msg_request_needed_exts(const _z_n_msg_request_t *m
 void _z_n_msg_request_clear(_z_n_msg_request_t *msg);
 
 typedef _z_reply_body_t _z_push_body_t;
-_z_push_body_t _z_push_body_null(void);
+static inline _z_push_body_t _z_push_body_null(void) {
+    return (_z_push_body_t){
+        ._is_put = false,
+        ._body._del._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()}};
+}
+
 _z_push_body_t _z_push_body_steal(_z_push_body_t *msg);
 void _z_push_body_clear(_z_push_body_t *msg);
 

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -149,6 +149,7 @@ _z_n_msg_request_exts_t _z_n_msg_request_needed_exts(const _z_n_msg_request_t *m
 void _z_n_msg_request_clear(_z_n_msg_request_t *msg);
 
 typedef _z_reply_body_t _z_push_body_t;
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_push_body_t _z_push_body_null(void) { return (_z_push_body_t){0}; }
 
 _z_push_body_t _z_push_body_steal(_z_push_body_t *msg);

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -149,11 +149,7 @@ _z_n_msg_request_exts_t _z_n_msg_request_needed_exts(const _z_n_msg_request_t *m
 void _z_n_msg_request_clear(_z_n_msg_request_t *msg);
 
 typedef _z_reply_body_t _z_push_body_t;
-static inline _z_push_body_t _z_push_body_null(void) {
-    return (_z_push_body_t){
-        ._is_put = false,
-        ._body._del._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()}};
-}
+static inline _z_push_body_t _z_push_body_null(void) { return (_z_push_body_t){0}; }
 
 _z_push_body_t _z_push_body_steal(_z_push_body_t *msg);
 void _z_push_body_clear(_z_push_body_t *msg);

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -29,8 +29,8 @@ bool _z_keyexpr_suffix_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *righ
 _z_keyexpr_t _z_keyexpr_from_string(uint16_t rid, _z_string_t *str);
 _z_keyexpr_t _z_keyexpr_from_substr(uint16_t rid, const char *str, size_t len);
 z_result_t _z_keyexpr_copy(_z_keyexpr_t *dst, const _z_keyexpr_t *src);
-_z_keyexpr_t _z_keyexpr_duplicate(_z_keyexpr_t src);
-_z_keyexpr_t _z_keyexpr_alias(_z_keyexpr_t src);
+_z_keyexpr_t _z_keyexpr_duplicate(const _z_keyexpr_t *src);
+_z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t *src);
 /// Returns either keyexpr defined by id + mapping with null suffix if try_declared is true and id is non-zero,
 /// or keyexpr defined by its suffix only, with 0 id and no mapping. This is to be used only when forwarding
 /// keyexpr in user api to properly separate declared keyexpr from its suffix.

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -26,17 +26,24 @@ bool _z_keyexpr_suffix_intersects(const _z_keyexpr_t *left, const _z_keyexpr_t *
 bool _z_keyexpr_suffix_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
 
 /*------------------ clone/Copy/Free helpers ------------------*/
+static inline _z_keyexpr_t _z_keyexpr_null(void) { return (_z_keyexpr_t){0}; }
+static inline _z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t src) {
+    return (_z_keyexpr_t){
+        ._id = src._id,
+        ._mapping = src._mapping,
+        ._suffix = _z_string_alias(src._suffix),
+    };
+}
+
 _z_keyexpr_t _z_keyexpr_from_string(uint16_t rid, _z_string_t *str);
 _z_keyexpr_t _z_keyexpr_from_substr(uint16_t rid, const char *str, size_t len);
 z_result_t _z_keyexpr_copy(_z_keyexpr_t *dst, const _z_keyexpr_t *src);
 _z_keyexpr_t _z_keyexpr_duplicate(const _z_keyexpr_t *src);
-_z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t *src);
 /// Returns either keyexpr defined by id + mapping with null suffix if try_declared is true and id is non-zero,
 /// or keyexpr defined by its suffix only, with 0 id and no mapping. This is to be used only when forwarding
 /// keyexpr in user api to properly separate declared keyexpr from its suffix.
 _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_declared);
 _z_keyexpr_t _z_keyexpr_steal(_Z_MOVE(_z_keyexpr_t) src);
-static inline _z_keyexpr_t _z_keyexpr_null(void) { return (_z_keyexpr_t){0}; }
 bool _z_keyexpr_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
 void _z_keyexpr_move(_z_keyexpr_t *dst, _z_keyexpr_t *src);
 void _z_keyexpr_clear(_z_keyexpr_t *rk);

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -26,6 +26,7 @@ bool _z_keyexpr_suffix_intersects(const _z_keyexpr_t *left, const _z_keyexpr_t *
 bool _z_keyexpr_suffix_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
 
 /*------------------ clone/Copy/Free helpers ------------------*/
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
 static inline _z_keyexpr_t _z_keyexpr_null(void) { return (_z_keyexpr_t){0}; }
 static inline _z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t src) {
     return (_z_keyexpr_t){

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -36,10 +36,7 @@ _z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t *src);
 /// keyexpr in user api to properly separate declared keyexpr from its suffix.
 _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_declared);
 _z_keyexpr_t _z_keyexpr_steal(_Z_MOVE(_z_keyexpr_t) src);
-static inline _z_keyexpr_t _z_keyexpr_null(void) {
-    _z_keyexpr_t keyexpr = {0, {0}, _z_string_null()};
-    return keyexpr;
-}
+static inline _z_keyexpr_t _z_keyexpr_null(void) { return (_z_keyexpr_t){0}; }
 bool _z_keyexpr_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
 void _z_keyexpr_move(_z_keyexpr_t *dst, _z_keyexpr_t *src);
 void _z_keyexpr_clear(_z_keyexpr_t *rk);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -64,7 +64,7 @@ _z_string_svec_t _z_string_array_null(void) { return _z_string_svec_make(0); }
 void z_string_array_new(z_owned_string_array_t *a) { a->_val = _z_string_array_null(); }
 
 size_t z_string_array_push_by_alias(z_loaned_string_array_t *a, const z_loaned_string_t *value) {
-    _z_string_t str = _z_string_alias(value);
+    _z_string_t str = _z_string_alias(*value);
     _z_string_svec_append(a, &str);
 
     return _z_string_svec_len(a);
@@ -130,7 +130,7 @@ void z_view_keyexpr_from_substr_unchecked(z_view_keyexpr_t *keyexpr, const char 
 }
 
 z_result_t z_keyexpr_as_view_string(const z_loaned_keyexpr_t *keyexpr, z_view_string_t *s) {
-    s->_val = _z_string_alias(&keyexpr->_suffix);
+    s->_val = _z_string_alias(keyexpr->_suffix);
     return _Z_RES_OK;
 }
 
@@ -1348,7 +1348,7 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     callback->_this._val.context = NULL;
 
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
-    _z_keyexpr_t key = _z_keyexpr_alias(&keyexpr_aliased);
+    _z_keyexpr_t key = _z_keyexpr_alias(keyexpr_aliased);
 
     // TODO: Currently, if resource declarations are done over multicast transports, the current protocol definition
     //       lacks a way to convey them to later-joining nodes. Thus, in the current version automatic
@@ -1357,7 +1357,7 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
         if (r == NULL) {
             bool do_keydecl = true;
-            _z_keyexpr_t resource_key = _z_keyexpr_alias(&keyexpr_aliased);
+            _z_keyexpr_t resource_key = _z_keyexpr_alias(keyexpr_aliased);
             // Remove wild
             char *wild = _z_string_pbrk(&keyexpr_aliased._suffix, "*$");
             if ((wild != NULL) && _z_keyexpr_has_suffix(&keyexpr_aliased)) {

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -829,11 +829,13 @@ z_result_t z_put(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr
                    reliability);
 
     // Trigger local subscriptions
+#if Z_FEATURE_LOCAL_SUBSCRIBER == 1
     _z_trigger_local_subscriptions(
         _Z_RC_IN_VAL(zs), keyexpr_aliased, _z_bytes_from_owned_bytes(&payload->_this),
         opt.encoding == NULL ? NULL : &opt.encoding->_this._val,
         _z_n_qos_make(opt.is_express, opt.congestion_control == Z_CONGESTION_CONTROL_BLOCK, opt.priority),
         opt.timestamp, _z_bytes_from_owned_bytes(&opt.attachment->_this), reliability);
+#endif
     // Clean-up
     z_encoding_drop(opt.encoding);
     z_bytes_drop(opt.attachment);
@@ -962,10 +964,12 @@ z_result_t z_publisher_put(const z_loaned_publisher_t *pub, z_moved_bytes_t *pay
                            _z_bytes_from_owned_bytes(&opt.attachment->_this), reliability);
         }
         // Trigger local subscriptions
+#if Z_FEATURE_LOCAL_SUBSCRIBER == 1
         _z_trigger_local_subscriptions(
             _Z_RC_IN_VAL(&sess_rc), pub_keyexpr, _z_bytes_from_owned_bytes(&payload->_this), &encoding,
             _z_n_qos_make(pub->_is_express, pub->_congestion_control == Z_CONGESTION_CONTROL_BLOCK, pub->_priority),
             opt.timestamp, _z_bytes_from_owned_bytes(&opt.attachment->_this), reliability);
+#endif
 
         _z_session_rc_drop(&sess_rc);
     } else {

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1344,7 +1344,7 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     callback->_this._val.context = NULL;
 
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
-    _z_keyexpr_t key = _z_keyexpr_alias(keyexpr_aliased);
+    _z_keyexpr_t key = _z_keyexpr_alias(&keyexpr_aliased);
 
     // TODO: Currently, if resource declarations are done over multicast transports, the current protocol definition
     //       lacks a way to convey them to later-joining nodes. Thus, in the current version automatic
@@ -1353,7 +1353,7 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
         if (r == NULL) {
             bool do_keydecl = true;
-            _z_keyexpr_t resource_key = _z_keyexpr_alias(keyexpr_aliased);
+            _z_keyexpr_t resource_key = _z_keyexpr_alias(&keyexpr_aliased);
             // Remove wild
             char *wild = _z_string_pbrk(&keyexpr_aliased._suffix, "*$");
             if ((wild != NULL) && _z_keyexpr_has_suffix(&keyexpr_aliased)) {

--- a/src/collections/bytes.c
+++ b/src/collections/bytes.c
@@ -27,12 +27,6 @@
 /*-------- Bytes --------*/
 bool _z_bytes_check(const _z_bytes_t *bytes) { return !_z_bytes_is_empty(bytes); }
 
-_z_bytes_t _z_bytes_null(void) {
-    _z_bytes_t b;
-    b._slices = _z_arc_slice_svec_make(0);
-    return b;
-}
-
 z_result_t _z_bytes_copy(_z_bytes_t *dst, const _z_bytes_t *src) {
     _z_arc_slice_svec_copy(&dst->_slices, &src->_slices);
     if (_z_arc_slice_svec_len(&dst->_slices) == _z_arc_slice_svec_len(&src->_slices)) {

--- a/src/collections/slice.c
+++ b/src/collections/slice.c
@@ -40,22 +40,15 @@ void _z_delete_context_delete(_z_delete_context_t *c, void *data) {
 
 /*-------- Slice --------*/
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity) {
-    z_result_t ret = _Z_RES_OK;
-
-    bs->start = capacity == 0 ? NULL : (uint8_t *)z_malloc(capacity);
-    if (bs->start != NULL) {
-        bs->len = capacity;
-        bs->_delete_context = _z_delete_context_default();
-    } else {
+    bs->start = (uint8_t *)z_malloc(capacity);
+    if (bs->start == NULL) {
         bs->len = 0;
         bs->_delete_context = _z_delete_context_null();
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }
-
-    if (bs->len != capacity) {
-        ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;
-    }
-
-    return ret;
+    bs->len = capacity;
+    bs->_delete_context = _z_delete_context_default();
+    return _Z_RES_OK;
 }
 
 _z_slice_t _z_slice_make(size_t capacity) {

--- a/src/collections/slice.c
+++ b/src/collections/slice.c
@@ -144,8 +144,6 @@ _z_slice_t _z_slice_duplicate(const _z_slice_t *src) {
     return dst;
 }
 
-bool _z_slice_is_empty(const _z_slice_t *bs) { return bs->len == 0; }
-
 _z_slice_t _z_slice_steal(_z_slice_t *b) {
     _z_slice_t ret = *b;
     *b = _z_slice_empty();

--- a/src/collections/slice.c
+++ b/src/collections/slice.c
@@ -28,13 +28,7 @@ void _z_default_deleter(void *data, void *context) {
     z_free(data);
 }
 
-_z_delete_context_t _z_delete_context_null(void) { return _z_delete_context_create(NULL, NULL); }
-
 bool _z_delete_context_is_null(const _z_delete_context_t *c) { return c->deleter == NULL; }
-
-_z_delete_context_t _z_delete_context_create(void (*deleter)(void *data, void *context), void *context) {
-    return (_z_delete_context_t){.deleter = deleter, .context = context};
-}
 
 _z_delete_context_t _z_delete_context_default(void) { return _z_delete_context_create(_z_default_deleter, NULL); }
 
@@ -45,10 +39,6 @@ void _z_delete_context_delete(_z_delete_context_t *c, void *data) {
 }
 
 /*-------- Slice --------*/
-_z_slice_t _z_slice_empty(void) {
-    return (_z_slice_t){.start = NULL, .len = 0, ._delete_context = _z_delete_context_null()};
-}
-
 z_result_t _z_slice_init(_z_slice_t *bs, size_t capacity) {
     z_result_t ret = _Z_RES_OK;
 

--- a/src/collections/slice.c
+++ b/src/collections/slice.c
@@ -65,11 +65,6 @@ _z_slice_t _z_slice_from_buf_custom_deleter(const uint8_t *p, size_t len, _z_del
     return bs;
 }
 
-_z_slice_t _z_slice_alias(const _z_slice_t *bs) {
-    _z_slice_t alias = {.len = bs->len, .start = bs->start, ._delete_context = _z_delete_context_null()};
-    return alias;
-}
-
 _z_slice_t _z_slice_alias_buf(const uint8_t *p, size_t len) {
     return _z_slice_from_buf_custom_deleter(p, len, _z_delete_context_null());
 }

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -79,11 +79,6 @@ _z_string_t _z_string_steal(_z_string_t *str) {
     return ret;
 }
 
-_z_string_t _z_string_alias(const _z_string_t *str) {
-    _z_string_t alias = {._slice = _z_slice_alias(&str->_slice)};
-    return alias;
-}
-
 void _z_string_move_str(_z_string_t *dst, char *src) { *dst = _z_string_alias_str(src); }
 
 void _z_string_reset(_z_string_t *str) { _z_slice_reset(&str->_slice); }

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -17,6 +17,7 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "zenoh-pico/utils/logging.h"
 #include "zenoh-pico/utils/pointers.h"
 
 /*-------- string --------*/
@@ -124,10 +125,10 @@ _z_string_t _z_string_convert_bytes(const _z_slice_t *bs) {
 }
 
 _z_string_t _z_string_preallocate(size_t len) {
-    _z_string_t s = _z_string_null();
-    _z_slice_init(&s._slice, len);
-    if (_z_slice_is_empty(&s._slice)) {
-        return _z_string_null();
+    _z_string_t s;
+    // As long as _z_string_t is only a slice, no need to do anything more
+    if (_z_slice_init(&s._slice, len) != _Z_RES_OK) {
+        _Z_ERROR("String allocation failed");
     }
     return s;
 }

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -20,8 +20,6 @@
 #include "zenoh-pico/utils/pointers.h"
 
 /*-------- string --------*/
-bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
-
 _z_string_t _z_string_copy_from_str(const char *value) {
     _z_string_t s;
     s._slice = _z_slice_copy_from_buf((uint8_t *)value, strlen(value));

--- a/src/collections/string.c
+++ b/src/collections/string.c
@@ -20,11 +20,6 @@
 #include "zenoh-pico/utils/pointers.h"
 
 /*-------- string --------*/
-_z_string_t _z_string_null(void) {
-    _z_string_t s = {._slice = _z_slice_empty()};
-    return s;
-}
-
 bool _z_string_check(const _z_string_t *value) { return !_z_slice_is_empty(&value->_slice); }
 
 _z_string_t _z_string_copy_from_str(const char *value) {

--- a/src/net/encoding.c
+++ b/src/net/encoding.c
@@ -19,6 +19,11 @@
 #include "zenoh-pico/utils/logging.h"
 #include "zenoh-pico/utils/result.h"
 
+_z_encoding_t _z_encoding_wrap(uint16_t id, const char *schema) {
+    return (_z_encoding_t){.id = id,
+                           .schema = (schema == NULL) ? _z_string_null() : _z_string_alias_str((char *)schema)};
+}
+
 z_result_t _z_encoding_make(_z_encoding_t *encoding, uint16_t id, const char *schema, size_t len) {
     encoding->id = id;
     // Clone schema
@@ -32,13 +37,6 @@ z_result_t _z_encoding_make(_z_encoding_t *encoding, uint16_t id, const char *sc
     }
     return _Z_RES_OK;
 }
-
-_z_encoding_t _z_encoding_wrap(uint16_t id, const char *schema) {
-    return (_z_encoding_t){.id = id,
-                           .schema = (schema == NULL) ? _z_string_null() : _z_string_alias_str((char *)schema)};
-}
-
-_z_encoding_t _z_encoding_null(void) { return _z_encoding_wrap(_Z_ENCODING_ID_DEFAULT, NULL); }
 
 void _z_encoding_clear(_z_encoding_t *encoding) { _z_string_clear(&encoding->schema); }
 

--- a/src/net/encoding.c
+++ b/src/net/encoding.c
@@ -40,10 +40,6 @@ z_result_t _z_encoding_make(_z_encoding_t *encoding, uint16_t id, const char *sc
 
 void _z_encoding_clear(_z_encoding_t *encoding) { _z_string_clear(&encoding->schema); }
 
-bool _z_encoding_check(const _z_encoding_t *encoding) {
-    return ((encoding->id != _Z_ENCODING_ID_DEFAULT) || _z_string_check(&encoding->schema));
-}
-
 z_result_t _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src) {
     *dst = _z_encoding_null();
     _Z_RETURN_IF_ERR(_z_string_copy(&dst->schema, &src->schema));

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -63,7 +63,7 @@ uint16_t _z_declare_resource(_z_session_t *zn, _z_keyexpr_t keyexpr) {
         uint16_t id = _z_register_resource(zn, keyexpr, 0, _Z_KEYEXPR_MAPPING_LOCAL);
         if (id != 0) {
             // Build the declare message to send on the wire
-            _z_keyexpr_t alias = _z_keyexpr_alias(&keyexpr);
+            _z_keyexpr_t alias = _z_keyexpr_alias(keyexpr);
             _z_declaration_t declaration = _z_make_decl_keyexpr(id, &alias);
             _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, false, 0);
             if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) == _Z_RES_OK) {
@@ -336,7 +336,7 @@ z_result_t _z_send_reply(const _z_query_t *query, const _z_session_rc_t *zsrc, _
     if (ret == _Z_RES_OK) {
         // Build the reply context decorator. This is NOT the final reply.
         _z_id_t zid = zn->_local_zid;
-        _z_keyexpr_t ke = _z_keyexpr_alias(&keyexpr);
+        _z_keyexpr_t ke = _z_keyexpr_alias(keyexpr);
         _z_zenoh_message_t z_msg;
         switch (kind) {
             case Z_SAMPLE_KIND_PUT:

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -63,7 +63,7 @@ uint16_t _z_declare_resource(_z_session_t *zn, _z_keyexpr_t keyexpr) {
         uint16_t id = _z_register_resource(zn, keyexpr, 0, _Z_KEYEXPR_MAPPING_LOCAL);
         if (id != 0) {
             // Build the declare message to send on the wire
-            _z_keyexpr_t alias = _z_keyexpr_alias(keyexpr);
+            _z_keyexpr_t alias = _z_keyexpr_alias(&keyexpr);
             _z_declaration_t declaration = _z_make_decl_keyexpr(id, &alias);
             _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, false, 0);
             if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) == _Z_RES_OK) {
@@ -108,7 +108,7 @@ _z_publisher_t _z_declare_publisher(const _z_session_rc_t *zn, _z_keyexpr_t keye
     // Allocate publisher
     _z_publisher_t ret;
     // Fill publisher
-    ret._key = _z_keyexpr_duplicate(keyexpr);
+    ret._key = _z_keyexpr_duplicate(&keyexpr);
     ret._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     ret._congestion_control = congestion_control;
     ret._priority = priority;
@@ -336,7 +336,7 @@ z_result_t _z_send_reply(const _z_query_t *query, const _z_session_rc_t *zsrc, _
     if (ret == _Z_RES_OK) {
         // Build the reply context decorator. This is NOT the final reply.
         _z_id_t zid = zn->_local_zid;
-        _z_keyexpr_t ke = _z_keyexpr_alias(keyexpr);
+        _z_keyexpr_t ke = _z_keyexpr_alias(&keyexpr);
         _z_zenoh_message_t z_msg;
         switch (kind) {
             case Z_SAMPLE_KIND_PUT:

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -35,6 +35,4 @@ void _z_publisher_free(_z_publisher_t **pub) {
     }
 }
 
-bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
-
 #endif

--- a/src/net/publish.c
+++ b/src/net/publish.c
@@ -36,16 +36,5 @@ void _z_publisher_free(_z_publisher_t **pub) {
 }
 
 bool _z_publisher_check(const _z_publisher_t *publisher) { return !_Z_RC_IS_NULL(&publisher->_zn); }
-_z_publisher_t _z_publisher_null(void) {
-    return (_z_publisher_t){._congestion_control = Z_CONGESTION_CONTROL_DEFAULT,
-                            ._id = 0,
-                            ._key = _z_keyexpr_null(),
-                            ._priority = Z_PRIORITY_DEFAULT,
-                            ._zn = _z_session_weak_null(),
-                            ._encoding = _z_encoding_null(),
-#if Z_FEATURE_INTEREST == 1
-                            ._filter = (_z_write_filter_t){._interest_id = 0, .ctx = NULL}
-#endif
-    };
-}
+
 #endif

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -87,8 +87,6 @@ _z_query_t _z_query_create(_z_value_t *value, _z_keyexpr_t *key, const _z_slice_
     return q;
 }
 
-bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
-
 void _z_queryable_clear(_z_queryable_t *qbl) {
     _z_session_weak_drop(&qbl->_zn);
     *qbl = _z_queryable_null();

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -16,18 +16,6 @@
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
-_z_query_t _z_query_null(void) {
-    return (_z_query_t){
-        ._anyke = false,
-        ._key = _z_keyexpr_null(),
-        ._parameters = NULL,
-        ._request_id = 0,
-        ._value = _z_value_null(),
-        .attachment = _z_bytes_null(),
-        ._zn = _z_session_weak_null(),
-    };
-}
-
 void _z_query_clear_inner(_z_query_t *q) {
     _z_keyexpr_clear(&q->_key);
     _z_value_clear(&q->_value);
@@ -98,8 +86,6 @@ _z_query_t _z_query_create(_z_value_t *value, _z_keyexpr_t *key, const _z_slice_
     _z_value_move(&q._value, value);
     return q;
 }
-
-_z_queryable_t _z_queryable_null(void) { return (_z_queryable_t){._entity_id = 0, ._zn = _z_session_weak_null()}; }
 
 bool _z_queryable_check(const _z_queryable_t *queryable) { return !_Z_RC_IS_NULL(&queryable->_zn); }
 

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -40,13 +40,13 @@ void _z_reply_data_free(_z_reply_data_t **reply_data) {
 
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src) {
     *dst = _z_reply_data_null();
+    dst->_tag = src->_tag;
     if (src->_tag == _Z_REPLY_TAG_DATA) {
         _Z_RETURN_IF_ERR(_z_sample_copy(&dst->_result.sample, &src->_result.sample));
     } else if (src->_tag == _Z_REPLY_TAG_ERROR) {
         _Z_RETURN_IF_ERR(_z_value_copy(&dst->_result.error, &src->_result.error));
     }
     dst->replier_id = src->replier_id;
-    dst->_tag = src->_tag;
     return _Z_RES_OK;
 }
 

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -39,13 +39,13 @@ void _z_reply_data_free(_z_reply_data_t **reply_data) {
 }
 
 z_result_t _z_reply_data_copy(_z_reply_data_t *dst, const _z_reply_data_t *src) {
-    *dst = _z_reply_data_null();
-    dst->_tag = src->_tag;
+    *dst = _z_reply_data_init();
     if (src->_tag == _Z_REPLY_TAG_DATA) {
         _Z_RETURN_IF_ERR(_z_sample_copy(&dst->_result.sample, &src->_result.sample));
     } else if (src->_tag == _Z_REPLY_TAG_ERROR) {
         _Z_RETURN_IF_ERR(_z_value_copy(&dst->_result.error, &src->_result.error));
     }
+    dst->_tag = src->_tag;
     dst->replier_id = src->replier_id;
     return _Z_RES_OK;
 }

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -17,15 +17,6 @@
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
-_z_reply_data_t _z_reply_data_null(void) {
-    return (_z_reply_data_t){.replier_id = {.id = {0}}, ._result.sample = _z_sample_null(), ._tag = _Z_REPLY_TAG_NONE};
-}
-
-_z_reply_t _z_reply_null(void) {
-    _z_reply_t r = {.data = _z_reply_data_null()};
-    return r;
-}
-
 #if Z_FEATURE_QUERY == 1
 void _z_reply_data_clear(_z_reply_data_t *reply_data) {
     if (reply_data->_tag == _Z_REPLY_TAG_DATA) {

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -16,19 +16,6 @@
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
-_z_sample_t _z_sample_null(void) {
-    _z_sample_t s = {
-        .keyexpr = _z_keyexpr_null(),
-        .payload = _z_bytes_null(),
-        .encoding = _z_encoding_null(),
-        .timestamp = _z_timestamp_null(),
-        .kind = 0,
-        .qos = {0},
-        .attachment = _z_bytes_null(),
-    };
-    return s;
-}
-
 bool _z_sample_check(const _z_sample_t *sample) {
     return _z_keyexpr_check(&sample->keyexpr) || _z_bytes_check(&sample->payload) ||
            _z_bytes_check(&sample->attachment) || _z_encoding_check(&sample->encoding);

--- a/src/net/sample.c
+++ b/src/net/sample.c
@@ -16,11 +16,6 @@
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
-bool _z_sample_check(const _z_sample_t *sample) {
-    return _z_keyexpr_check(&sample->keyexpr) || _z_bytes_check(&sample->payload) ||
-           _z_bytes_check(&sample->attachment) || _z_encoding_check(&sample->encoding);
-}
-
 void _z_sample_move(_z_sample_t *dst, _z_sample_t *src) {
     _z_keyexpr_move(&dst->keyexpr, &src->keyexpr);
     _z_bytes_move(&dst->payload, &src->payload);

--- a/src/net/subscribe.c
+++ b/src/net/subscribe.c
@@ -32,6 +32,5 @@ void _z_subscriber_free(_z_subscriber_t **sub) {
 }
 
 bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
-_z_subscriber_t _z_subscriber_null(void) { return (_z_subscriber_t){._entity_id = 0, ._zn = _z_session_weak_null()}; }
 
 #endif

--- a/src/net/subscribe.c
+++ b/src/net/subscribe.c
@@ -31,6 +31,4 @@ void _z_subscriber_free(_z_subscriber_t **sub) {
     }
 }
 
-bool _z_subscriber_check(const _z_subscriber_t *subscriber) { return !_Z_RC_IS_NULL(&subscriber->_zn); }
-
 #endif

--- a/src/protocol/core.c
+++ b/src/protocol/core.c
@@ -66,11 +66,6 @@ _z_id_t _z_id_empty(void) {
                      }};
 }
 
-_z_source_info_t _z_source_info_null(void) {
-    return (_z_source_info_t){._source_sn = 0, ._entity_id = 0, ._id = _z_id_empty()};
-}
-_z_timestamp_t _z_timestamp_null(void) { return (_z_timestamp_t){.id = _z_id_empty(), .time = 0}; }
-
 uint64_t _z_timestamp_ntp64_from_time(uint32_t seconds, uint32_t nanos) {
     const uint64_t FRAC_PER_SEC = (uint64_t)1 << 32;
     const uint64_t NANOS_PER_SEC = 1000000000;
@@ -79,7 +74,6 @@ uint64_t _z_timestamp_ntp64_from_time(uint32_t seconds, uint32_t nanos) {
     return ((uint64_t)seconds << 32) | fractions;
 }
 
-_z_value_t _z_value_null(void) { return (_z_value_t){.payload = _z_bytes_null(), .encoding = _z_encoding_null()}; }
 _z_value_t _z_value_steal(_z_value_t *value) {
     _z_value_t ret = *value;
     *value = _z_value_null();
@@ -99,10 +93,6 @@ z_result_t _z_hello_copy(_z_hello_t *dst, const _z_hello_t *src) {
     dst->_whatami = src->_whatami;
     memcpy(&dst->_zid.id, &src->_zid.id, _Z_ID_LEN);
     return _Z_RES_OK;
-}
-
-_z_hello_t _z_hello_null(void) {
-    return (_z_hello_t){._zid = _z_id_empty(), ._version = 0, ._whatami = 0x0, ._locators = _z_string_svec_make(0)};
 }
 
 void _z_value_move(_z_value_t *dst, _z_value_t *src) {

--- a/src/protocol/definitions/declarations.c
+++ b/src/protocol/definitions/declarations.c
@@ -71,7 +71,7 @@ _z_declaration_t _z_make_undecl_subscriber(uint32_t id, _Z_OPTIONAL const _z_key
     return (_z_declaration_t){
         ._tag = _Z_UNDECL_SUBSCRIBER,
         ._body = {._undecl_subscriber = {
-                      ._id = id, ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(*key)}}};
+                      ._id = id, ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(key)}}};
 }
 
 _z_declaration_t _z_make_decl_queryable(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, bool complete, uint16_t distance) {
@@ -85,7 +85,7 @@ _z_declaration_t _z_make_undecl_queryable(uint32_t id, _Z_OPTIONAL const _z_keye
     return (_z_declaration_t){
         ._tag = _Z_UNDECL_QUERYABLE,
         ._body = {._undecl_queryable = {
-                      ._id = id, ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(*key)}}};
+                      ._id = id, ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(key)}}};
 }
 _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id) {
     return (_z_declaration_t){._tag = _Z_DECL_TOKEN,
@@ -98,7 +98,7 @@ _z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL const _z_keyexpr_
     return (_z_declaration_t){
         ._tag = _Z_UNDECL_TOKEN,
         ._body = {._undecl_token = {._id = id,
-                                    ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(*key)}}};
+                                    ._ext_keyexpr = (key == NULL) ? _z_keyexpr_null() : _z_keyexpr_duplicate(key)}}};
 }
 _z_declaration_t _z_make_decl_final(void) {
     return (_z_declaration_t){._tag = _Z_DECL_FINAL, ._body = {._decl_final = {0}}};

--- a/src/protocol/definitions/declarations.c
+++ b/src/protocol/definitions/declarations.c
@@ -104,16 +104,6 @@ _z_declaration_t _z_make_decl_final(void) {
     return (_z_declaration_t){._tag = _Z_DECL_FINAL, ._body = {._decl_final = {0}}};
 }
 
-_z_decl_kexpr_t _z_decl_kexpr_null(void) { return (_z_decl_kexpr_t){0}; }
-_z_decl_subscriber_t _z_decl_subscriber_null(void) { return (_z_decl_subscriber_t){0}; }
-_z_decl_queryable_t _z_decl_queryable_null(void) { return (_z_decl_queryable_t){0}; }
-_z_decl_token_t _z_decl_token_null(void) { return (_z_decl_token_t){0}; }
-_z_undecl_kexpr_t _z_undecl_kexpr_null(void) { return (_z_undecl_kexpr_t){0}; }
-_z_undecl_subscriber_t _z_undecl_subscriber_null(void) { return (_z_undecl_subscriber_t){0}; }
-_z_undecl_queryable_t _z_undecl_queryable_null(void) { return (_z_undecl_queryable_t){0}; }
-_z_undecl_token_t _z_undecl_token_null(void) { return (_z_undecl_token_t){0}; }
-_z_decl_final_t _z_decl_final_null(void) { return (_z_decl_final_t){0}; }
-
 void _z_decl_fix_mapping(_z_declaration_t *msg, uint16_t mapping) {
     switch (msg->_tag) {
         case _Z_DECL_KEXPR: {

--- a/src/protocol/definitions/interest.c
+++ b/src/protocol/definitions/interest.c
@@ -33,5 +33,3 @@ _z_interest_t _z_make_interest_final(uint32_t id) {
         .flags = 0,
     };
 }
-
-_z_interest_t _z_interest_null(void) { return (_z_interest_t){0}; }

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -72,11 +72,6 @@ _z_push_body_t _z_push_body_steal(_z_push_body_t *msg) {
     *msg = _z_push_body_null();
     return ret;
 }
-_z_push_body_t _z_push_body_null(void) {
-    return (_z_push_body_t){
-        ._is_put = false,
-        ._body._del._commons = {._timestamp = _z_timestamp_null(), ._source_info = _z_source_info_null()}};
-}
 
 void _z_n_msg_response_final_clear(_z_n_msg_response_final_t *msg) { (void)(msg); }
 

--- a/src/protocol/keyexpr.c
+++ b/src/protocol/keyexpr.c
@@ -36,7 +36,7 @@ _z_keyexpr_t _z_keyexpr_from_string(uint16_t rid, _z_string_t *str) {
     return (_z_keyexpr_t){
         ._id = rid,
         ._mapping = _z_keyexpr_mapping(_Z_KEYEXPR_MAPPING_LOCAL),
-        ._suffix = (_z_string_check(str)) ? _z_string_alias(str) : _z_string_null(),
+        ._suffix = (_z_string_check(str)) ? _z_string_alias(*str) : _z_string_null(),
     };
 }
 
@@ -104,15 +104,6 @@ bool _z_keyexpr_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right) {
         return false;
     }
     return _z_string_equals(&left->_suffix, &right->_suffix);
-}
-
-_z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t *src) {
-    _z_keyexpr_t alias = {
-        ._id = src->_id,
-        ._mapping = src->_mapping,
-        ._suffix = _z_string_alias(&src->_suffix),
-    };
-    return alias;
 }
 
 _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_declared) {

--- a/src/protocol/keyexpr.c
+++ b/src/protocol/keyexpr.c
@@ -59,9 +59,9 @@ z_result_t _z_keyexpr_copy(_z_keyexpr_t *dst, const _z_keyexpr_t *src) {
     return _Z_RES_OK;
 }
 
-_z_keyexpr_t _z_keyexpr_duplicate(_z_keyexpr_t src) {
+_z_keyexpr_t _z_keyexpr_duplicate(const _z_keyexpr_t *src) {
     _z_keyexpr_t dst;
-    _z_keyexpr_copy(&dst, &src);
+    _z_keyexpr_copy(&dst, src);
     return dst;
 }
 
@@ -106,11 +106,11 @@ bool _z_keyexpr_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right) {
     return _z_string_equals(&left->_suffix, &right->_suffix);
 }
 
-_z_keyexpr_t _z_keyexpr_alias(_z_keyexpr_t src) {
+_z_keyexpr_t _z_keyexpr_alias(const _z_keyexpr_t *src) {
     _z_keyexpr_t alias = {
-        ._id = src._id,
-        ._mapping = src._mapping,
-        ._suffix = _z_string_alias(&src._suffix),
+        ._id = src->_id,
+        ._mapping = src->_mapping,
+        ._suffix = _z_string_alias(&src->_suffix),
     };
     return alias;
 }

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -101,7 +101,7 @@ static z_result_t _z_interest_send_decl_resource(_z_session_t *zn, uint32_t inte
     while (xs != NULL) {
         _z_resource_t *res = _z_resource_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(&res->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(res->_key);
         _z_declaration_t declaration = _z_make_decl_keyexpr(res->_id, &key);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
@@ -123,7 +123,7 @@ static z_result_t _z_interest_send_decl_subscriber(_z_session_t *zn, uint32_t in
     while (xs != NULL) {
         _z_subscription_rc_t *sub = _z_subscription_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(sub)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(_Z_RC_IN_VAL(sub)->_key);
         _z_declaration_t declaration = _z_make_decl_subscriber(&key, _Z_RC_IN_VAL(sub)->_id);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
@@ -152,7 +152,7 @@ static z_result_t _z_interest_send_decl_queryable(_z_session_t *zn, uint32_t int
     while (xs != NULL) {
         _z_session_queryable_rc_t *qle = _z_session_queryable_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(qle)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(_Z_RC_IN_VAL(qle)->_key);
         _z_declaration_t declaration = _z_make_decl_queryable(
             &key, _Z_RC_IN_VAL(qle)->_id, _Z_RC_IN_VAL(qle)->_complete, _Z_QUERYABLE_DISTANCE_DEFAULT);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -101,7 +101,7 @@ static z_result_t _z_interest_send_decl_resource(_z_session_t *zn, uint32_t inte
     while (xs != NULL) {
         _z_resource_t *res = _z_resource_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(res->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(&res->_key);
         _z_declaration_t declaration = _z_make_decl_keyexpr(res->_id, &key);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
@@ -123,7 +123,7 @@ static z_result_t _z_interest_send_decl_subscriber(_z_session_t *zn, uint32_t in
     while (xs != NULL) {
         _z_subscription_rc_t *sub = _z_subscription_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(_Z_RC_IN_VAL(sub)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(sub)->_key);
         _z_declaration_t declaration = _z_make_decl_subscriber(&key, _Z_RC_IN_VAL(sub)->_id);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
@@ -152,7 +152,7 @@ static z_result_t _z_interest_send_decl_queryable(_z_session_t *zn, uint32_t int
     while (xs != NULL) {
         _z_session_queryable_rc_t *qle = _z_session_queryable_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(_Z_RC_IN_VAL(qle)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(qle)->_key);
         _z_declaration_t declaration = _z_make_decl_queryable(
             &key, _Z_RC_IN_VAL(qle)->_id, _Z_RC_IN_VAL(qle)->_complete, _Z_QUERYABLE_DISTANCE_DEFAULT);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
@@ -228,7 +228,7 @@ static _z_keyexpr_t _unsafe_z_get_key_from_declare(_z_session_t *zn, uint32_t id
     while (xs != NULL) {
         _z_declare_data_t *decl = _z_declare_data_list_head(xs);
         if (_z_declare_data_eq(&comp, decl)) {
-            return _z_keyexpr_duplicate(decl->_key);
+            return _z_keyexpr_duplicate(&decl->_key);
         }
         xs = _z_declare_data_list_tail(xs);
     }

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -148,7 +148,7 @@ z_result_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, 
                     (void)memset(&partial_reply, 0,
                                  sizeof(_z_reply_t));  // Avoid warnings on uninitialized values on the reply
                     partial_reply.data._tag = _Z_REPLY_TAG_DATA;
-                    partial_reply.data._result.sample.keyexpr = _z_keyexpr_duplicate(reply.data._result.sample.keyexpr);
+                    partial_reply.data._result.sample.keyexpr = _z_keyexpr_duplicate(&reply.data._result.sample.keyexpr);
                     pen_rep->_reply = partial_reply;
                 } else {
                     pen_rep->_reply = reply;  // Store the whole reply in the latest mode

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -148,7 +148,8 @@ z_result_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, 
                     (void)memset(&partial_reply, 0,
                                  sizeof(_z_reply_t));  // Avoid warnings on uninitialized values on the reply
                     partial_reply.data._tag = _Z_REPLY_TAG_DATA;
-                    partial_reply.data._result.sample.keyexpr = _z_keyexpr_duplicate(&reply.data._result.sample.keyexpr);
+                    partial_reply.data._result.sample.keyexpr =
+                        _z_keyexpr_duplicate(&reply.data._result.sample.keyexpr);
                     pen_rep->_reply = partial_reply;
                 } else {
                     pen_rep->_reply = reply;  // Store the whole reply in the latest mode

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -139,7 +139,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
             }
         }
     }
-    // Warning: list must be release with _z_list_free(&strs, _z_noop_free) or will release the suffix as well
+    // Warning: list must be released with _z_list_free(&strs, _z_noop_free) or will release the suffix as well
     _z_list_free(&strs, _z_noop_free);
     return ret;
 }

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -205,7 +205,6 @@ _z_keyexpr_t _z_get_expanded_key_from_key(_z_session_t *zn, const _z_keyexpr_t *
 /// Returns the ID of the registered keyexpr. Returns 0 if registration failed.
 uint16_t _z_register_resource(_z_session_t *zn, _z_keyexpr_t key, uint16_t id, uint16_t register_to_mapping) {
     uint16_t ret = Z_RESOURCE_ID_NONE;
-    key = _z_keyexpr_alias(key);
     uint16_t mapping = register_to_mapping;
     uint16_t parent_mapping = _z_keyexpr_mapping_id(&key);
 
@@ -226,7 +225,7 @@ uint16_t _z_register_resource(_z_session_t *zn, _z_keyexpr_t key, uint16_t id, u
             ret = Z_RESOURCE_ID_NONE;
         } else {
             res->_refcount = 1;
-            res->_key = _z_keyexpr_duplicate(key);
+            res->_key = _z_keyexpr_duplicate(&key);
             ret = id == Z_RESOURCE_ID_NONE ? _z_get_resource_id(zn) : id;
             res->_id = ret;
             // Register the resource

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -88,10 +88,19 @@ _z_resource_t *__z_get_resource_by_key(_z_resource_list_t *rl, const _z_keyexpr_
 }
 
 _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keyexpr_t *keyexpr) {
-    _z_keyexpr_t ret = {._id = Z_RESOURCE_ID_NONE, ._suffix = _z_string_null(), ._mapping = _z_keyexpr_mapping(0)};
+    _z_zint_t id = keyexpr->_id;
+
+    // Check if ke is already expanded
+    if (id == Z_RESOURCE_ID_NONE) {
+        if (!_z_keyexpr_has_suffix(keyexpr)) {
+            return _z_keyexpr_null();
+        }
+        return _z_keyexpr_duplicate(keyexpr);
+    }
 
     // Need to build the complete resource name, by recursively look at RIDs
     // Resource names are looked up from right to left
+    _z_keyexpr_t ret = _z_keyexpr_null();
     _z_string_list_t *strs = NULL;
     size_t len = 0;
 
@@ -100,9 +109,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
         len = len + _z_string_len(&keyexpr->_suffix);
         strs = _z_string_list_push(strs, (_z_string_t *)&keyexpr->_suffix);
     }
-
     // Recursively go through all the RIDs
-    _z_zint_t id = keyexpr->_id;
     uint16_t mapping = _z_keyexpr_mapping_id(keyexpr);
     while (id != Z_RESOURCE_ID_NONE) {
         _z_resource_t *res = __z_get_resource_by_id(xs, mapping, id);

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -98,9 +98,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
     // Append suffix as the right-most segment
     if (_z_keyexpr_has_suffix(keyexpr)) {
         len = len + _z_string_len(&keyexpr->_suffix);
-        strs = _z_string_list_push(strs, (_z_string_t *)&keyexpr->_suffix);  // Warning: list must be release with
-                                                                             //   _z_list_free(&strs, _z_noop_free);
-                                                                             //   or will release the suffix as well
+        strs = _z_string_list_push(strs, (_z_string_t *)&keyexpr->_suffix);
     }
 
     // Recursively go through all the RIDs
@@ -114,9 +112,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
         }
         if (_z_keyexpr_has_suffix(&res->_key)) {
             len = len + _z_string_len(&res->_key._suffix);
-            strs = _z_string_list_push(strs, &res->_key._suffix);  // Warning: list must be release with
-                                                                   //   _z_list_free(&strs, _z_noop_free);
-                                                                   //   or will release the suffix as well
+            strs = _z_string_list_push(strs, &res->_key._suffix);
         }
         id = res->_key._id;
     }
@@ -136,6 +132,7 @@ _z_keyexpr_t __z_get_expanded_key_from_key(_z_resource_list_t *xs, const _z_keye
             }
         }
     }
+    // Warning: list must be release with _z_list_free(&strs, _z_noop_free) or will release the suffix as well
     _z_list_free(&strs, _z_noop_free);
     return ret;
 }

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -160,7 +160,7 @@ z_result_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr
     if (_z_keyexpr_has_suffix(&key)) {
         _z_subscription_rc_list_t *subs = __unsafe_z_get_subscriptions_by_key(zn, _Z_RESOURCE_IS_LOCAL, &key);
         _zp_session_unlock_mutex(zn);
-        
+
         // Check if there is subs
         size_t sub_nb = _z_subscription_rc_list_len(subs);
         if (sub_nb == 0) {

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -159,14 +159,18 @@ z_result_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr
     _Z_DEBUG("Triggering subs for %d - %.*s", key._id, (int)_z_string_len(&key._suffix), _z_string_data(&key._suffix));
     if (_z_keyexpr_has_suffix(&key)) {
         _z_subscription_rc_list_t *subs = __unsafe_z_get_subscriptions_by_key(zn, _Z_RESOURCE_IS_LOCAL, &key);
-
         _zp_session_unlock_mutex(zn);
-
+        
+        // Check if there is subs
+        size_t sub_nb = _z_subscription_rc_list_len(subs);
+        if (sub_nb == 0) {
+            return _Z_RES_OK;
+        }
         // Build the sample
         _z_sample_t sample = _z_sample_create(&key, payload, timestamp, encoding, kind, qos, attachment, reliability);
         // Parse subscription list
         _z_subscription_rc_list_t *xs = subs;
-        _Z_DEBUG("Triggering %ju subs", (uintmax_t)_z_subscription_rc_list_len(xs));
+        _Z_DEBUG("Triggering %ju subs", (uintmax_t)sub_nb);
         while (xs != NULL) {
             _z_subscription_rc_t *sub = _z_subscription_rc_list_head(xs);
             _Z_RC_IN_VAL(sub)->_callback(&sample, _Z_RC_IN_VAL(sub)->_arg);


### PR DESCRIPTION
There is a small performance dip in non-fragment peer throughput compared with 0.11. Profiling helped identify a much longer time spent in `trigger_local_subscriber`and this PR aims to fix this.

* Static inline functions:
Functions that should have been inlined by the compiler (like `z_sample_null`) weren't. This is solved by explicitly setting all the `_null`, `_check` and `_alias` functions to `static inline`.

* Null functions:
A lot of time was spent initializing types to 0 compared to just using `memset(0)`, switching all the `_null` functions to a `{0}` initialization closed this gap and is less prone to error.

* Slice init / string preallocate:
This functions had many superfluous checks / init. They got simplified.

* get_expanded_key_by_key:
Added a shorter path for already expanded keys.

* trigger_local_subcriber:
Added a shorter path when there is 0 subscribers to trigger.
Added a config token, `off` by default, to execute this function.

*The fastest code is the one we don't execute*

