### PR TITLE
Fix undefined behavior on udp config

### DIFF
--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -288,7 +288,7 @@ z_result_t _z_endpoint_config_from_string(_z_str_intmap_t *strint, _z_string_t *
     char *p_start = (char *)memchr(_z_string_data(str), ENDPOINT_CONFIG_SEPARATOR, _z_string_len(str));
     if (p_start != NULL) {
         p_start = _z_ptr_char_offset(p_start, 1);
-        size_t cfg_size = _z_string_len(str) - _z_ptr_char_diff(_z_string_data(str), p_start);
+        size_t cfg_size = _z_string_len(str) - _z_ptr_char_diff(p_start, _z_string_data(str));
 
         // Call the right configuration parser depending on the protocol
         _z_string_t cmp_str = _z_string_null();

--- a/src/protocol/config.c
+++ b/src/protocol/config.c
@@ -83,14 +83,13 @@ z_result_t _z_str_intmap_from_strn(_z_str_intmap_t *strint, const char *s, uint8
             size_t p_value_len = 0;
             if (p_value_end == NULL) {
                 p_value_end = end;
-                p_value_len = value_max_size;
+                p_value_len = value_max_size + 1;
             } else {
-                p_value_len = _z_ptr_char_diff(p_value_end, p_value_start);
+                p_value_len = _z_ptr_char_diff(p_value_end, p_value_start) + 1;
             }
-            char *p_value = (char *)z_malloc(p_value_len + 1);
+            char *p_value = (char *)z_malloc(p_value_len);
             if (p_value != NULL) {
-                memcpy(p_value, p_value_start, p_value_len);
-                p_value[p_value_len] = '\0';
+                _z_str_n_copy(p_value, p_value_start, p_value_len);
                 _z_str_intmap_insert(strint, key, p_value);
 
                 // Process next key value


### PR DESCRIPTION
`_z_string_t` treated as null-terminated strings in config were causing undefined behavior picked up by valgrind