### PR TITLE
Add `export "C"` for all header files

### DIFF
--- a/include/zenoh-pico/collections/arc_slice.h
+++ b/include/zenoh-pico/collections/arc_slice.h
@@ -24,6 +24,10 @@
 #include "slice.h"
 #include "zenoh-pico/system/platform_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 _Z_REFCOUNT_DEFINE(_z_slice, _z_slice)
 
 /*-------- ArcSlice --------*/
@@ -51,5 +55,9 @@ const uint8_t* _z_arc_slice_data(const _z_arc_slice_t* s);
 z_result_t _z_arc_slice_copy(_z_arc_slice_t* dst, const _z_arc_slice_t* src);
 z_result_t _z_arc_slice_move(_z_arc_slice_t* dst, _z_arc_slice_t* src);
 z_result_t _z_arc_slice_drop(_z_arc_slice_t* s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_ARC_SLICE_H */

--- a/include/zenoh-pico/collections/array.h
+++ b/include/zenoh-pico/collections/array.h
@@ -19,6 +19,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Internal Array Macros ------------------*/
 #define _Z_ARRAY_DEFINE(name, type)                                                                 \
     typedef struct {                                                                                \
@@ -70,5 +74,9 @@
             *a = NULL;                                                                              \
         }                                                                                           \
     }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_ARRAY_H */

--- a/include/zenoh-pico/collections/bytes.h
+++ b/include/zenoh-pico/collections/bytes.h
@@ -23,6 +23,10 @@
 #include "vec.h"
 #include "zenoh-pico/protocol/iobuf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 inline size_t _z_arc_slice_size(const _z_arc_slice_t *s) {
     (void)s;
     return sizeof(_z_arc_slice_t);
@@ -93,5 +97,9 @@ _z_bytes_t _z_bytes_writer_finish(_z_bytes_writer_t *writer);
 void _z_bytes_writer_clear(_z_bytes_writer_t *writer);
 void _z_bytes_writer_move(_z_bytes_writer_t *dst, _z_bytes_writer_t *src);
 size_t _z_bytes_reader_remaining(const _z_bytes_reader_t *reader);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_BYTES_H */

--- a/include/zenoh-pico/collections/element.h
+++ b/include/zenoh-pico/collections/element.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/system/platform.h"
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- element functions --------*/
 typedef size_t (*z_element_size_f)(void *e);
 typedef void (*z_element_clear_f)(void *e);
@@ -73,5 +77,9 @@ static inline void _z_noop_move(void *dst, void *src) {
 }
 
 _Z_ELEM_DEFINE(_z_noop, _z_noop_t, _z_noop_size, _z_noop_clear, _z_noop_copy)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_ELEMENT_H */

