### PR TITLE
Rename closure callback/dropper types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -463,7 +463,7 @@ See details at :ref:`owned_types_concept`
 .. c:type:: z_loaned_closure_sample_t
 .. c:type:: z_moved_closure_sample_t
 
-.. c:type:: void (* z_sample_handler_t)(z_loaned_sample_t * sample, void * arg);
+.. c:type:: void (* z_closure_sample_callback_t)(z_loaned_sample_t * sample, void * arg);
 
     Function pointer type for handling samples.
     Represents a callback function that is invoked when a sample is available for processing.
@@ -496,7 +496,7 @@ See details at :ref:`owned_types_concept`
 .. c:type:: z_loaned_closure_query_t
 .. c:type:: z_moved_closure_query_t
 
-.. c:type:: void (* z_query_handler_t)(z_loaned_query_t * query, void * arg);
+.. c:type:: void (* z_closure_query_callback_t)(z_loaned_query_t * query, void * arg);
 
     Function pointer type for handling queries.
     Represents a callback function that is invoked when a query is available for processing.
@@ -530,7 +530,7 @@ See details at :ref:`owned_types_concept`
 .. c:type:: z_loaned_closure_reply_t
 .. c:type:: z_moved_closure_reply_t
  
-.. c:type:: void (* z_reply_handler_t)(z_loaned_reply_t * reply, void * arg);
+.. c:type:: void (* z_closure_reply_callback_t)(z_loaned_reply_t * reply, void * arg);
 
     Function pointer type for handling replies.
     Represents a callback function that is invoked when a reply is available for processing.
@@ -564,7 +564,7 @@ See details at :ref:`owned_types_concept`
 .. c:type:: z_loaned_closure_hello_t
 .. c:type:: z_moved_closure_hello_t
  
-.. c:type:: void (* z_hello_handler_t)(z_loaned_hello_t * hello, void * arg);
+.. c:type:: void (* z_closure_hello_callback_t)(z_loaned_hello_t * hello, void * arg);
 
     Function pointer type for handling scouting response.
     Represents a callback function that is invoked when a hello is available for processing.
@@ -598,7 +598,7 @@ See details at :ref:`owned_types_concept`
 .. c:type:: z_loaned_closure_zid_t
 .. c:type:: z_moved_closure_zid_t
  
-.. c:type:: void (* z_zid_handler_t)(z_loaned_zid_t * zid, void * arg);
+.. c:type:: void (* z_closure_zid_callback_t)(z_loaned_zid_t * zid, void * arg);
 
     Function pointer type for handling Zenoh ID routers response.
     Represents a callback function that is invoked when a zid is available for processing.

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -982,8 +982,8 @@ const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query);
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_sample(z_owned_closure_sample_t *closure, z_sample_handler_t call, z_dropper_handler_t drop,
-                            void *context);
+z_result_t z_closure_sample(z_owned_closure_sample_t *closure, z_closure_sample_callback_t call,
+                            z_closure_drop_callback_t drop, void *context);
 
 /**
  * Calls a sample closure.
@@ -1007,8 +1007,8 @@ void z_closure_sample_call(const z_loaned_closure_sample_t *closure, z_loaned_sa
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_query(z_owned_closure_query_t *closure, z_query_handler_t call, z_dropper_handler_t drop,
-                           void *context);
+z_result_t z_closure_query(z_owned_closure_query_t *closure, z_closure_query_callback_t call,
+                           z_closure_drop_callback_t drop, void *context);
 
 /**
  * Calls a query closure.
@@ -1032,8 +1032,8 @@ void z_closure_query_call(const z_loaned_closure_query_t *closure, z_loaned_quer
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_reply(z_owned_closure_reply_t *closure, z_reply_handler_t call, z_dropper_handler_t drop,
-                           void *context);
+z_result_t z_closure_reply(z_owned_closure_reply_t *closure, z_closure_reply_callback_t call,
+                           z_closure_drop_callback_t drop, void *context);
 
 /**
  * Calls a reply closure.
@@ -1057,8 +1057,8 @@ void z_closure_reply_call(const z_loaned_closure_reply_t *closure, z_loaned_repl
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_hello(z_owned_closure_hello_t *closure, z_loaned_hello_handler_t call, z_dropper_handler_t drop,
-                           void *context);
+z_result_t z_closure_hello(z_owned_closure_hello_t *closure, z_loaned_hello_handler_t call,
+                           z_closure_drop_callback_t drop, void *context);
 
 /**
  * Calls a hello closure.
@@ -1082,7 +1082,8 @@ void z_closure_hello_call(const z_loaned_closure_hello_t *closure, z_loaned_hell
  * Return:
  *   ``0`` in case of success, negative error code otherwise
  */
