### PR TITLE
Remove default parameters from z_closure

### DIFF
--- a/examples/espidf/z_get.c
+++ b/examples/espidf/z_get.c
@@ -169,7 +169,7 @@ void app_main() {
             opts.payload = z_move(payload);
         }
         z_owned_closure_reply_t callback;
-        z_closure(&callback, reply_handler, reply_dropper);
+        z_closure(&callback, reply_handler, reply_dropper, NULL);
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
         if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {

--- a/examples/espidf/z_queryable.c
+++ b/examples/espidf/z_queryable.c
@@ -169,7 +169,7 @@ void app_main() {
     // Declare Zenoh queryable
     printf("Declaring Queryable on %s...", KEYEXPR);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);

--- a/examples/espidf/z_sub.c
+++ b/examples/espidf/z_sub.c
@@ -151,7 +151,7 @@ void app_main() {
 
     printf("Declaring Subscriber on '%s'...", KEYEXPR);
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);

--- a/examples/freertos_plus_tcp/z_get.c
+++ b/examples/freertos_plus_tcp/z_get.c
@@ -93,7 +93,7 @@ void app_main(void) {
             opts.payload = z_move(payload);
         }
         z_owned_closure_reply_t callback;
-        z_closure(&callback, reply_handler, reply_dropper);
+        z_closure(&callback, reply_handler, reply_dropper, NULL);
         if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
             printf("Unable to send query.\n");
             return;

--- a/examples/freertos_plus_tcp/z_queryable.c
+++ b/examples/freertos_plus_tcp/z_queryable.c
@@ -85,7 +85,7 @@ void app_main(void) {
 
     printf("Creating Queryable on '%s'...\n", KEYEXPR);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");

--- a/examples/freertos_plus_tcp/z_sub.c
+++ b/examples/freertos_plus_tcp/z_sub.c
@@ -62,7 +62,7 @@ void app_main(void) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);

--- a/examples/freertos_plus_tcp/z_sub_st.c
+++ b/examples/freertos_plus_tcp/z_sub_st.c
@@ -59,7 +59,7 @@ void app_main(void) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", KEYEXPR);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);

--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_reply_t callback;
-    z_closure(&callback, reply_handler, reply_dropper);
+    z_closure(&callback, reply_handler, reply_dropper, NULL);
     if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
         printf("Unable to send query.\n");
         return -1;

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
     opts.encoding = z_move(encoding);
 
     z_owned_closure_reply_t callback;
-    z_closure(&callback, reply_handler, reply_dropper);
+    z_closure(&callback, reply_handler, reply_dropper, NULL);
     if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
         printf("Unable to send query.\n");
         return -1;

--- a/examples/unix/c11/z_info.c
+++ b/examples/unix/c11/z_info.c
@@ -86,14 +86,14 @@ int main(int argc, char **argv) {
 
     printf("Routers IDs:\n");
     z_owned_closure_zid_t callback;
-    z_closure(&callback, print_zid);
+    z_closure(&callback, print_zid, NULL, NULL);
     z_info_routers_zid(z_loan(s), z_move(callback));
 
     // `callback` has been `z_move`d just above, so it's safe to reuse the variable,
     // we'll just have to make sure we `z_move` it again to avoid mem-leaks.
     printf("Peers IDs:\n");
     z_owned_closure_zid_t callback2;
-    z_closure(&callback2, print_zid);
+    z_closure(&callback2, print_zid, NULL, NULL);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
     z_drop(z_move(s));

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
 
     printf("Creating Queryable on '%s'...\n", keyexpr);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
 
     printf("Creating Queryable on '%s'...\n", keyexpr);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;

--- a/examples/windows/z_get.c
+++ b/examples/windows/z_get.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         opts.payload = z_move(payload);
     }
     z_owned_closure_reply_t callback;
-    z_closure(&callback, reply_handler, reply_dropper);
+    z_closure(&callback, reply_handler, reply_dropper, NULL);
     if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {
         printf("Unable to send query.\n");
         return -1;

--- a/examples/windows/z_info.c
+++ b/examples/windows/z_info.c
@@ -59,14 +59,14 @@ int main(int argc, char **argv) {
 
     printf("Routers IDs:\n");
     z_owned_closure_zid_t callback;
-    z_closure(&callback, print_zid);
+    z_closure(&callback, print_zid, NULL, NULL);
     z_info_routers_zid(z_loan(s), z_move(callback));
 
     // `callback` has been `z_move`d just above, so it's safe to reuse the variable,
     // we'll just have to make sure we `z_move` it again to avoid mem-leaks.
     printf("Peers IDs:\n");
     z_owned_closure_zid_t callback2;
-    z_closure(&callback2, print_zid);
+    z_closure(&callback2, print_zid, NULL, NULL);
     z_info_peers_zid(z_loan(s), z_move(callback2));
 
     z_drop(z_move(s));

--- a/examples/windows/z_queryable.c
+++ b/examples/windows/z_queryable.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
     printf("Creating Queryable on '%s'...\n", keyexpr);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     if (z_declare_queryable(z_loan(s), &qable, z_loan(ke), z_move(callback), NULL) < 0) {
         printf("Unable to create queryable.\n");

--- a/examples/windows/z_sub.c
+++ b/examples/windows/z_sub.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;

--- a/examples/windows/z_sub_st.c
+++ b/examples/windows/z_sub_st.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     }
 
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     printf("Declaring Subscriber on '%s'...\n", keyexpr);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;

--- a/examples/zephyr/z_get.c
+++ b/examples/zephyr/z_get.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
             opts.payload = z_move(payload);
         }
         z_owned_closure_reply_t callback;
-        z_closure(&callback, reply_handler, reply_dropper);
+        z_closure(&callback, reply_handler, reply_dropper, NULL);
         z_view_keyexpr_t ke;
         z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
         if (z_get(z_loan(s), z_loan(ke), "", z_move(callback), &opts) < 0) {

--- a/examples/zephyr/z_queryable.c
+++ b/examples/zephyr/z_queryable.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     // Declare Zenoh queryable
     printf("Declaring Queryable on %s...", KEYEXPR);
     z_owned_closure_query_t callback;
-    z_closure(&callback, query_handler);
+    z_closure(&callback, query_handler, NULL, NULL);
     z_owned_queryable_t qable;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);

--- a/examples/zephyr/z_sub.c
+++ b/examples/zephyr/z_sub.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
 
     printf("Declaring Subscriber on '%s'...", KEYEXPR);
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str_unchecked(&ke, KEYEXPR);
     z_owned_subscriber_t sub;

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -545,8 +545,8 @@ inline void z_call(const z_loaned_closure_zid_t &closure, const z_id_t *zid)
 inline void z_closure(
     z_owned_closure_hello_t* closure,
     void (*call)(z_loaned_hello_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
+    void (*drop)(void*),
+    void *context) {
     closure->_val.context = context;
     closure->_val.drop = drop;
     closure->_val.call = call;
@@ -554,8 +554,8 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_query_t* closure,
     void (*call)(z_loaned_query_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
+    void (*drop)(void*),
+    void *context) {
     closure->_val.context = context;
     closure->_val.drop = drop;
     closure->_val.call = call;
@@ -563,8 +563,8 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_reply_t* closure,
     void (*call)(z_loaned_reply_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
+    void (*drop)(void*),
+    void *context) {
     closure->_val.context = context;
     closure->_val.drop = drop;
     closure->_val.call = call;
@@ -572,8 +572,8 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_sample_t* closure,
     void (*call)(z_loaned_sample_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
+    void (*drop)(void*),
+    void *context) {
     closure->_val.context = context;
     closure->_val.drop = drop;
     closure->_val.call = call;
@@ -581,8 +581,8 @@ inline void z_closure(
 inline void z_closure(
     z_owned_closure_zid_t* closure,
     void (*call)(const z_id_t*, void*),
-    void (*drop)(void*) = NULL,
-    void *context = NULL) {
+    void (*drop)(void*),
+    void *context) {
     closure->_val.context = context;
     closure->_val.drop = drop;
     closure->_val.call = call;

--- a/tests/z_test_fragment_rx.c
+++ b/tests/z_test_fragment_rx.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     }
     // Declare subscriber
     z_owned_closure_sample_t callback;
-    z_closure(&callback, data_handler);
+    z_closure(&callback, data_handler, NULL, NULL);
     z_owned_subscriber_t sub;
     z_view_keyexpr_t ke;
     z_view_keyexpr_from_str(&ke, keyexpr);


### PR DESCRIPTION
The default parameters for `z_closure` not implemented in zenoh-c. It's possible to add it (done in PR https://github.com/eclipse-zenoh/zenoh-c/pull/782) , but in fact this functionality is useless in practice: no one will use callbacks without context in real applications. So for simplicity it seems better to remove this, despite that this is slight API change.