--- a/include/zenoh-pico/collections/fifo.h
+++ b/include/zenoh-pico/collections/fifo.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/element.h"
 #include "zenoh-pico/collections/ring.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Fifo Buffer --------*/
 typedef struct {
     _z_ring_t _ring;
@@ -59,5 +63,9 @@ void _z_fifo_free(_z_fifo_t **xs, z_element_free_f f_f);
     static inline type *name##_fifo_pull(name##_fifo_t *r) { return (type *)_z_fifo_pull(r); }             \
     static inline void name##_fifo_clear(name##_fifo_t *r) { _z_fifo_clear(r, name##_elem_free); }         \
     static inline void name##_fifo_free(name##_fifo_t **r) { _z_fifo_free(r, name##_elem_free); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_FIFO_H */

--- a/include/zenoh-pico/collections/intmap.h
+++ b/include/zenoh-pico/collections/intmap.h
@@ -22,6 +22,10 @@
 #include "zenoh-pico/collections/list.h"
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- int-void map --------*/
 #define _Z_DEFAULT_INT_MAP_CAPACITY 16
 
@@ -112,5 +116,9 @@ void _z_int_void_map_free(_z_int_void_map_t **map, z_element_free_f f);
     static inline void name##_intmap_free(name##_intmap_t **m) {                                                \
         _z_int_void_map_free(m, name##_intmap_entry_elem_free);                                                 \
     }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_INTMAP_H */

--- a/include/zenoh-pico/collections/lifo.h
+++ b/include/zenoh-pico/collections/lifo.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/collections/element.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Ring Buffer --------*/
 typedef struct {
     void **_val;
@@ -60,5 +64,9 @@ void _z_lifo_free(_z_lifo_t **xs, z_element_free_f f_f);
     static inline type *name##_lifo_pull(name##_lifo_t *r) { return (type *)_z_lifo_pull(r); }             \
     static inline void name##_lifo_clear(name##_lifo_t *r) { _z_lifo_clear(r, name##_elem_free); }         \
     static inline void name##_lifo_free(name##_lifo_t **r) { _z_lifo_free(r, name##_elem_free); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_LIFO_H */

--- a/include/zenoh-pico/collections/list.h
+++ b/include/zenoh-pico/collections/list.h
@@ -20,6 +20,10 @@
 
 #include "zenoh-pico/collections/element.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Single-linked List --------*/
 /**
  * A single-linked list.
@@ -71,5 +75,9 @@ void _z_list_free(_z_list_t **xs, z_element_free_f f_f);
     }                                                                                                                \
     static inline name##_list_t *name##_list_clone(name##_list_t *l) { return _z_list_clone(l, name##_elem_clone); } \
     static inline void name##_list_free(name##_list_t **l) { _z_list_free(l, name##_elem_free); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_LIST_H */

--- a/include/zenoh-pico/collections/ring.h
+++ b/include/zenoh-pico/collections/ring.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/collections/element.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Ring Buffer --------*/
 typedef struct {
     void **_val;
@@ -64,5 +68,9 @@ void _z_ring_free(_z_ring_t **xs, z_element_free_f f_f);
     static inline type *name##_ring_pull(name##_ring_t *r) { return (type *)_z_ring_pull(r); }                         \
     static inline void name##_ring_clear(name##_ring_t *r) { _z_ring_clear(r, name##_elem_free); }                     \
     static inline void name##_ring_free(name##_ring_t **r) { _z_ring_free(r, name##_elem_free); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_RING_H */

--- a/include/zenoh-pico/collections/slice.h
+++ b/include/zenoh-pico/collections/slice.h
@@ -21,6 +21,10 @@
 
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     void (*deleter)(void *data, void *context);
     void *context;
@@ -66,5 +70,9 @@ bool _z_slice_eq(const _z_slice_t *left, const _z_slice_t *right);
 void _z_slice_clear(_z_slice_t *bs);
 void _z_slice_free(_z_slice_t **bs);
 bool _z_slice_is_alloced(const _z_slice_t *s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_SLICE_H */

--- a/include/zenoh-pico/collections/string.h
+++ b/include/zenoh-pico/collections/string.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/collections/slice.h"
 #include "zenoh-pico/collections/vec.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- str --------*/
 typedef char *_z_str_t;
 
@@ -99,5 +103,9 @@ static inline void _z_string_elem_move(void *dst, void *src) { _z_string_move((_
 _Z_SVEC_DEFINE(_z_string, _z_string_t)
 _Z_LIST_DEFINE(_z_string, _z_string_t)
 _Z_INT_MAP_DEFINE(_z_string, _z_string_t)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_STRING_H */

--- a/include/zenoh-pico/collections/vec.h
+++ b/include/zenoh-pico/collections/vec.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/collections/element.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-------- Dynamically allocated vector --------*/
 /**
  * A dynamically allocated vector. Elements are stored as pointers.
@@ -113,5 +117,9 @@ void _z_svec_release(_z_svec_t *v);
     static inline void name##_svec_reset(name##_svec_t *v) { _z_svec_reset(v, name##_elem_clear, sizeof(type)); }  \
     static inline void name##_svec_clear(name##_svec_t *v) { _z_svec_clear(v, name##_elem_clear, sizeof(type)); }  \
     static inline void name##_svec_free(name##_svec_t **v) { _z_svec_free(v, name##_elem_clear, sizeof(type)); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_COLLECTIONS_VECTOR_H */

--- a/include/zenoh-pico/link/config/bt.h
+++ b/include/zenoh-pico/link/config/bt.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_BLUETOOTH == 1
 
 #define BT_CONFIG_ARGC 3
@@ -48,6 +52,10 @@ char *_z_bt_config_to_str(const _z_str_intmap_t *s);
 
 z_result_t _z_bt_config_from_str(_z_str_intmap_t *strint, const char *s);
 z_result_t _z_bt_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_BT_H */

--- a/include/zenoh-pico/link/config/raweth.h
+++ b/include/zenoh-pico/link/config/raweth.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/link/link.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RAWETH_SCHEMA "reth"
 
 z_result_t _z_endpoint_raweth_valid(_z_endpoint_t *endpoint);
@@ -28,5 +32,9 @@ size_t _z_raweth_config_strlen(const _z_str_intmap_t *s);
 char *_z_raweth_config_to_str(const _z_str_intmap_t *s);
 z_result_t _z_raweth_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
 z_result_t _z_raweth_config_from_str(_z_str_intmap_t *strint, const char *s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_RAWETH_H */

--- a/include/zenoh-pico/link/config/serial.h
+++ b/include/zenoh-pico/link/config/serial.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_SERIAL == 1
 
 #define SERIAL_CONFIG_ARGC 1
@@ -64,6 +68,10 @@ char *_z_serial_config_to_str(const _z_str_intmap_t *s);
 
 z_result_t _z_serial_config_from_str(_z_str_intmap_t *strint, const char *s);
 z_result_t _z_serial_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_SERIAL_H */

--- a/include/zenoh-pico/link/config/tcp.h
+++ b/include/zenoh-pico/link/config/tcp.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_TCP == 1
 
 #define TCP_CONFIG_ARGC 1
@@ -38,6 +42,10 @@ char *_z_tcp_config_to_str(const _z_str_intmap_t *s);
 
 z_result_t _z_tcp_config_from_str(_z_str_intmap_t *strint, const char *s);
 z_result_t _z_tcp_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_TCP_H */

--- a/include/zenoh-pico/link/config/udp.h
+++ b/include/zenoh-pico/link/config/udp.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/collections/intmap.h"
 #include "zenoh-pico/collections/string.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UDP_CONFIG_ARGC 3
 
 #define UDP_CONFIG_IFACE_KEY 0x01
@@ -46,6 +50,10 @@ char *_z_udp_config_to_str(const _z_str_intmap_t *s);
 
 z_result_t _z_udp_config_from_str(_z_str_intmap_t *strint, const char *s);
 z_result_t _z_udp_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_UDP_H */

--- a/include/zenoh-pico/link/config/ws.h
+++ b/include/zenoh-pico/link/config/ws.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_WS == 1
 
 #define WS_CONFIG_TOUT_KEY 0x01
@@ -37,6 +41,10 @@ char *_z_ws_config_to_str(const _z_str_intmap_t *s);
 
 z_result_t _z_ws_config_from_str(_z_str_intmap_t *strint, const char *s);
 z_result_t _z_ws_config_from_strn(_z_str_intmap_t *strint, const char *s, size_t n);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_CONFIG_WS_H */

--- a/include/zenoh-pico/link/endpoint.h
+++ b/include/zenoh-pico/link/endpoint.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Locator ------------------*/
 #if Z_FEATURE_LINK_TCP == 1
 #define TCP_SCHEMA "tcp"
@@ -71,5 +75,9 @@ _z_string_t _z_endpoint_to_string(const _z_endpoint_t *e);
 z_result_t _z_endpoint_from_string(_z_endpoint_t *ep, _z_string_t *s);
 void _z_endpoint_clear(_z_endpoint_t *ep);
 void _z_endpoint_free(_z_endpoint_t **ep);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_LINK_ENDPOINT_H */

--- a/include/zenoh-pico/link/link.h
+++ b/include/zenoh-pico/link/link.h
@@ -46,6 +46,10 @@
 
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Link transport capability enum.
  *
@@ -143,5 +147,9 @@ z_result_t _z_listen_link(_z_link_t *zl, _z_string_t *locator);
 z_result_t _z_link_send_wbuf(const _z_link_t *zl, const _z_wbuf_t *wbf);
 size_t _z_link_recv_zbuf(const _z_link_t *zl, _z_zbuf_t *zbf, _z_slice_t *addr);
 size_t _z_link_recv_exact_zbuf(const _z_link_t *zl, _z_zbuf_t *zbf, size_t len, _z_slice_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_LINK_H */

--- a/include/zenoh-pico/link/manager.h
+++ b/include/zenoh-pico/link/manager.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/link/link.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_TCP == 1
 z_result_t _z_endpoint_tcp_valid(_z_endpoint_t *ep);
 z_result_t _z_new_link_tcp(_z_link_t *zl, _z_endpoint_t *ep);
@@ -42,6 +46,10 @@ z_result_t _z_new_link_serial(_z_link_t *zl, _z_endpoint_t ep);
 #if Z_FEATURE_LINK_WS == 1
 z_result_t _z_endpoint_ws_valid(_z_endpoint_t *ep);
 z_result_t _z_new_link_ws(_z_link_t *zl, _z_endpoint_t *ep);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_LINK_MANAGER_H */

--- a/include/zenoh-pico/net/config.h
+++ b/include/zenoh-pico/net/config.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/utils/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Create an empty set of properties for zenoh-net session configuration.
  *
@@ -49,5 +53,9 @@ z_result_t _z_config_default(_z_config_t *config);
  *     `0`` in case of success, or a ``negative value`` otherwise.
  */
 z_result_t _z_config_client(_z_config_t *config, const char *locator);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_CONFIG_NETAPI_H */

--- a/include/zenoh-pico/net/encoding.h
+++ b/include/zenoh-pico/net/encoding.h
@@ -17,6 +17,10 @@
 #include "zenoh-pico/api/constants.h"
 #include "zenoh-pico/collections/string.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _Z_ENCODING_ID_DEFAULT 0
 
 /**
@@ -35,5 +39,9 @@ bool _z_encoding_check(const _z_encoding_t *encoding);
 z_result_t _z_encoding_copy(_z_encoding_t *dst, const _z_encoding_t *src);
 void _z_encoding_move(_z_encoding_t *dst, _z_encoding_t *src);
 _z_encoding_t _z_encoding_steal(_z_encoding_t *val);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_ENCODING_NETAPI_H */

--- a/include/zenoh-pico/net/filtering.h
+++ b/include/zenoh-pico/net/filtering.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
     WRITE_FILTER_INIT = 0,
     WRITE_FILTER_ACTIVE = 1,
@@ -44,5 +48,9 @@ typedef struct _z_publisher_t _z_publisher_t;
 z_result_t _z_write_filter_create(_z_publisher_t *pub);
 z_result_t _z_write_filter_destroy(_z_publisher_t *pub);
 bool _z_write_filter_active(const _z_publisher_t *pub);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_FILTERING_NETAPI_H */

--- a/include/zenoh-pico/net/logger.h
+++ b/include/zenoh-pico/net/logger.h
@@ -15,9 +15,17 @@
 #ifndef ZENOH_PICO_LOGGER_NETAPI_H
 #define ZENOH_PICO_LOGGER_NETAPI_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Initialise the zenoh runtime logger
  */
 void _z_init_logger(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_LOGGER_NETAPI_H */

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -26,6 +26,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/utils/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Discovery ------------------*/
 
 /**
@@ -255,6 +259,10 @@ z_result_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *paramete
 uint32_t _z_add_interest(_z_session_t *zn, _z_keyexpr_t keyexpr, _z_interest_handler_t callback, uint8_t flags,
                          void *arg);
 z_result_t _z_remove_interest(_z_session_t *zn, uint32_t interest_id);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PRIMITIVES_H */

--- a/include/zenoh-pico/net/publish.h
+++ b/include/zenoh-pico/net/publish.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return type when declaring a publisher.
  */
@@ -41,6 +45,10 @@ void _z_publisher_clear(_z_publisher_t *pub);
 void _z_publisher_free(_z_publisher_t **pub);
 bool _z_publisher_check(const _z_publisher_t *publisher);
 _z_publisher_t _z_publisher_null(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_PUBLISH_H */

--- a/include/zenoh-pico/net/query.h
+++ b/include/zenoh-pico/net/query.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The query to be answered by a queryable.
  */
@@ -56,6 +60,10 @@ void _z_queryable_clear(_z_queryable_t *qbl);
 void _z_queryable_free(_z_queryable_t **qbl);
 _z_queryable_t _z_queryable_null(void);
 bool _z_queryable_check(const _z_queryable_t *queryable);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_QUERY_NETAPI_H */

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -23,6 +23,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/session/session.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Reply tag values.
  *
@@ -96,5 +100,9 @@ void _z_pending_reply_clear(_z_pending_reply_t *res);
 
 _Z_ELEM_DEFINE(_z_pending_reply, _z_pending_reply_t, _z_noop_size, _z_pending_reply_clear, _z_noop_copy)
 _Z_LIST_DEFINE(_z_pending_reply, _z_pending_reply_t)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_REPLY_NETAPI_H */

--- a/include/zenoh-pico/net/sample.h
+++ b/include/zenoh-pico/net/sample.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/session/session.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * A zenoh-net data sample.
  *
@@ -58,5 +62,8 @@ _z_sample_t _z_sample_duplicate(const _z_sample_t *src);
 _z_sample_t _z_sample_create(_z_keyexpr_t *key, const _z_bytes_t payload, const _z_timestamp_t *timestamp,
                              _z_encoding_t *encoding, const z_sample_kind_t kind, const _z_qos_t qos,
                              const _z_bytes_t attachment, z_reliability_t reliability);
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SAMPLE_NETAPI_H */

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -24,6 +24,10 @@
 #include "zenoh-pico/session/session.h"
 #include "zenoh-pico/utils/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * A zenoh-net session.
  */
@@ -198,5 +202,9 @@ z_result_t _zp_start_lease_task(_z_session_t *z, z_task_attr_t *attr);
  */
 z_result_t _zp_stop_lease_task(_z_session_t *z);
 #endif  // Z_FEATURE_MULTI_THREAD == 1
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_NET_SESSION_H */

--- a/include/zenoh-pico/net/subscribe.h
+++ b/include/zenoh-pico/net/subscribe.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Return type when declaring a subscriber.
  */
@@ -34,6 +38,10 @@ void _z_subscriber_clear(_z_subscriber_t *sub);
 void _z_subscriber_free(_z_subscriber_t **sub);
 bool _z_subscriber_check(const _z_subscriber_t *subscriber);
 _z_subscriber_t _z_subscriber_null(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SUBSCRIBE_NETAPI_H */

--- a/include/zenoh-pico/protocol/codec/core.h
+++ b/include/zenoh-pico/protocol/codec/core.h
@@ -24,6 +24,10 @@
 #include "zenoh-pico/utils/config.h"
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef z_result_t (*__z_single_byte_reader_t)(uint8_t *, void *context);
 /*------------------ Internal Zenoh-net Macros ------------------*/
 z_result_t _z_consolidation_mode_encode(_z_wbuf_t *wbf, z_consolidation_mode_t en);
@@ -83,5 +87,9 @@ z_result_t _z_keyexpr_decode(_z_keyexpr_t *ke, _z_zbuf_t *buf, bool has_suffix);
 z_result_t _z_timestamp_encode(_z_wbuf_t *buf, const _z_timestamp_t *ts);
 z_result_t _z_timestamp_encode_ext(_z_wbuf_t *buf, const _z_timestamp_t *ts);
 z_result_t _z_timestamp_decode(_z_timestamp_t *ts, _z_zbuf_t *buf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_CORE_H */

--- a/include/zenoh-pico/protocol/codec/declarations.h
+++ b/include/zenoh-pico/protocol/codec/declarations.h
@@ -17,6 +17,11 @@
 
 #include "zenoh-pico/protocol/definitions/declarations.h"
 #include "zenoh-pico/protocol/iobuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _Z_DECL_KEXPR_MID 0
 #define _Z_DECL_KEXPR_FLAG_N 0x20
 #define _Z_UNDECL_KEXPR_MID 1
@@ -49,5 +54,9 @@ z_result_t _z_undecl_token_decode(_z_undecl_token_t *decl, _z_zbuf_t *zbf, uint8
 
 z_result_t _z_declaration_encode(_z_wbuf_t *wbf, const _z_declaration_t *decl);
 z_result_t _z_declaration_decode(_z_declaration_t *decl, _z_zbuf_t *zbf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_DECLARATIONS_H */

--- a/include/zenoh-pico/protocol/codec/ext.h
+++ b/include/zenoh-pico/protocol/codec/ext.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/protocol/ext.h"
 #include "zenoh-pico/protocol/iobuf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Message Extension ------------------*/
 z_result_t _z_msg_ext_encode(_z_wbuf_t *wbf, const _z_msg_ext_t *ext, bool has_next);
 z_result_t _z_msg_ext_decode(_z_msg_ext_t *ext, _z_zbuf_t *zbf, bool *has_next);
@@ -65,5 +69,9 @@ z_result_t _z_msg_ext_decode_zint_na(_z_msg_ext_zint_t *pld, _z_zbuf_t *zbf);
 z_result_t _z_msg_ext_encode_zbuf(_z_wbuf_t *wbf, const _z_msg_ext_zbuf_t *pld);
 z_result_t _z_msg_ext_decode_zbuf(_z_msg_ext_zbuf_t *pld, _z_zbuf_t *zbf);
 z_result_t _z_msg_ext_decode_zbuf_na(_z_msg_ext_zbuf_t *pld, _z_zbuf_t *zbf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TEST_H */

--- a/include/zenoh-pico/protocol/codec/interest.h
+++ b/include/zenoh-pico/protocol/codec/interest.h
@@ -18,7 +18,15 @@
 #include "zenoh-pico/protocol/definitions/interest.h"
 #include "zenoh-pico/protocol/iobuf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_interest_encode(_z_wbuf_t *wbf, const _z_interest_t *interest, bool is_final);
 z_result_t _z_interest_decode(_z_interest_t *decl, _z_zbuf_t *zbf, bool is_final, bool has_ext);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_DECLARATIONS_H */

--- a/include/zenoh-pico/protocol/codec/message.h
+++ b/include/zenoh-pico/protocol/codec/message.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/protocol/definitions/network.h"
 #include "zenoh-pico/protocol/iobuf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_push_body_encode(_z_wbuf_t *wbf, const _z_push_body_t *pshb);
 z_result_t _z_push_body_decode(_z_push_body_t *body, _z_zbuf_t *zbf, uint8_t header);
 
@@ -35,5 +39,9 @@ z_result_t _z_put_decode(_z_msg_put_t *put, _z_zbuf_t *zbf, uint8_t header);
 
 z_result_t _z_del_encode(_z_wbuf_t *wbf, const _z_msg_del_t *del);
 z_result_t _z_del_decode(_z_msg_del_t *del, _z_zbuf_t *zbf, uint8_t header);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_MESSAGE_H */

--- a/include/zenoh-pico/protocol/codec/network.h
+++ b/include/zenoh-pico/protocol/codec/network.h
@@ -19,6 +19,11 @@
 
 #include "zenoh-pico/protocol/definitions/network.h"
 #include "zenoh-pico/protocol/iobuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_push_encode(_z_wbuf_t *wbf, const _z_n_msg_push_t *msg);
 z_result_t _z_push_decode(_z_n_msg_push_t *msg, _z_zbuf_t *zbf, uint8_t header);
 z_result_t _z_request_encode(_z_wbuf_t *wbf, const _z_n_msg_request_t *msg);
@@ -34,5 +39,9 @@ z_result_t _z_n_interest_decode(_z_n_msg_interest_t *interest, _z_zbuf_t *zbf, u
 
 z_result_t _z_network_message_encode(_z_wbuf_t *wbf, const _z_network_message_t *msg);
 z_result_t _z_network_message_decode(_z_network_message_t *msg, _z_zbuf_t *zbf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_NETWORK_H */

--- a/include/zenoh-pico/protocol/codec/transport.h
+++ b/include/zenoh-pico/protocol/codec/transport.h
@@ -17,6 +17,11 @@
 
 #include "zenoh-pico/protocol/definitions/transport.h"
 #include "zenoh-pico/protocol/iobuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _ZENOH_PICO_FRAME_MESSAGES_VEC_SIZE 32
 
 z_result_t _z_scouting_message_encode(_z_wbuf_t *buf, const _z_scouting_message_t *msg);
@@ -48,4 +53,9 @@ z_result_t _z_fragment_decode(_z_t_msg_fragment_t *msg, _z_zbuf_t *zbf, uint8_t 
 
 z_result_t _z_transport_message_encode(_z_wbuf_t *wbf, const _z_transport_message_t *msg);
 z_result_t _z_transport_message_decode(_z_transport_message_t *msg, _z_zbuf_t *zbf);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CODEC_TRANSPORT_H */

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -29,6 +29,10 @@
 #include "zenoh-pico/net/encoding.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _Z_OPTIONAL
 #define _Z_MOVE(x) x *
 
@@ -208,5 +212,9 @@ typedef struct {
     uint32_t _request_id;
     uint32_t _entity_id;
 } _z_reply_context_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_CORE_H */

--- a/include/zenoh-pico/protocol/definitions/declarations.h
+++ b/include/zenoh-pico/protocol/definitions/declarations.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/keyexpr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     uint16_t _id;
     _z_keyexpr_t _keyexpr;
@@ -112,5 +116,9 @@ _z_declaration_t _z_make_decl_token(_Z_MOVE(_z_keyexpr_t) key, uint32_t id);
 _z_declaration_t _z_make_undecl_token(uint32_t id, _Z_OPTIONAL const _z_keyexpr_t* key);
 
 _z_declaration_t _z_make_decl_final(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_DECLARATIONS_H */

--- a/include/zenoh-pico/protocol/definitions/interest.h
+++ b/include/zenoh-pico/protocol/definitions/interest.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/keyexpr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _Z_INTEREST_FLAG_KEYEXPRS (1)
 #define _Z_INTEREST_FLAG_SUBSCRIBERS (1 << 1)
 #define _Z_INTEREST_FLAG_QUERYABLES (1 << 2)
@@ -42,5 +46,9 @@ void _z_interest_clear(_z_interest_t* decl);
 
 _z_interest_t _z_make_interest(_Z_MOVE(_z_keyexpr_t) key, uint32_t id, uint8_t flags);
 _z_interest_t _z_make_interest_final(uint32_t id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_INTEREST_H */

--- a/include/zenoh-pico/protocol/definitions/message.h
+++ b/include/zenoh-pico/protocol/definitions/message.h
@@ -18,6 +18,11 @@
 #include "zenoh-pico/net/encoding.h"
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/definitions/core.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Zenoh Messages */
 #define _Z_MID_Z_OAM 0x00
 #define _Z_MID_Z_PUT 0x01
@@ -139,5 +144,9 @@ typedef struct {
 } _z_msg_reply_t;
 void _z_msg_reply_clear(_z_msg_reply_t *msg);
 #define _Z_FLAG_Z_R_C 0x20
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_MESSAGE_H */

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -25,6 +25,11 @@
 #include "zenoh-pico/protocol/definitions/message.h"
 #include "zenoh-pico/protocol/ext.h"
 #include "zenoh-pico/protocol/keyexpr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Network Messages */
 #define _Z_MID_N_OAM 0x1f
 #define _Z_MID_N_DECLARE 0x1e
@@ -300,5 +305,9 @@ _z_network_message_t _z_n_msg_make_response_final(_z_zint_t rid);
 _z_network_message_t _z_n_msg_make_declare(_z_declaration_t declaration, bool has_interest_id, uint32_t interest_id);
 _z_network_message_t _z_n_msg_make_push(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_push_body_t) body);
 _z_network_message_t _z_n_msg_make_interest(_z_interest_t interest);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_NETWORK_H */

--- a/include/zenoh-pico/protocol/definitions/transport.h
+++ b/include/zenoh-pico/protocol/definitions/transport.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/link/endpoint.h"
 #include "zenoh-pico/protocol/definitions/network.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _Z_MID_SCOUT 0x01
 #define _Z_MID_HELLO 0x02
 
@@ -540,5 +544,9 @@ _z_scouting_message_t _z_s_msg_make_hello(z_whatami_t whatami, _z_id_t zid, _z_l
 void _z_s_msg_copy(_z_scouting_message_t *clone, _z_scouting_message_t *msg);
 void _z_s_msg_copy_scout(_z_s_msg_scout_t *clone, _z_s_msg_scout_t *msg);
 void _z_s_msg_copy_hello(_z_s_msg_hello_t *clone, _z_s_msg_hello_t *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_TRANSPORT_H */

--- a/include/zenoh-pico/protocol/ext.h
+++ b/include/zenoh-pico/protocol/ext.h
@@ -20,6 +20,10 @@
 
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*=============================*/
 /*       Message header        */
 /*=============================*/
@@ -98,5 +102,9 @@ void _z_msg_ext_copy_zbuf(_z_msg_ext_zbuf_t *clone, const _z_msg_ext_zbuf_t *ext
 
 _Z_ELEM_DEFINE(_z_msg_ext, _z_msg_ext_t, _z_noop_size, _z_msg_ext_clear, _z_msg_ext_copy)
 _Z_VEC_DEFINE(_z_msg_ext, _z_msg_ext_t)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_PROTOCOL_EXTENSION_H */

--- a/include/zenoh-pico/protocol/iobuf.h
+++ b/include/zenoh-pico/protocol/iobuf.h
@@ -23,6 +23,10 @@
 #include "zenoh-pico/collections/slice.h"
 #include "zenoh-pico/collections/vec.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ IOSli ------------------*/
 
 typedef struct {
@@ -128,5 +132,9 @@ void _z_wbuf_copy(_z_wbuf_t *dst, const _z_wbuf_t *src);
 void _z_wbuf_reset(_z_wbuf_t *wbf);
 void _z_wbuf_clear(_z_wbuf_t *wbf);
 void _z_wbuf_free(_z_wbuf_t **wbf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_PROTOCOL_IOBUF_H */

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/api/constants.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 zp_keyexpr_canon_status_t _z_keyexpr_is_canon(const char *start, size_t len);
 zp_keyexpr_canon_status_t _z_keyexpr_canonize(char *start, size_t *len);
 bool _z_keyexpr_suffix_includes(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
@@ -44,5 +48,9 @@ bool _z_keyexpr_equals(const _z_keyexpr_t *left, const _z_keyexpr_t *right);
 void _z_keyexpr_move(_z_keyexpr_t *dst, _z_keyexpr_t *src);
 void _z_keyexpr_clear(_z_keyexpr_t *rk);
 void _z_keyexpr_free(_z_keyexpr_t **rk);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_KEYEXPR_H */

--- a/include/zenoh-pico/session/interest.h
+++ b/include/zenoh-pico/session/interest.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/net/session.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_INTEREST == 1
 _z_session_interest_rc_t *_z_get_interest_by_id(_z_session_t *zn, const _z_zint_t id);
 _z_session_interest_rc_t *_z_register_interest(_z_session_t *zn, _z_session_interest_t *intr);
@@ -31,5 +35,9 @@ z_result_t _z_interest_process_undeclares(_z_session_t *zn, const _z_declaration
 z_result_t _z_interest_process_declare_final(_z_session_t *zn, uint32_t id);
 z_result_t _z_interest_process_interest_final(_z_session_t *zn, uint32_t id);
 z_result_t _z_interest_process_interest(_z_session_t *zn, _z_keyexpr_t key, uint32_t id, uint8_t flags);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SESSION_INTEREST_H */

--- a/include/zenoh-pico/session/push.h
+++ b/include/zenoh-pico/session/push.h
@@ -21,6 +21,14 @@
 #ifndef ZENOH_PICO_SESSION_PUSH_H
 #define ZENOH_PICO_SESSION_PUSH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_trigger_push(_z_session_t *zn, _z_n_msg_push_t *push, z_reliability_t reliability);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SESSION_PUSH_H */

--- a/include/zenoh-pico/session/query.h
+++ b/include/zenoh-pico/session/query.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_QUERY == 1
 /*------------------ Query ------------------*/
 _z_zint_t _z_get_query_id(_z_session_t *zn);
@@ -31,6 +35,10 @@ z_result_t _z_trigger_query_reply_err(_z_session_t *zn, _z_zint_t id, _z_msg_err
 z_result_t _z_trigger_query_reply_final(_z_session_t *zn, _z_zint_t id);
 void _z_unregister_pending_query(_z_session_t *zn, _z_pending_query_t *pq);
 void _z_flush_pending_queries(_z_session_t *zn);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SESSION_QUERY_H */

--- a/include/zenoh-pico/session/reply.h
+++ b/include/zenoh-pico/session/reply.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/protocol/definitions/message.h"
 #include "zenoh-pico/protocol/definitions/network.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef ZENOH_PICO_SESSION_REPLY_H
 #define ZENOH_PICO_SESSION_REPLY_H
 
@@ -27,5 +31,9 @@ z_result_t _z_trigger_reply_partial(_z_session_t *zn, _z_zint_t id, _z_keyexpr_t
 z_result_t _z_trigger_reply_err(_z_session_t *zn, _z_zint_t id, _z_msg_err_t *error);
 
 z_result_t _z_trigger_reply_final(_z_session_t *zn, _z_n_msg_response_final_t *final);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SESSION_REPLY_H */

--- a/include/zenoh-pico/session/resource.h
+++ b/include/zenoh-pico/session/resource.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/net/session.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Entity ------------------*/
 uint32_t _z_get_entity_id(_z_session_t *zn);
 
@@ -35,5 +39,9 @@ void _z_flush_resources(_z_session_t *zn);
 _z_keyexpr_t __unsafe_z_get_expanded_key_from_key(_z_session_t *zn, const _z_keyexpr_t *keyexpr);
 _z_resource_t *__unsafe_z_get_resource_by_id(_z_session_t *zn, uint16_t mapping, _z_zint_t id);
 _z_resource_t *__unsafe_z_get_resource_matching_key(_z_session_t *zn, const _z_keyexpr_t *keyexpr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_SESSION_RESOURCE_H */

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -26,6 +26,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/transport/manager.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The callback signature of the cleanup functions.
  */
@@ -202,5 +206,9 @@ typedef struct {
 void _z_declare_data_clear(_z_declare_data_t *data);
 _Z_ELEM_DEFINE(_z_declare_data, _z_declare_data_t, _z_noop_size, _z_declare_data_clear, _z_noop_copy)
 _Z_LIST_DEFINE(_z_declare_data, _z_declare_data_t)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_SESSION_SESSION_H */

--- a/include/zenoh-pico/session/subscription.h
+++ b/include/zenoh-pico/session/subscription.h
@@ -18,6 +18,10 @@
 #include "zenoh-pico/net/encoding.h"
 #include "zenoh-pico/net/session.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Subscription ------------------*/
 void _z_trigger_local_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes_t payload,
                                     _z_encoding_t *encoding, const _z_n_qos_t qos, const _z_timestamp_t *timestamp,
@@ -33,6 +37,10 @@ z_result_t _z_trigger_subscriptions(_z_session_t *zn, const _z_keyexpr_t keyexpr
                                     const _z_n_qos_t qos, const _z_bytes_t attachment, z_reliability_t reliability);
 void _z_unregister_subscription(_z_session_t *zn, uint8_t is_local, _z_subscription_rc_t *sub);
 void _z_flush_subscriptions(_z_session_t *zn);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INCLUDE_ZENOH_PICO_SESSION_SUBSCRIPTION_H */

--- a/include/zenoh-pico/session/utils.h
+++ b/include/zenoh-pico/session/utils.h
@@ -22,6 +22,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/protocol/core.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Session ------------------*/
 _z_hello_list_t *_z_scout_inner(const z_what_t what, _z_id_t id, _z_string_t *locator, const uint32_t timeout,
                                 const bool exit_on_first);
@@ -36,5 +40,9 @@ z_result_t _z_send_n_msg(_z_session_t *zn, _z_network_message_t *n_msg, z_reliab
 
 void _zp_session_lock_mutex(_z_session_t *zn);
 void _zp_session_unlock_mutex(_z_session_t *zn);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_SESSION_UTILS_H */

--- a/include/zenoh-pico/system/link/raweth.h
+++ b/include/zenoh-pico/system/link/raweth.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_RAWETH_TRANSPORT == 1
 
 // Ethernet types (big endian)
@@ -90,6 +94,10 @@ z_result_t _z_close_raweth(_z_sys_net_socket_t *sock);
 uint16_t _z_raweth_ntohs(uint16_t val);
 uint16_t _z_raweth_htons(uint16_t val);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SYSTEM_LINK_RAWETH_H */

--- a/include/zenoh-pico/system/link/serial.h
+++ b/include/zenoh-pico/system/link/serial.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_SERIAL == 1
 
 #define _Z_SERIAL_MTU_SIZE 1500
@@ -41,6 +45,10 @@ size_t _z_read_exact_serial(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t
 size_t _z_read_serial(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len);
 size_t _z_send_serial(const _z_sys_net_socket_t sock, const uint8_t *ptr, size_t len);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SYSTEM_LINK_BT_H */

--- a/include/zenoh-pico/system/link/tcp.h
+++ b/include/zenoh-pico/system/link/tcp.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_TCP == 1
 
 typedef struct {
@@ -36,6 +40,10 @@ void _z_close_tcp(_z_sys_net_socket_t *sock);
 size_t _z_read_exact_tcp(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len);
 size_t _z_read_tcp(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len);
 size_t _z_send_tcp(const _z_sys_net_socket_t sock, const uint8_t *ptr, size_t len);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SYSTEM_LINK_TCP_H */

--- a/include/zenoh-pico/system/link/udp.h
+++ b/include/zenoh-pico/system/link/udp.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_UDP_UNICAST == 1 || Z_FEATURE_LINK_UDP_MULTICAST == 1
 
 typedef struct {
@@ -54,6 +58,10 @@ size_t _z_read_udp_multicast(const _z_sys_net_socket_t sock, uint8_t *ptr, size_
                              _z_slice_t *ep);
 size_t _z_send_udp_multicast(const _z_sys_net_socket_t sock, const uint8_t *ptr, size_t len,
                              const _z_sys_net_endpoint_t rep);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SYSTEM_LINK_UDP_H */

--- a/include/zenoh-pico/system/link/ws.h
+++ b/include/zenoh-pico/system/link/ws.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/system/platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_LINK_WS == 1
 
 typedef struct {
@@ -36,6 +40,10 @@ void _z_close_ws(_z_sys_net_socket_t *sock);
 size_t _z_read_exact_ws(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len);
 size_t _z_read_ws(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len);
 size_t _z_send_ws(const _z_sys_net_socket_t sock, const uint8_t *ptr, size_t len);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZENOH_PICO_SYSTEM_LINK_WS_H */

--- a/include/zenoh-pico/system/platform/arduino/esp32.h
+++ b/include/zenoh-pico/system/platform/arduino/esp32.h
@@ -21,6 +21,10 @@
 #include <pthread.h>
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef void *_z_task_t;
 typedef void *z_task_attr_t;  // Not used in ESP32
@@ -55,5 +59,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_ESP32_TYPES_H */

--- a/include/zenoh-pico/system/platform/arduino/opencr.h
+++ b/include/zenoh-pico/system/platform/arduino/opencr.h
@@ -20,6 +20,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef void *_z_task_t;
 typedef void *z_task_attr_t;
@@ -59,5 +63,9 @@ typedef struct {
     };
     bool _err;
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_ARDUINO_OPENCR_TYPES_H */

--- a/include/zenoh-pico/system/platform/emscripten.h
+++ b/include/zenoh-pico/system/platform/emscripten.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 #include <pthread.h>
 
@@ -49,5 +53,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_WASM_TYPES_H */

--- a/include/zenoh-pico/system/platform/espidf.h
+++ b/include/zenoh-pico/system/platform/espidf.h
@@ -22,6 +22,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 #include <pthread.h>
 
@@ -68,5 +72,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_ESPIDF_TYPES_H */

--- a/include/zenoh-pico/system/platform/flipper.h
+++ b/include/zenoh-pico/system/platform/flipper.h
@@ -21,6 +21,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define FLIPPER_DEFAULT_THREAD_STACK_SIZE 2048
 #define FLIPPER_SERIAL_STREAM_BUFFER_SIZE 512
 #define FLIPPER_SERIAL_STREAM_TRIGGERED_LEVEL 10
@@ -42,5 +46,9 @@ typedef struct {
     FuriHalSerialHandle* _serial;
 #endif
 } _z_sys_net_socket_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_FLIPPER_TYPES_H */

--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -18,6 +18,10 @@
 #include "FreeRTOS_IP.h"
 #include "semphr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef struct {
     const char *name;
@@ -57,5 +61,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/zenoh-pico/system/platform/mbed.h
+++ b/include/zenoh-pico/system/platform/mbed.h
@@ -20,6 +20,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int _z_socket_t;
 
 #if Z_FEATURE_MULTI_THREAD == 1
@@ -60,5 +64,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_MBED_TYPES_H */

--- a/include/zenoh-pico/system/platform/unix.h
+++ b/include/zenoh-pico/system/platform/unix.h
@@ -19,12 +19,17 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/time.h>
+#if Z_FEATURE_MULTI_THREAD == 1
+#include <pthread.h>
+#endif  // Z_FEATURE_MULTI_THREAD == 1
 
 #include "zenoh-pico/config.h"
 
-#if Z_FEATURE_MULTI_THREAD == 1
-#include <pthread.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+#if Z_FEATURE_MULTI_THREAD == 1
 typedef pthread_t _z_task_t;
 typedef pthread_attr_t z_task_attr_t;
 typedef pthread_mutex_t _z_mutex_t;
@@ -50,5 +55,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_UNIX_TYPES_H */

--- a/include/zenoh-pico/system/platform/void.h
+++ b/include/zenoh-pico/system/platform/void.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef void *_z_task_t;
 typedef void *z_task_attr_t;
@@ -26,5 +30,9 @@ typedef void *_z_condvar_t;
 
 typedef void *z_clock_t;
 typedef void *z_time_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_VOID_H */

--- a/include/zenoh-pico/system/platform/windows.h
+++ b/include/zenoh-pico/system/platform/windows.h
@@ -20,6 +20,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef HANDLE *_z_task_t;
 typedef void *z_task_attr_t;  // Not used in Windows
@@ -47,5 +51,9 @@ typedef struct {
 } _z_sys_net_endpoint_t;
 
 inline void __asm__(char *instruction) { (void)(instruction); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_VOID_H */

--- a/include/zenoh-pico/system/platform/zephyr.h
+++ b/include/zenoh-pico/system/platform/zephyr.h
@@ -30,6 +30,10 @@
 
 #include "zenoh-pico/config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
 typedef pthread_t _z_task_t;
 typedef pthread_attr_t z_task_attr_t;
@@ -58,5 +62,9 @@ typedef struct {
 #endif
     };
 } _z_sys_net_endpoint_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_SYSTEM_ZEPHYR_TYPES_H */

--- a/include/zenoh-pico/transport/common/lease.h
+++ b/include/zenoh-pico/transport/common/lease.h
@@ -17,7 +17,15 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_send_join(_z_transport_t *zt);
 z_result_t _z_send_keep_alive(_z_transport_t *zt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_LEASE_H */

--- a/include/zenoh-pico/transport/common/read.h
+++ b/include/zenoh-pico/transport/common/read.h
@@ -17,7 +17,15 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_read(_z_transport_t *zt);
 void *_zp_read_task(void *zt_arg);  // The argument is void* to avoid incompatible pointer types in tasks
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_READ_H */

--- a/include/zenoh-pico/transport/common/rx.h
+++ b/include/zenoh-pico/transport/common/rx.h
@@ -18,8 +18,16 @@
 #include "zenoh-pico/link/link.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ Transmission and Reception helpers ------------------*/
 size_t _z_read_stream_size(_z_zbuf_t *zbuf);
 z_result_t _z_link_recv_t_msg(_z_transport_message_t *t_msg, const _z_link_t *zl);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_RX_H */

--- a/include/zenoh-pico/transport/common/tx.h
+++ b/include/zenoh-pico/transport/common/tx.h
@@ -19,6 +19,10 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void __unsafe_z_prepare_wbuf(_z_wbuf_t *buf, uint8_t link_flow_capability);
 void __unsafe_z_finalize_wbuf(_z_wbuf_t *buf, uint8_t link_flow_capability);
 /*This function is unsafe because it operates in potentially concurrent
@@ -28,5 +32,9 @@ z_result_t __unsafe_z_serialize_zenoh_fragment(_z_wbuf_t *dst, _z_wbuf_t *src, z
 /*------------------ Transmission and Reception helpers ------------------*/
 z_result_t _z_send_t_msg(_z_transport_t *zt, const _z_transport_message_t *t_msg);
 z_result_t _z_link_send_t_msg(const _z_link_t *zl, const _z_transport_message_t *t_msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_TX_H */

--- a/include/zenoh-pico/transport/manager.h
+++ b/include/zenoh-pico/transport/manager.h
@@ -19,7 +19,15 @@
 #include "zenoh-pico/link/manager.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_new_transport(_z_transport_t *zt, _z_id_t *bs, _z_string_t *locator, z_whatami_t mode);
 void _z_free_transport(_z_transport_t **zt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_TRANSPORT_MANAGER_H */

--- a/include/zenoh-pico/transport/multicast.h
+++ b/include/zenoh-pico/transport/multicast.h
@@ -17,7 +17,15 @@
 
 #include "zenoh-pico/api/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void _zp_multicast_fetch_zid(const _z_transport_t *zt, _z_closure_zid_t *callback);
 void _zp_multicast_info_session(const _z_transport_t *zt, _z_config_t *ps);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_MULTICAST_H */

--- a/include/zenoh-pico/transport/multicast/lease.h
+++ b/include/zenoh-pico/transport/multicast/lease.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _zp_multicast_send_join(_z_transport_multicast_t *ztm);
 z_result_t _zp_multicast_send_keep_alive(_z_transport_multicast_t *ztm);
 z_result_t _zp_multicast_stop_lease_task(_z_transport_multicast_t *ztm);
@@ -27,5 +31,9 @@ z_result_t _zp_multicast_start_lease_task(_z_transport_multicast_t *ztm, z_task_
 #else
 z_result_t _zp_multicast_start_lease_task(_z_transport_multicast_t *ztm, void *attr, void *task);
 #endif /* Z_FEATURE_MULTI_THREAD == 1 &&  (Z_FEATURE_MULTICAST_TRANSPORT == 1 || Z_FEATURE_RAWETH_TRANSPORT == 1) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_MULTICAST_LEASE_H */

--- a/include/zenoh-pico/transport/multicast/read.h
+++ b/include/zenoh-pico/transport/multicast/read.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _zp_multicast_read(_z_transport_multicast_t *ztm);
 z_result_t _zp_multicast_stop_read_task(_z_transport_t *zt);
 void *_zp_multicast_read_task(void *ztm_arg);  // The argument is void* to avoid incompatible pointer types in tasks
@@ -26,5 +30,9 @@ z_result_t _zp_multicast_start_read_task(_z_transport_t *zt, z_task_attr_t *attr
 #else
 z_result_t _zp_multicast_start_read_task(_z_transport_t *zt, void *attr, void *task);
 #endif /* #if Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_MULTICAST_TRANSPORT == 1 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_MULTICAST_READ_H */

--- a/include/zenoh-pico/transport/multicast/rx.h
+++ b/include/zenoh-pico/transport/multicast/rx.h
@@ -17,8 +17,16 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_multicast_recv_t_msg(_z_transport_multicast_t *ztm, _z_transport_message_t *t_msg, _z_slice_t *addr);
 z_result_t _z_multicast_handle_transport_message(_z_transport_multicast_t *ztm, _z_transport_message_t *t_msg,
                                                  _z_slice_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_LINK_RX_H */

--- a/include/zenoh-pico/transport/multicast/transport.h
+++ b/include/zenoh-pico/transport/multicast/transport.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/api/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
                                          _z_transport_multicast_establish_param_t *param);
 z_result_t _z_multicast_open_peer(_z_transport_multicast_establish_param_t *param, const _z_link_t *zl,
@@ -26,4 +30,9 @@ z_result_t _z_multicast_open_client(_z_transport_multicast_establish_param_t *pa
 z_result_t _z_multicast_send_close(_z_transport_multicast_t *ztm, uint8_t reason, bool link_only);
 z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t reason);
 void _z_multicast_transport_clear(_z_transport_t *zt);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZENOH_PICO_MULTICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/multicast/tx.h
+++ b/include/zenoh-pico/transport/multicast/tx.h
@@ -18,8 +18,16 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                                    z_congestion_control_t cong_ctrl);
 z_result_t _z_multicast_send_t_msg(_z_transport_multicast_t *ztm, const _z_transport_message_t *t_msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_MULTICAST_TX_H */

--- a/include/zenoh-pico/transport/raweth/read.h
+++ b/include/zenoh-pico/transport/raweth/read.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm);
 z_result_t _zp_raweth_stop_read_task(_z_transport_t *zt);
 void *_zp_raweth_read_task(void *ztm_arg);  // The argument is void* to avoid incompatible pointer types in tasks
@@ -26,5 +30,9 @@ z_result_t _zp_raweth_start_read_task(_z_transport_t *zt, z_task_attr_t *attr, _
 #else
 z_result_t _zp_raweth_start_read_task(_z_transport_t *zt, void *attr, void *task);
 #endif /* Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_RAWETH_TRANSPORT == 1 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_RAWETH_READ_H */

--- a/include/zenoh-pico/transport/raweth/rx.h
+++ b/include/zenoh-pico/transport/raweth/rx.h
@@ -17,7 +17,15 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_raweth_recv_t_msg(_z_transport_multicast_t *ztm, _z_transport_message_t *t_msg, _z_slice_t *addr);
 z_result_t _z_raweth_recv_t_msg_na(_z_transport_multicast_t *ztm, _z_transport_message_t *t_msg, _z_slice_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_RAWETH_RX_H */

--- a/include/zenoh-pico/transport/raweth/tx.h
+++ b/include/zenoh-pico/transport/raweth/tx.h
@@ -18,9 +18,17 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_raweth_link_send_t_msg(const _z_link_t *zl, const _z_transport_message_t *t_msg);
 z_result_t _z_raweth_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                                 z_congestion_control_t cong_ctrl);
 z_result_t _z_raweth_send_t_msg(_z_transport_multicast_t *ztm, const _z_transport_message_t *t_msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_RAWETH_TX_H */

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -25,6 +25,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/definitions/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 #if Z_FEATURE_FRAGMENTATION == 1
     // Defragmentation buffers
@@ -181,5 +185,9 @@ typedef struct {
 z_result_t _z_transport_close(_z_transport_t *zt, uint8_t reason);
 void _z_transport_clear(_z_transport_t *zt);
 void _z_transport_free(_z_transport_t **zt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_TRANSPORT_TRANSPORT_H */

--- a/include/zenoh-pico/transport/unicast.h
+++ b/include/zenoh-pico/transport/unicast.h
@@ -17,7 +17,15 @@
 
 #include "zenoh-pico/api/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void _zp_unicast_fetch_zid(const _z_transport_t *zt, _z_closure_zid_t *callback);
 void _zp_unicast_info_session(const _z_transport_t *zt, _z_config_t *ps);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UNICAST_H */

--- a/include/zenoh-pico/transport/unicast/lease.h
+++ b/include/zenoh-pico/transport/unicast/lease.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _zp_unicast_send_keep_alive(_z_transport_unicast_t *ztu);
 z_result_t _zp_unicast_stop_lease_task(_z_transport_t *zt);
 void *_zp_unicast_lease_task(void *ztu_arg);  // The argument is void* to avoid incompatible pointer types in tasks
@@ -26,5 +30,9 @@ z_result_t _zp_unicast_start_lease_task(_z_transport_t *zt, z_task_attr_t *attr,
 #else
 z_result_t _zp_unicast_start_lease_task(_z_transport_t *zt, void *attr, void *task);
 #endif /* Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_LINK_TASK_LEASE_H */

--- a/include/zenoh-pico/transport/unicast/read.h
+++ b/include/zenoh-pico/transport/unicast/read.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu);
 z_result_t _zp_unicast_stop_read_task(_z_transport_t *zt);
 void *_zp_unicast_read_task(void *ztu_arg);  // The argument is void* to avoid incompatible pointer types in tasks
@@ -26,5 +30,9 @@ z_result_t _zp_unicast_start_read_task(_z_transport_t *zt, z_task_attr_t *attr, 
 #else
 z_result_t _zp_unicast_start_read_task(_z_transport_t *zt, void *attr, void *task);
 #endif /* Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UNICAST_READ_H */

--- a/include/zenoh-pico/transport/unicast/rx.h
+++ b/include/zenoh-pico/transport/unicast/rx.h
@@ -17,8 +17,16 @@
 
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_unicast_recv_t_msg(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg);
 z_result_t _z_unicast_recv_t_msg_na(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg);
 z_result_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UNICAST_RX_H */

--- a/include/zenoh-pico/transport/unicast/transport.h
+++ b/include/zenoh-pico/transport/unicast/transport.h
@@ -17,6 +17,10 @@
 
 #include "zenoh-pico/api/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_unicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
                                        _z_transport_unicast_establish_param_t *param);
 z_result_t _z_unicast_open_client(_z_transport_unicast_establish_param_t *param, const _z_link_t *zl,
@@ -26,4 +30,9 @@ z_result_t _z_unicast_open_peer(_z_transport_unicast_establish_param_t *param, c
 z_result_t _z_unicast_send_close(_z_transport_unicast_t *ztu, uint8_t reason, bool link_only);
 z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reason);
 void _z_unicast_transport_clear(_z_transport_t *zt);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZENOH_PICO_UNICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/unicast/tx.h
+++ b/include/zenoh-pico/transport/unicast/tx.h
@@ -18,8 +18,16 @@
 #include "zenoh-pico/net/session.h"
 #include "zenoh-pico/transport/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 z_result_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                                  z_congestion_control_t cong_ctrl);
 z_result_t _z_unicast_send_t_msg(_z_transport_unicast_t *ztu, const _z_transport_message_t *t_msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_LINK_TX_H */

--- a/include/zenoh-pico/transport/utils.h
+++ b/include/zenoh-pico/transport/utils.h
@@ -20,6 +20,10 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/definitions/transport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*------------------ SN helpers ------------------*/
 _z_zint_t _z_sn_max(uint8_t bits);
 _z_zint_t _z_sn_half(_z_zint_t sn);
@@ -30,5 +34,9 @@ _z_zint_t _z_sn_decrement(const _z_zint_t sn_resolution, const _z_zint_t sn);
 
 void _z_conduit_sn_list_copy(_z_conduit_sn_list_t *dst, const _z_conduit_sn_list_t *src);
 void _z_conduit_sn_list_decrement(const _z_zint_t sn_resolution, _z_conduit_sn_list_t *sns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_TRANSPORT_UTILS_H */

--- a/include/zenoh-pico/utils/checksum.h
+++ b/include/zenoh-pico/utils/checksum.h
@@ -18,6 +18,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint32_t _z_crc32(const uint8_t *message, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UTILS_CHECKSUM_H */

--- a/include/zenoh-pico/utils/config.h
+++ b/include/zenoh-pico/utils/config.h
@@ -21,6 +21,10 @@
 #include "zenoh-pico/collections/string.h"
 #include "zenoh-pico/utils/result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Properties returned by _z_info()
 #define Z_INFO_PID_KEY 0x00
 #define Z_INFO_PEER_PID_KEY 0x01
@@ -108,5 +112,9 @@ char *_z_config_get(const _z_config_t *ps, uint8_t key);
  *
  */
 #define _z_config_free _z_str_intmap_free
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UTILS_PROPERTY_H */

--- a/include/zenoh-pico/utils/encoding.h
+++ b/include/zenoh-pico/utils/encoding.h
@@ -18,7 +18,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 size_t _z_cobs_encode(const uint8_t *input, size_t input_len, uint8_t *output);
 size_t _z_cobs_decode(const uint8_t *input, size_t input_len, uint8_t *output);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UTILS_ENCODING_H */

--- a/include/zenoh-pico/utils/logging.h
+++ b/include/zenoh-pico/utils/logging.h
@@ -19,6 +19,10 @@
 
 #include "zenoh-pico/system/platform_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Logging values
 #define _Z_LOG_LVL_ERROR 1
 #define _Z_LOG_LVL_INFO 2
@@ -71,5 +75,9 @@ static inline void __z_print_timestamp(void) {
         }                                      \
     } while (false)
 #endif  // ZENOH_DEBUG == 0 && !defined(Z_BUILD_DEBUG)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // ZENOH_PICO_UTILS_LOGGING_H

--- a/include/zenoh-pico/utils/pointers.h
+++ b/include/zenoh-pico/utils/pointers.h
@@ -18,6 +18,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Computes the distance between two ``uint8_t`` pointers as an absolute value.
  * Note that ``l_ptr`` must be higher than ``r_ptr``.
@@ -91,5 +95,9 @@ const char *_z_cptr_char_offset(const char *ptr, ptrdiff_t off);
  *   Returns a ``char`` pointer, pointing to the offset position.
  */
 char *_z_ptr_char_offset(char *ptr, ptrdiff_t off);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UTILS_POINTERS_H */

--- a/include/zenoh-pico/utils/result.h
+++ b/include/zenoh-pico/utils/result.h
@@ -17,6 +17,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define _ZP_UNUSED(x) (void)(x)
 #define _ZP_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
@@ -105,5 +109,9 @@ typedef enum {
 
 #define _Z_IS_OK(expr) (expr == _Z_RES_OK)
 #define _Z_IS_ERR(expr) (expr != _Z_RES_OK)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZENOH_PICO_UTILS_RESULT_H */

--- a/include/zenoh-pico/utils/string.h
+++ b/include/zenoh-pico/utils/string.h
@@ -12,9 +12,16 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+#ifndef ZENOH_PICO_UTILS_STRING_H
+#define ZENOH_PICO_UTILS_STRING_H
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct {
     char const *start;
@@ -55,3 +62,9 @@ _z_str_se_t _z_splitstr_nextback(_z_splitstr_t *str);
 size_t _z_strcnt(char const *haystack_start, const char *harstack_end, const char *needle_start);
 
 size_t _z_str_startswith(const char *s, const char *needle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZENOH_PICO_UTILS_STRING_H */

--- a/include/zenoh-pico/utils/uuid.h
+++ b/include/zenoh-pico/utils/uuid.h
@@ -14,6 +14,13 @@
 
 #include <stdint.h>
 
+#ifndef ZENOH_PICO_UTILS_UUID_H
+#define ZENOH_PICO_UTILS_UUID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Converts an UUID in string format to a byte array.
  *
@@ -22,3 +29,9 @@
  *   uuid_str: A valid UUID string.
  */
 void _z_uuid_to_bytes(uint8_t *bytes, const char *uuid_str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZENOH_PICO_UTILS_UUID_H */


### PR DESCRIPTION
Partially closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/666

\+ missed include guard macros