-z_result_t z_closure_zid(z_owned_closure_zid_t *closure, z_zid_handler_t call, z_dropper_handler_t drop, void *context);
+z_result_t z_closure_zid(z_owned_closure_zid_t *closure, z_closure_zid_callback_t call, z_closure_drop_callback_t drop,
+                         void *context);
 
 /**
  * Calls a zid closure.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -417,13 +417,13 @@ _Z_OWNED_TYPE_VALUE(_z_reply_t, reply)
  */
 _Z_OWNED_TYPE_VALUE(_z_string_svec_t, string_array)
 
-typedef void (*z_dropper_handler_t)(void *arg);
-typedef _z_sample_handler_t z_sample_handler_t;
+typedef void (*z_closure_drop_callback_t)(void *arg);
+typedef _z_closure_sample_callback_t z_closure_sample_callback_t;
 
 typedef struct {
     void *context;
-    z_sample_handler_t call;
-    z_dropper_handler_t drop;
+    z_closure_sample_callback_t call;
+    z_closure_drop_callback_t drop;
 } _z_closure_sample_t;
 
 /**
@@ -431,12 +431,12 @@ typedef struct {
  */
 _Z_OWNED_TYPE_VALUE(_z_closure_sample_t, closure_sample)
 
-typedef _z_query_handler_t z_query_handler_t;
+typedef _z_closure_query_callback_t z_closure_query_callback_t;
 
 typedef struct {
     void *context;
-    z_query_handler_t call;
-    z_dropper_handler_t drop;
+    z_closure_query_callback_t call;
+    z_closure_drop_callback_t drop;
 } _z_closure_query_t;
 
 /**
@@ -444,12 +444,12 @@ typedef struct {
  */
 _Z_OWNED_TYPE_VALUE(_z_closure_query_t, closure_query)
 
-typedef _z_reply_handler_t z_reply_handler_t;
+typedef _z_closure_reply_callback_t z_closure_reply_callback_t;
 
 typedef struct {
     void *context;
-    z_reply_handler_t call;
-    z_dropper_handler_t drop;
+    z_closure_reply_callback_t call;
+    z_closure_drop_callback_t drop;
 } _z_closure_reply_t;
 
 /**
@@ -462,7 +462,7 @@ typedef void (*z_loaned_hello_handler_t)(z_loaned_hello_t *hello, void *arg);
 typedef struct {
     void *context;
     z_loaned_hello_handler_t call;
-    z_dropper_handler_t drop;
+    z_closure_drop_callback_t drop;
 } _z_closure_hello_t;
 
 /**
@@ -470,12 +470,12 @@ typedef struct {
  */
 _Z_OWNED_TYPE_VALUE(_z_closure_hello_t, closure_hello)
 
-typedef void (*z_zid_handler_t)(const z_id_t *id, void *arg);
+typedef void (*z_closure_zid_callback_t)(const z_id_t *id, void *arg);
 
 typedef struct {
     void *context;
-    z_zid_handler_t call;
-    z_dropper_handler_t drop;
+    z_closure_zid_callback_t call;
+    z_closure_drop_callback_t drop;
 } _z_closure_zid_t;
 
 /**

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -38,7 +38,7 @@
  *     timeout: The time that should be spent scouting before returning the results.
  */
 void _z_scout(const z_what_t what, const _z_id_t zid, _z_string_t *locator, const uint32_t timeout,
-              _z_hello_handler_t callback, void *arg_call, _z_drop_handler_t dropper, void *arg_drop);
+              _z_closure_hello_callback_t callback, void *arg_call, _z_drop_handler_t dropper, void *arg_drop);
 
 /*------------------ Declarations ------------------*/
 
