### PR TITLE
API alignment

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1027,8 +1027,8 @@ Option Types
 
 Functions
 ---------
-.. autocfunction:: primitives.h::z_queryable_declare
-.. autocfunction:: primitives.h::z_queryable_declare_background
+.. autocfunction:: primitives.h::z_declare_queryable
+.. autocfunction:: primitives.h::z_declare_background_queryable
 
 .. autocfunction:: primitives.h::z_queryable_options_default
 .. autocfunction:: primitives.h::z_query_reply_options_default

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -982,8 +982,8 @@ Option Types
 Functions
 ---------
 
-.. autocfunction:: primitives.h::z_subscriber_declare
-.. autocfunction:: primitives.h::z_subscriber_declare_background
+.. autocfunction:: primitives.h::z_declare_subscriber
+.. autocfunction:: primitives.h::z_declare_background_subscriber
 
 .. autocfunction:: primitives.h::z_subscriber_options_default
 .. autocfunction:: primitives.h::z_subscriber_keyexpr

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -941,6 +941,7 @@ Functions
 .. autocfunction:: primitives.h::z_delete
 
 .. autocfunction:: primitives.h::z_declare_publisher
+.. autocfunction:: primitives.h::z_undeclare_publisher
 .. autocfunction:: primitives.h::z_publisher_put
 .. autocfunction:: primitives.h::z_publisher_delete
 .. autocfunction:: primitives.h::z_publisher_keyexpr
@@ -983,6 +984,7 @@ Functions
 ---------
 
 .. autocfunction:: primitives.h::z_declare_subscriber
+.. autocfunction:: primitives.h::z_undeclare_subscriber
 .. autocfunction:: primitives.h::z_declare_background_subscriber
 
 .. autocfunction:: primitives.h::z_subscriber_options_default
@@ -1028,6 +1030,7 @@ Option Types
 Functions
 ---------
 .. autocfunction:: primitives.h::z_declare_queryable
+.. autocfunction:: primitives.h::z_undeclare_queryable
 .. autocfunction:: primitives.h::z_declare_background_queryable
 
 .. autocfunction:: primitives.h::z_queryable_options_default

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -940,7 +940,7 @@ Functions
 .. autocfunction:: primitives.h::z_put
 .. autocfunction:: primitives.h::z_delete
 
-.. autocfunction:: primitives.h::z_publisher_declare
+.. autocfunction:: primitives.h::z_declare_publisher
 .. autocfunction:: primitives.h::z_publisher_put
 .. autocfunction:: primitives.h::z_publisher_delete
 .. autocfunction:: primitives.h::z_publisher_keyexpr

