### PR TITLE
build shared lib for packages instead of static one

### DIFF
--- a/ci/scripts/build-linux.bash
+++ b/ci/scripts/build-linux.bash
@@ -9,7 +9,7 @@ readonly version=${VERSION:?input VERSION is required}
 # Build target
 readonly target=${TARGET:?input TARGET is required}
 
-BUILD_TYPE=RELEASE make "$target"
+BUILD_SHARED_LIBS=ON BUILD_TYPE=RELEASE make "$target"
 
 readonly out=$GITHUB_WORKSPACE
 readonly repo_name=${repo#*/}


### PR DESCRIPTION
build shared lib for packages instead of static one
Closes #756.