@@ -144,8 +144,8 @@ z_result_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, _z_bytes_t pay
  * Returns:
  *    The created :c:type:`_z_subscriber_t` (in null state if the declaration failed).
  */
-_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_sample_handler_t callback,
-                                      _z_drop_handler_t dropper, void *arg);
+_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr,
+                                      _z_closure_sample_callback_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_subscriber_t`.
@@ -175,7 +175,7 @@ z_result_t _z_undeclare_subscriber(_z_subscriber_t *sub);
  *    The created :c:type:`_z_queryable_t` (in null state if the declaration failed)..
  */
 _z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, bool complete,
-                                    _z_query_handler_t callback, _z_drop_handler_t dropper, void *arg);
+                                    _z_closure_query_callback_t callback, _z_drop_handler_t dropper, void *arg);
 
 /**
  * Undeclare a :c:type:`_z_queryable_t`.
@@ -245,9 +245,10 @@ z_result_t _z_send_reply_err(const _z_query_t *query, const _z_session_rc_t *zsr
  *
  */
 z_result_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
-                    const z_consolidation_mode_t consolidation, const _z_value_t value, _z_reply_handler_t callback,
-                    _z_drop_handler_t dropper, void *arg, uint64_t timeout_ms, const _z_bytes_t attachment,
-                    z_congestion_control_t cong_ctrl, z_priority_t priority, bool is_express);
+                    const z_consolidation_mode_t consolidation, const _z_value_t value,
+                    _z_closure_reply_callback_t callback, _z_drop_handler_t dropper, void *arg, uint64_t timeout_ms,
+                    const _z_bytes_t attachment, z_congestion_control_t cong_ctrl, z_priority_t priority,
+                    bool is_express);
 #endif
 
 #if Z_FEATURE_INTEREST == 1

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -54,13 +54,13 @@ typedef struct _z_sample_t _z_sample_t;
 /**
  * The callback signature of the functions handling data messages.
  */
-typedef void (*_z_sample_handler_t)(_z_sample_t *sample, void *arg);
+typedef void (*_z_closure_sample_callback_t)(_z_sample_t *sample, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     uint16_t _key_id;
     uint32_t _id;
-    _z_sample_handler_t _callback;
+    _z_closure_sample_callback_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
 } _z_subscription_t;
@@ -85,12 +85,12 @@ typedef struct _z_query_rc_t _z_query_rc_t;
 /**
  * The callback signature of the functions handling query messages.
  */
-typedef void (*_z_query_handler_t)(_z_query_rc_t *query, void *arg);
+typedef void (*_z_closure_query_callback_t)(_z_query_rc_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     uint32_t _id;
-    _z_query_handler_t _callback;
+    _z_closure_query_callback_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
     bool _complete;
@@ -114,12 +114,12 @@ typedef struct _z_reply_t _z_reply_t;
 /**
  * The callback signature of the functions handling query replies.
  */
-typedef void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg);
+typedef void (*_z_closure_reply_callback_t)(_z_reply_t *reply, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     _z_zint_t _id;
-    _z_reply_handler_t _callback;
+    _z_closure_reply_callback_t _callback;
     _z_drop_handler_t _dropper;
     void *_arg;
     _z_pending_reply_list_t *_pending_replies;
@@ -142,11 +142,11 @@ typedef struct {
     _z_reply_data_list_t *_replies;
 } _z_pending_query_collect_t;
 
-struct __z_hello_handler_wrapper_t;  // Forward declaration to be used in _z_hello_handler_t
+struct __z_hello_handler_wrapper_t;  // Forward declaration to be used in _z_closure_hello_callback_t
 /**
  * The callback signature of the functions handling hello messages.
  */
-typedef void (*_z_hello_handler_t)(_z_hello_t *hello, struct __z_hello_handler_wrapper_t *arg);
+typedef void (*_z_closure_hello_callback_t)(_z_hello_t *hello, struct __z_hello_handler_wrapper_t *arg);
 
 z_result_t _z_session_generate_zid(_z_id_t *bs, uint8_t size);
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -549,11 +549,11 @@ static _z_encoding_t _z_encoding_from_owned(const z_owned_encoding_t *encoding) 
 _Z_OWNED_FUNCTIONS_VALUE_IMPL(_z_sample_t, sample, _z_sample_check, _z_sample_null, _z_sample_copy, _z_sample_clear)
 _Z_OWNED_FUNCTIONS_RC_IMPL(session)
 
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_sample, _z_sample_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_query, _z_query_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_reply, _z_reply_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_hello, z_loaned_hello_handler_t, z_dropper_handler_t)
-_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_zid, z_zid_handler_t, z_dropper_handler_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_sample, _z_closure_sample_callback_t, z_closure_drop_callback_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_query, _z_closure_query_callback_t, z_closure_drop_callback_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_reply, _z_closure_reply_callback_t, z_closure_drop_callback_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_hello, z_loaned_hello_handler_t, z_closure_drop_callback_t)
+_Z_OWNED_FUNCTIONS_CLOSURE_IMPL(closure_zid, z_closure_zid_callback_t, z_closure_drop_callback_t)
 
 /************* Primitives **************/
 typedef struct __z_hello_handler_wrapper_t {

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -38,7 +38,7 @@
 
 /*------------------ Scouting ------------------*/
 void _z_scout(const z_what_t what, const _z_id_t zid, _z_string_t *locator, const uint32_t timeout,
-              _z_hello_handler_t callback, void *arg_call, _z_drop_handler_t dropper, void *arg_drop) {
+              _z_closure_hello_callback_t callback, void *arg_call, _z_drop_handler_t dropper, void *arg_drop) {
     _z_hello_list_t *hellos = _z_scout_inner(what, zid, locator, timeout, false);
 
     while (hellos != NULL) {
@@ -192,8 +192,8 @@ z_result_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes
 
 #if Z_FEATURE_SUBSCRIPTION == 1
 /*------------------ Subscriber Declaration ------------------*/
-_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, _z_sample_handler_t callback,
-                                      _z_drop_handler_t dropper, void *arg) {
+_z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr,
+                                      _z_closure_sample_callback_t callback, _z_drop_handler_t dropper, void *arg) {
     _z_subscription_t s;
     s._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     s._key_id = keyexpr._id;
@@ -256,7 +256,7 @@ z_result_t _z_undeclare_subscriber(_z_subscriber_t *sub) {
 #if Z_FEATURE_QUERYABLE == 1
 /*------------------ Queryable Declaration ------------------*/
 _z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keyexpr, bool complete,
-                                    _z_query_handler_t callback, _z_drop_handler_t dropper, void *arg) {
+                                    _z_closure_query_callback_t callback, _z_drop_handler_t dropper, void *arg) {
     _z_session_queryable_t q;
     q._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     q._key = _z_get_expanded_key_from_key(_Z_RC_IN_VAL(zn), &keyexpr);
@@ -452,7 +452,7 @@ z_result_t _z_send_reply_err(const _z_query_t *query, const _z_session_rc_t *zsr
 #if Z_FEATURE_QUERY == 1
 /*------------------ Query ------------------*/
 z_result_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
-                    const z_consolidation_mode_t consolidation, _z_value_t value, _z_reply_handler_t callback,
+                    const z_consolidation_mode_t consolidation, _z_value_t value, _z_closure_reply_callback_t callback,
                     _z_drop_handler_t dropper, void *arg, uint64_t timeout_ms, const _z_bytes_t attachment,
                     z_congestion_control_t cong_ctrl, z_priority_t priority, bool is_express) {
     z_result_t ret = _Z_RES_OK;


### PR DESCRIPTION
Rename closure callback to have the same name as for zenoh-c and avoid name conflict with channel handlers:
- `z_xxx_handler_t` -> `z_closure_xxx_callback_t`