--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -84,7 +84,7 @@ void setup() {
     Serial.println("...");
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&s), &pub, z_view_keyexpr_loan(&ke), NULL) < 0) {
         Serial.println("Unable to declare publisher for key expression!");
         while (1) {
             ;

--- a/examples/arduino/z_pull.ino
+++ b/examples/arduino/z_pull.ino
@@ -84,7 +84,7 @@ void setup() {
     z_ring_channel_sample_new(&closure, &handler, SIZE);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         Serial.println("Unable to declare subscriber.");
         return;

--- a/examples/arduino/z_queryable.ino
+++ b/examples/arduino/z_queryable.ino
@@ -112,7 +112,7 @@ void setup() {
     z_closure_query(&callback, query_handler, NULL, NULL);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_declare_queryable(z_session_loan(&s), &qable, z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         Serial.println("Unable to declare queryable.");
         while (1) {

--- a/examples/arduino/z_sub.ino
+++ b/examples/arduino/z_sub.ino
@@ -99,7 +99,7 @@ void setup() {
     z_closure_sample(&callback, data_handler, NULL, NULL);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         Serial.println("Unable to declare subscriber.");
         while (1) {

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -143,7 +143,7 @@ void app_main() {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/espidf/z_pull.c
+++ b/examples/espidf/z_pull.c
@@ -151,7 +151,7 @@ void app_main() {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -173,7 +173,7 @@ void app_main() {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);
     }

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -155,7 +155,7 @@ void app_main() {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/freertos_plus_tcp/z_pub.c
+++ b/examples/freertos_plus_tcp/z_pub.c
@@ -86,7 +86,7 @@ void app_main(void) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -51,7 +51,7 @@ void app_main(void) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_pull.c
+++ b/examples/freertos_plus_tcp/z_pull.c
@@ -60,7 +60,7 @@ void app_main(void) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_put.c
+++ b/examples/freertos_plus_tcp/z_put.c
@@ -55,7 +55,7 @@ void app_main(void) {
     z_owned_keyexpr_t ke;
     z_view_keyexpr_t vke;
     z_view_keyexpr_from_str_unchecked(&vke, KEYEXPR);
-    if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
+    if (z_declare_keyexpr(z_loan(s), &ke, z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
         z_drop(z_move(s));
         return;
@@ -78,7 +78,7 @@ void app_main(void) {
     }
 
     // Clean up
-    z_undeclare_keyexpr(z_move(ke), z_loan(s));
+    z_undeclare_keyexpr(z_loan(s), z_move(ke));
     z_drop(z_move(s));
 }
 #else

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -87,7 +87,7 @@ void app_main(void) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -67,7 +67,7 @@ void app_main(void) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -64,7 +64,7 @@ void app_main(void) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return;
     }

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&s), &pub, z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/mbed/z_pull.cpp
+++ b/examples/mbed/z_pull.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/mbed/z_queryable.cpp
+++ b/examples/mbed/z_queryable.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_declare_queryable(z_session_loan(&s), &qable, z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);

--- a/examples/mbed/z_sub.cpp
+++ b/examples/mbed/z_sub.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(session), &sub, z_loan(pong), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
 
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
+    if (z_declare_publisher(z_loan(session), &pub, z_loan(ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
-    if (z_subscriber_declare_background(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
+    if (z_declare_publisher(z_loan(session), &pub, z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_put.c
+++ b/examples/unix/c11/z_put.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t vke;
     z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
-    if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
+    if (z_declare_keyexpr(z_loan(s), &ke, z_loan(vke)) < 0) {
         z_drop(z_move(s));
         return -1;
     }
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
         printf("Oh no! Put has failed...\n");
     }
     // Clean up
-    z_undeclare_keyexpr(z_move(ke), z_loan(s));
+    z_undeclare_keyexpr(z_loan(s), z_move(ke));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     z_owned_ring_handler_query_t handler;
     z_ring_channel_query_new(&closure, &handler, 10);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     z_closure(&callback, on_sample, drop_stats, (void *)context);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare_background(z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_background_subscriber(z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t ping;
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_session_loan(&session), z_view_keyexpr_loan(&ping), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&session), &pub, z_view_keyexpr_loan(&ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_ping.c
+++ b/examples/unix/c99/z_ping.c
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_session_loan(&session), z_view_keyexpr_loan(&pong),
+    if (z_declare_subscriber(z_session_loan(&session), &sub, z_view_keyexpr_loan(&pong),
                              z_closure_sample_move(&respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_session_loan(&session), z_view_keyexpr_loan(&pong), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&session), &pub, z_view_keyexpr_loan(&pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_pong.c
+++ b/examples/unix/c99/z_pong.c
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure_sample(&respond, callback, drop, (void*)(&pub));
 
-    if (z_subscriber_declare_background(z_session_loan(&session), z_view_keyexpr_loan(&ping),
+    if (z_declare_background_subscriber(z_session_loan(&session), z_view_keyexpr_loan(&ping),
                                         z_closure_sample_move(&respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;

--- a/examples/unix/c99/z_pub.c
+++ b/examples/unix/c99/z_pub.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&s), &pub, z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_session_loan(&s), z_view_keyexpr_loan(&ke), NULL) < 0) {
+    if (z_declare_publisher(z_session_loan(&s), &pub, z_view_keyexpr_loan(&ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/unix/c99/z_pull.c
+++ b/examples/unix/c99/z_pull.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&closure),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c99/z_put.c
+++ b/examples/unix/c99/z_put.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t vke;
     z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
-    if (z_declare_keyexpr(&ke, z_session_loan(&s), z_view_keyexpr_loan(&vke)) < 0) {
+    if (z_declare_keyexpr(z_session_loan(&s), &ke, z_view_keyexpr_loan(&vke)) < 0) {
         printf("Unable to declare key expression!\n");
         z_session_drop(z_session_move(&s));
         return -1;
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean up
-    z_undeclare_keyexpr(z_keyexpr_move(&ke), z_session_loan(&s));
+    z_undeclare_keyexpr(z_session_loan(&s), z_keyexpr_move(&ke));
     z_session_drop(z_session_move(&s));
     return 0;
 }

--- a/examples/unix/c99/z_queryable.c
+++ b/examples/unix/c99/z_queryable.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
 
     printf("Creating Queryable on '%s'...\n", keyexpr);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
+    if (z_declare_queryable(z_session_loan(&s), &qable, z_view_keyexpr_loan(&ke), z_closure_query_move(&callback),
                             NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;

--- a/examples/unix/c99/z_sub.c
+++ b/examples/unix/c99/z_sub.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/unix/c99/z_sub_st.c
+++ b/examples/unix/c99/z_sub_st.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_session_loan(&s), z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
+    if (z_declare_subscriber(z_session_loan(&s), &sub, z_view_keyexpr_loan(&ke), z_closure_sample_move(&callback),
                              NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, NULL);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_loan(session), z_loan(pong), z_move(respond), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(session), &sub, z_loan(pong), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/windows/z_ping.c
+++ b/examples/windows/z_ping.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t ping;
     z_view_keyexpr_from_str_unchecked(&ping, "test/ping");
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(session), z_loan(ping), NULL) < 0) {
+    if (z_declare_publisher(z_loan(session), &pub, z_loan(ping), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
     z_owned_closure_sample_t respond;
     z_closure(&respond, callback, drop, (void*)(&pub));
 
-    if (z_subscriber_declare_background(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
+    if (z_declare_background_subscriber(z_loan(session), z_loan(ping), z_move(respond), NULL) < 0) {
         printf("Unable to declare subscriber for key expression.\n");
         return -1;
     }

--- a/examples/windows/z_pong.c
+++ b/examples/windows/z_pong.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     z_view_keyexpr_t pong;
     z_view_keyexpr_from_str_unchecked(&pong, "test/pong");
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(session), z_loan(pong), NULL) < 0) {
+    if (z_declare_publisher(z_loan(session), &pub, z_loan(pong), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pub.c
+++ b/examples/windows/z_pub.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }

--- a/examples/windows/z_pull.c
+++ b/examples/windows/z_pull.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/windows/z_put.c
+++ b/examples/windows/z_put.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t vke;
     z_view_keyexpr_from_str(&vke, keyexpr);
     z_owned_keyexpr_t ke;
-    if (z_declare_keyexpr(&ke, z_loan(s), z_loan(vke)) < 0) {
+    if (z_declare_keyexpr(z_loan(s), &ke, z_loan(vke)) < 0) {
         printf("Unable to declare key expression!\n");
         z_drop(z_move(s));
         return -1;
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     }
 
     // Clean up
-    z_undeclare_keyexpr(z_move(ke), z_loan(s));
+    z_undeclare_keyexpr(z_loan(s), z_move(ke));
     z_drop(z_move(s));
     return 0;
 }

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     z_owned_closure_query_t callback;
     z_closure(&callback, query_handler);
     z_owned_queryable_t qable;
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");
         return -1;
     }

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_publisher_t pub;
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/examples/zephyr/z_pull.c
+++ b/examples/zephyr/z_pull.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, KEYEXPR);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(closure), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(closure), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
-    if (z_queryable_declare(&qable, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare queryable.\n");
         exit(-1);
     }

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         exit(-1);
     }

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1721,8 +1721,8 @@ void z_queryable_options_default(z_queryable_options_t *options);
  * Note that dropping queryable drops its callback.
  *
  * Parameters:
- *   queryable: Pointer to an uninitialized :c:type:`z_owned_queryable_t` to contain the queryable.
  *   zs: Pointer to a :c:type:`z_loaned_session_t` to declare the subscriber through.
+ *   queryable: Pointer to an uninitialized :c:type:`z_owned_queryable_t` to contain the queryable.
  *   keyexpr: Pointer to a :c:type:`z_loaned_keyexpr_t` to bind the subscriber with.
  *   callback: Pointer to a :c:type:`z_owned_closure_query_t` callback.
  *   options: Pointer to a :c:type:`z_queryable_options_t` to configure the declare.
@@ -1730,7 +1730,7 @@ void z_queryable_options_default(z_queryable_options_t *options);
  * Return:
  *   ``0`` if declare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_queryable_declare(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
+z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t *queryable,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options);
 
@@ -1747,7 +1747,7 @@ z_result_t z_queryable_declare(z_owned_queryable_t *queryable, const z_loaned_se
  * Return:
  *   ``0`` if declare operation is successful, ``negative value`` otherwise.
  */
-z_result_t z_queryable_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                           z_moved_closure_query_t *callback, const z_queryable_options_t *options);
 
 /**

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1569,15 +1569,15 @@ void z_publisher_options_default(z_publisher_options_t *options);
  * :c:func:`z_publisher_put` and :c:func:`z_publisher_delete` functions.
  *
  * Parameters:
- *   pub: Pointer to an uninitialized :c:type:`z_owned_publisher_t`.
  *   zs: Pointer to a :c:type:`z_loaned_session_t` to declare the publisher through.
+ *   pub: Pointer to an uninitialized :c:type:`z_owned_publisher_t`.
  *   keyexpr: Pointer to a :c:type:`z_loaned_keyexpr_t` to bind the publisher with.
  *   options: Pointer to a :c:type:`z_publisher_options_t` to configure the operation.
  *
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_publisher_declare(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
+z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t *pub,
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1581,6 +1581,17 @@ z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options);
 
 /**
+ * Undeclares the publisher.
+ *
+ * Parameters:
+ *   pub: Moved :c:type:`z_owned_publisher_t` to undeclare.
+ *
+ * Return:
+ *   ``0`` if undeclare is successful, ``negative value`` otherwise.
+ */
+z_result_t z_undeclare_publisher(z_moved_publisher_t *pub);
+
+/**
  * Builds a :c:type:`z_publisher_put_options_t` with default values.
  *
  * Parameters:
@@ -1733,6 +1744,17 @@ void z_queryable_options_default(z_queryable_options_t *options);
 z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t *queryable,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options);
+
+/**
+ * Undeclares the queryable.
+ *
+ * Parameters:
+ *   pub: Moved :c:type:`z_owned_queryable_t` to undeclare.
+ *
+ * Return:
+ *   ``0`` if undeclare is successful, ``negative value`` otherwise.
+ */
+z_result_t z_undeclare_queryable(z_moved_queryable_t *pub);
 
 /**
  * Declares a background queryable for a given keyexpr. The queryable callback will be called
@@ -1994,6 +2016,17 @@ void z_subscriber_options_default(z_subscriber_options_t *options);
 z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber_t *sub,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options);
+
+/**
+ * Undeclares the subscriber.
+ *
+ * Parameters:
+ *   pub: Moved :c:type:`z_owned_subscriber_t` to undeclare.
+ *
+ * Return:
+ *   ``0`` if undeclare is successful, ``negative value`` otherwise.
+ */
+z_result_t z_undeclare_subscriber(z_moved_subscriber_t *pub);
 
 /**
  * Declares a background subscriber for a given keyexpr. Subscriber callback will be called to process the messages,

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1982,8 +1982,8 @@ void z_subscriber_options_default(z_subscriber_options_t *options);
  * Note that dropping subscriber drops its callback.
  *
  * Parameters:
- *   sub: Pointer to a :c:type:`z_owned_subscriber_t` to contain the subscriber.
  *   zs: Pointer to a :c:type:`z_loaned_session_t` to declare the subscriber through.
+ *   sub: Pointer to a :c:type:`z_owned_subscriber_t` to contain the subscriber.
  *   keyexpr: Pointer to a :c:type:`z_loaned_keyexpr_t` to bind the subscriber with.
  *   callback: Pointer to a`z_owned_closure_sample_t` callback.
  *   options: Pointer to a :c:type:`z_subscriber_options_t` to configure the operation
@@ -1991,7 +1991,7 @@ void z_subscriber_options_default(z_subscriber_options_t *options);
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_subscriber_declare(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
+z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber_t *sub,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options);
 
@@ -2008,7 +2008,7 @@ z_result_t z_subscriber_declare(z_owned_subscriber_t *sub, const z_loaned_sessio
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_subscriber_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                            z_moved_closure_sample_t *callback, const z_subscriber_options_t *options);
 
 /**

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1899,7 +1899,7 @@ z_result_t z_keyexpr_from_substr_autocanonize(z_owned_keyexpr_t *keyexpr, const 
  * Return:
  *   ``0`` if declare is successful, ``negative value`` otherwise.
  */
-z_result_t z_declare_keyexpr(z_owned_keyexpr_t *declared_keyexpr, const z_loaned_session_t *zs,
+z_result_t z_declare_keyexpr(const z_loaned_session_t *zs, z_owned_keyexpr_t *declared_keyexpr,
                              const z_loaned_keyexpr_t *keyexpr);
 
 /**
@@ -1912,7 +1912,7 @@ z_result_t z_declare_keyexpr(z_owned_keyexpr_t *declared_keyexpr, const z_loaned
  * Return:
  *   ``0`` if undeclare is successful, ``negative value`` otherwise.
  */
-z_result_t z_undeclare_keyexpr(z_moved_keyexpr_t *keyexpr, const z_loaned_session_t *zs);
+z_result_t z_undeclare_keyexpr(const z_loaned_session_t *zs, z_moved_keyexpr_t *keyexpr);
 
 /**
  * Constructs a new empty string array.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -169,7 +169,7 @@ typedef struct {
 } z_query_consolidation_t;
 
 /**
- * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_publisher_declare`.
+ * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_declare_publisher`.
  *
  * Members:
  *   z_owned_encoding_t *encoding: Default encoding for messages put by this publisher.
@@ -386,7 +386,7 @@ typedef struct {
 } zp_send_join_options_t;
 
 /**
- * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_publisher_declare`.
+ * Represents the configuration used to configure a publisher upon declaration with :c:func:`z_declare_publisher`.
  *
  * Members:
  *   uint64_t timeout_ms: The maximum duration in ms the scouting can take.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -138,7 +138,7 @@ _Z_OWNED_TYPE_VALUE(_z_encoding_t, encoding)
 _Z_OWNED_TYPE_VALUE(_z_value_t, reply_err)
 
 /**
- * Represents the configuration used to configure a subscriber upon declaration :c:func:`z_subscriber_declare`.
+ * Represents the configuration used to configure a subscriber upon declaration :c:func:`z_declare_subscriber`.
  */
 typedef struct {
     uint8_t __dummy;  // Just to avoid empty structures that might cause undefined behavior

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -190,7 +190,7 @@ typedef struct {
 } z_publisher_options_t;
 
 /**
- * Represents the configuration used to configure a queryable upon declaration :c:func:`z_queryable_declare`.
+ * Represents the configuration used to configure a queryable upon declaration :c:func:`z_declare_queryable`.
  *
  * Members:
  *   bool complete: The completeness of the queryable.

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1316,15 +1316,15 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_subscriber_t, subscriber, _z_subscriber
 
 void z_subscriber_options_default(z_subscriber_options_t *options) { options->__dummy = 0; }
 
-z_result_t z_subscriber_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                            z_moved_closure_sample_t *callback, const z_subscriber_options_t *options) {
     z_owned_subscriber_t sub;
-    _Z_RETURN_IF_ERR(z_subscriber_declare(&sub, zs, keyexpr, callback, options));
+    _Z_RETURN_IF_ERR(z_declare_subscriber(sz, &sub, keyexpr, callback, options));
     _z_subscriber_clear(&sub._val);
     return _Z_RES_OK;
 }
 
-z_result_t z_subscriber_declare(z_owned_subscriber_t *sub, const z_loaned_session_t *zs,
+z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber_t *sub,
                                 const z_loaned_keyexpr_t *keyexpr, z_moved_closure_sample_t *callback,
                                 const z_subscriber_options_t *options) {
     _ZP_UNUSED(options);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1281,7 +1281,7 @@ z_result_t z_keyexpr_from_substr(z_owned_keyexpr_t *key, const char *name, size_
     return _Z_RES_OK;
 }
 
-z_result_t z_declare_keyexpr(z_owned_keyexpr_t *key, const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr) {
+z_result_t z_declare_keyexpr(const z_loaned_session_t *zs, z_owned_keyexpr_t *key, const z_loaned_keyexpr_t *keyexpr) {
     _z_keyexpr_t k = _z_keyexpr_alias_from_user_defined(*keyexpr, false);
     uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), k);
     key->_val = _z_rid_with_suffix(id, NULL);
@@ -1296,7 +1296,7 @@ z_result_t z_declare_keyexpr(z_owned_keyexpr_t *key, const z_loaned_session_t *z
     return _Z_RES_OK;
 }
 
-z_result_t z_undeclare_keyexpr(z_moved_keyexpr_t *keyexpr, const z_loaned_session_t *zs) {
+z_result_t z_undeclare_keyexpr(const z_loaned_session_t *zs, z_moved_keyexpr_t *keyexpr) {
     z_result_t ret = _Z_RES_OK;
 
     ret = _z_undeclare_resource(_Z_RC_IN_VAL(zs), keyexpr->_this._val._id);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -913,6 +913,12 @@ z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t
     return _Z_RES_OK;
 }
 
+z_result_t z_undeclare_publisher(z_moved_publisher_t *pub) {
+    z_result_t ret = _z_undeclare_publisher(&pub->_this._val);
+    _z_publisher_clear(&pub->_this._val);
+    return ret;
+}
+
 void z_publisher_put_options_default(z_publisher_put_options_t *options) {
     options->encoding = NULL;
     options->attachment = NULL;
@@ -1144,6 +1150,12 @@ z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t
     return _Z_RES_OK;
 }
 
+z_result_t z_undeclare_queryable(z_moved_queryable_t *queryable) {
+    z_result_t ret = _z_undeclare_queryable(&queryable->_this._val);
+    _z_queryable_clear(&queryable->_this._val);
+    return ret;
+}
+
 void z_query_reply_options_default(z_query_reply_options_t *options) {
     options->encoding = NULL;
     options->congestion_control = Z_CONGESTION_CONTROL_DEFAULT;
@@ -1373,6 +1385,12 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     } else {
         return _Z_RES_OK;
     }
+}
+
+z_result_t z_undeclare_subscriber(z_moved_subscriber_t *sub) {
+    z_result_t ret = _z_undeclare_subscriber(&sub->_this._val);
+    _z_subscriber_clear(&sub->_this._val);
+    return ret;
 }
 
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub) {

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1103,15 +1103,15 @@ _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL(_z_queryable_t, queryable, _z_queryable_ch
 
 void z_queryable_options_default(z_queryable_options_t *options) { options->complete = _Z_QUERYABLE_COMPLETE_DEFAULT; }
 
-z_result_t z_queryable_declare_background(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
+z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                           z_moved_closure_query_t *callback, const z_queryable_options_t *options) {
     z_owned_queryable_t qle;
-    _Z_RETURN_IF_ERR(z_queryable_declare(&qle, zs, keyexpr, callback, options));
+    _Z_RETURN_IF_ERR(z_declare_queryable(zs, &qle, keyexpr, callback, options));
     _z_queryable_clear(&qle._val);
     return _Z_RES_OK;
 }
 
-z_result_t z_queryable_declare(z_owned_queryable_t *queryable, const z_loaned_session_t *zs,
+z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t *queryable,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options) {
     void *ctx = callback->_this._val.context;
@@ -1319,7 +1319,7 @@ void z_subscriber_options_default(z_subscriber_options_t *options) { options->__
 z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr,
                                            z_moved_closure_sample_t *callback, const z_subscriber_options_t *options) {
     z_owned_subscriber_t sub;
-    _Z_RETURN_IF_ERR(z_declare_subscriber(sz, &sub, keyexpr, callback, options));
+    _Z_RETURN_IF_ERR(z_declare_subscriber(zs, &sub, keyexpr, callback, options));
     _z_subscriber_clear(&sub._val);
     return _Z_RES_OK;
 }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -871,7 +871,7 @@ void z_publisher_options_default(z_publisher_options_t *options) {
 #endif
 }
 
-z_result_t z_publisher_declare(z_owned_publisher_t *pub, const z_loaned_session_t *zs,
+z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t *pub,
                                const z_loaned_keyexpr_t *keyexpr, const z_publisher_options_t *options) {
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
     _z_keyexpr_t key = keyexpr_aliased;

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr_str);
     z_owned_subscriber_t _ret_sub;
-    _ret_res = z_subscriber_declare(&_ret_sub, z_loan(s2), z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
+    _ret_res = z_declare_subscriber(z_loan(s2), &_ret_sub, z_loan(ke), z_move(_ret_closure_sample), &_ret_sub_opt);
     assert(_ret_res == _Z_RES_OK);
     printf("Ok\n");
 

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
     z_view_keyexpr_t s1_key;
     z_view_keyexpr_from_str(&s1_key, s1_res);
     z_owned_keyexpr_t _ret_expr;
-    z_declare_keyexpr(&_ret_expr, z_loan(s1), z_loan(s1_key));
+    z_declare_keyexpr(z_loan(s1), &_ret_expr, z_loan(s1_key));
     assert(z_internal_check(_ret_expr));
     printf("Ok\n");
 
@@ -312,7 +312,7 @@ int main(int argc, char **argv) {
     assert_eq(datas, 2);
 
     printf("Undeclaring Keyexpr...");
-    _ret_res = z_undeclare_keyexpr(z_move(_ret_expr), z_loan(s1));
+    _ret_res = z_undeclare_keyexpr(z_loan(s1), z_move(_ret_expr));
     printf(" %02x\n", _ret_res);
     assert_eq(_ret_res, 0);
     assert(!z_internal_check(_ret_expr));

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -325,7 +325,7 @@ int main(int argc, char **argv) {
     _ret_pub_opt.encoding = z_move(encoding);
     _ret_pub_opt.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
     z_owned_publisher_t _ret_pub;
-    _ret_res = z_publisher_declare(&_ret_pub, z_loan(s1), z_loan(s1_key), &_ret_pub_opt);
+    _ret_res = z_declare_publisher(z_loan(s1), &_ret_pub, z_loan(s1_key), &_ret_pub_opt);
     assert(_ret_res == _Z_RES_OK);
     assert(!z_internal_check(encoding));
     printf("Ok\n");

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -375,7 +375,7 @@ int main(int argc, char **argv) {
     z_queryable_options_t _ret_qle_opt;
     z_queryable_options_default(&_ret_qle_opt);
     z_owned_queryable_t qle;
-    assert(z_queryable_declare(&qle, z_loan(s1), z_loan(s1_key), z_move(_ret_closure_query), &_ret_qle_opt) ==
+    assert(z_declare_queryable(z_loan(s1), &qle, z_loan(s1_key), z_move(_ret_closure_query), &_ret_qle_opt) ==
            _Z_RES_OK);
     printf("Ok\n");
 

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
         z_owned_keyexpr_t expr;
-        z_declare_keyexpr(&expr, z_loan(s1), z_loan(ke));
+        z_declare_keyexpr(z_loan(s1), &expr, z_loan(ke));
         printf("Declared resource on session 1: %u %.*s\n", z_loan(expr)->_id,
                (int)z_string_len(&z_loan(expr)->_suffix), z_string_data(&z_loan(expr)->_suffix));
         rids1[i] = expr;
@@ -183,7 +183,7 @@ int main(int argc, char **argv) {
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
         z_owned_keyexpr_t expr;
-        z_declare_keyexpr(&expr, z_loan(s2), z_loan(ke));
+        z_declare_keyexpr(z_loan(s2), &expr, z_loan(ke));
         printf("Declared resource on session 2: %u %.*s\n", z_loan(expr)->_id,
                (int)z_string_len(&z_loan(expr)->_suffix), z_string_data(&z_loan(expr)->_suffix));
         rids2[i] = expr;
@@ -380,14 +380,14 @@ int main(int argc, char **argv) {
     // Undeclare resources on both sessions
     for (unsigned int i = 0; i < SET; i++) {
         printf("Undeclared resource on session 1: %u\n", z_loan(rids1[i])->_id);
-        z_undeclare_keyexpr(z_move(rids1[i]), z_loan(s1));
+        z_undeclare_keyexpr(z_loan(s1), z_move(rids1[i]));
     }
 
     z_sleep_s(SLEEP);
 
     for (unsigned int i = 0; i < SET; i++) {
         printf("Undeclared resource on session 2: %u\n", z_loan(rids2[i])->_id);
-        z_undeclare_keyexpr(z_move(rids2[i]), z_loan(s2));
+        z_undeclare_keyexpr(z_loan(s2), z_move(rids2[i]));
     }
 
     z_sleep_s(SLEEP);

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
     // Declare publisher on first session
     for (unsigned int i = 0; i < SET; i++) {
         z_owned_publisher_t *pub = (z_owned_publisher_t *)z_malloc(sizeof(z_owned_publisher_t));
-        if (z_publisher_declare(pub, z_loan(s1), z_loan(rids1[i]), NULL) < 0) {
+        if (z_declare_publisher(z_loan(s1), pub, z_loan(rids1[i]), NULL) < 0) {
             printf("Declared publisher on session 1: %zu\n", z_loan(*pub)->_id);
         }
         pubs1 = _z_list_push(pubs1, pub);

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
         z_owned_closure_sample_t callback;
         z_closure(&callback, data_handler, NULL, &idx[i]);
         z_owned_subscriber_t *sub = (z_owned_subscriber_t *)z_malloc(sizeof(z_owned_subscriber_t));
-        z_result_t res = z_subscriber_declare(sub, z_loan(s2), z_loan(rids2[i]), z_move(callback), NULL);
+        z_result_t res = z_declare_subscriber(z_loan(s2), sub, z_loan(rids2[i]), z_move(callback), NULL);
         assert(res == _Z_RES_OK);
         printf("Declared subscription on session 2: %ju %u %s\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id,
                z_loan(rids2[i])->_id, "");

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
         z_owned_queryable_t *qle = (z_owned_queryable_t *)z_malloc(sizeof(z_owned_queryable_t));
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
-        assert(z_queryable_declare(qle, z_loan(s2), z_loan(ke), z_move(callback), NULL) == _Z_RES_OK);
+        assert(z_declare_queryable(z_loan(s2), qle, z_loan(ke), z_move(callback), NULL) == _Z_RES_OK);
         printf("Declared queryable on session 2: %ju %zu %s\n", (uintmax_t)qle->_val._entity_id, (z_zint_t)0, s1_res);
         qles2 = _z_list_push(qles2, qle);
     }

--- a/tests/z_peer_multicast_test.c
+++ b/tests/z_peer_multicast_test.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
         z_owned_subscriber_t *sub = (z_owned_subscriber_t *)z_malloc(sizeof(z_owned_subscriber_t));
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str(&ke, s1_res);
-        z_result_t res = z_subscriber_declare(sub, z_loan(s2), z_loan(ke), z_move(callback), NULL);
+        z_result_t res = z_declare_subscriber(z_loan(s2), sub, z_loan(ke), z_move(callback), NULL);
         assert(res == _Z_RES_OK);
         printf("Declared subscription on session 2: %ju %zu %s\n", (uintmax_t)z_subscriber_loan(sub)->_entity_id,
                (z_zint_t)0, s1_res);

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create subscriber.\n");
         exit(-1);
     }

--- a/tests/z_perf_tx.c
+++ b/tests/z_perf_tx.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     z_owned_publisher_t pub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_publisher_declare(&pub, z_loan(s), z_loan(ke), NULL) < 0) {
+    if (z_declare_publisher(z_loan(s), &pub, z_loan(ke), NULL) < 0) {
         printf("Unable to declare publisher for key expression!\n");
         exit(-1);
     }

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);
-    if (z_subscriber_declare(&sub, z_loan(s), z_loan(ke), z_move(callback), NULL) < 0) {
+    if (z_declare_subscriber(z_loan(s), &sub, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to declare subscriber.\n");
         return -1;
     }


### PR DESCRIPTION
 - Rename z_publisher_declare to z_declare_publisher and make session first
 - Rename z_subscriber_declare to z_declare_subscriber and make session first
 - Rename z_queryable_declare to z_declare_queryable and make session first
 - Move a session as the first parameter for z_declare_keyexpr/z_undeclare_keyexpr
 - Return undeclare method for publisher/subscriber/queryable