### PR TITLE
Align closure handler names

### DIFF
--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -982,7 +982,7 @@ const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query);
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_sample(z_owned_closure_sample_t *closure, z_data_handler_t call, z_dropper_handler_t drop,
+z_result_t z_closure_sample(z_owned_closure_sample_t *closure, z_sample_handler_t call, z_dropper_handler_t drop,
                             void *context);
 
 /**
@@ -1007,7 +1007,7 @@ void z_closure_sample_call(const z_loaned_closure_sample_t *closure, z_loaned_sa
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_query(z_owned_closure_query_t *closure, z_queryable_handler_t call, z_dropper_handler_t drop,
+z_result_t z_closure_query(z_owned_closure_query_t *closure, z_query_handler_t call, z_dropper_handler_t drop,
                            void *context);
 
 /**
@@ -1082,7 +1082,7 @@ void z_closure_hello_call(const z_loaned_closure_hello_t *closure, z_loaned_hell
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_zid(z_owned_closure_zid_t *closure, z_id_handler_t call, z_dropper_handler_t drop, void *context);
+z_result_t z_closure_zid(z_owned_closure_zid_t *closure, z_zid_handler_t call, z_dropper_handler_t drop, void *context);
 
 /**
  * Calls a zid closure.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -418,11 +418,11 @@ _Z_OWNED_TYPE_VALUE(_z_reply_t, reply)
 _Z_OWNED_TYPE_VALUE(_z_string_svec_t, string_array)
 
 typedef void (*z_dropper_handler_t)(void *arg);
-typedef _z_data_handler_t z_data_handler_t;
+typedef _z_sample_handler_t z_sample_handler_t;
 
 typedef struct {
     void *context;
-    z_data_handler_t call;
+    z_sample_handler_t call;
     z_dropper_handler_t drop;
 } _z_closure_sample_t;
 
@@ -431,11 +431,11 @@ typedef struct {
  */
 _Z_OWNED_TYPE_VALUE(_z_closure_sample_t, closure_sample)
 
-typedef _z_queryable_handler_t z_queryable_handler_t;
+typedef _z_query_handler_t z_query_handler_t;
 
 typedef struct {
     void *context;
-    z_queryable_handler_t call;
+    z_query_handler_t call;
     z_dropper_handler_t drop;
 } _z_closure_query_t;
 
@@ -470,11 +470,11 @@ typedef struct {
  */
 _Z_OWNED_TYPE_VALUE(_z_closure_hello_t, closure_hello)
 
-typedef void (*z_id_handler_t)(const z_id_t *id, void *arg);
+typedef void (*z_zid_handler_t)(const z_id_t *id, void *arg);
 
 typedef struct {
     void *context;
-    z_id_handler_t call;
+    z_zid_handler_t call;
     z_dropper_handler_t drop;
 } _z_closure_zid_t;
 

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -144,7 +144,7 @@ z_result_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t pay
  * Returns:
  *    The created :c:type:`_z_subscriber_t` (in null state if the declaration failed).
  */
-_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_data_handler_t callback,
+_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_sample_handler_t callback,
                                       _z_drop_handler_t dropper, void *arg);
 
 /**
@@ -175,7 +175,7 @@ z_result_t _z_undeclare_subscriber(_z_subscriber_t *sub);
  *    The created :c:type:`_z_queryable_t` (in null state if the declaration failed)..
  */
 _z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, bool complete,
-                                    _z_queryable_handler_t callback, _z_drop_handler_t dropper, void *arg);
+                                    _z_query_handler_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_queryable_t`.

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -54,13 +54,13 @@ typedef struct _z_sample_t _z_sample_t;
 /**
  * The callback signature of the functions handling data messages.
  */
-typedef void (*_z_data_handler_t)(_z_sample_t *sample, void *arg);
+typedef void (*_z_sample_handler_t)(_z_sample_t *sample, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     uint16_t _key_id;
     uint32_t _id;
-    _z_data_handler_t _callback;
+    _z_sample_handler_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
 } _z_subscription_t;
@@ -85,12 +85,12 @@ typedef struct _z_query_rc_t _z_query_rc_t;
 /**
  * The callback signature of the functions handling query messages.
  */
-typedef void (*_z_queryable_handler_t)(_z_query_rc_t *query, void *arg);
+typedef void (*_z_query_handler_t)(_z_query_rc_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     uint32_t _id;
-    _z_queryable_handler_t _callback;
+    _z_query_handler_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
     bool _complete;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -549,11 +549,11 @@ static _z_encoding_t _z_encoding_from_owned(const z_owned_encoding_t *encoding) 
 _Z_OWNED_FUNCTIONS_VALUE_IMPL(_z_sample_t, sample, _z_sample_check, _z_sample_null, _z_sample_copy, _z_sample_clear)
 _Z_OWNED_FUNCTIONS_RC_IMPL(session)
 
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_sample, _z_data_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_query, _z_queryable_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_sample, _z_sample_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_query, _z_query_handler_t, z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_reply, _z_reply_handler_t, z_dropper_handler_t)
 _Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_hello, z_loaned_hello_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_zid, z_id_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_zid, z_zid_handler_t, z_dropper_handler_t)
 
 /************* Primitives **************/
 typedef struct __z_hello_handler_wrapper_t {

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -192,7 +192,7 @@ z_result_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes
 
 #if Z_FEATURE_SUBSCRIPTION == 1
 /*------------------ Subscriber Declaration ------------------*/
-_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_data_handler_t callback,
+_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_sample_handler_t callback,
                                       _z_drop_handler_t dropper, void *arg) {
     _z_subscription_t s;
     s._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
@@ -256,7 +256,7 @@ z_result_t _z_undeclare_subscriber(_z_subscriber_t *sub) {
 #if Z_FEATURE_QUERYABLE == 1
 /*------------------ Queryable Declaration ------------------*/
 _z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, bool complete,
-                                    _z_queryable_handler_t callback, _z_drop_handler_t dropper, void *arg) {
+                                    _z_query_handler_t callback, _z_drop_handler_t dropper, void *arg) {
     _z_session_queryable_t q;
     q._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     q._key = _z_get_expanded_key_from_key(_Z_RC_IN_VAL(zn), &keyexpr);


### PR DESCRIPTION
Align closure handler names with closure names:
 - `z_data_handler_t` -> `z_sample_handler_t`
 - `z_queryable_handler_t` -> `z_query_handler_t`
 - `z_id_handler_t` -> `z_zid_handler_t`