### PR TITLE
Add manual batching mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ set(Z_FEATURE_RAWETH_TRANSPORT 0 CACHE STRING "Toggle raw ethernet transport")
 set(Z_FEATURE_TCP_NODELAY 1 CACHE STRING "Toggle TCP_NODELAY")
 set(Z_FEATURE_LOCAL_SUBSCRIBER 0 CACHE STRING "Toggle local subscriptions")
 set(Z_FEATURE_PUBLISHER_SESSION_CHECK 1 CACHE STRING "Toggle publisher session check")
+set(Z_FEATURE_BATCHING 1 CACHE STRING "Toggle batching")
 
 add_compile_definitions("Z_BUILD_DEBUG=$<CONFIG:Debug>")
 message(STATUS "Building with feature confing:\n\

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -2057,8 +2057,29 @@ const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *subs
 #endif
 
 #if Z_FEATURE_BATCHING == 1
-z_result_t zp_batching_start(const z_loaned_session_t *zs);
-z_result_t zp_batching_stop(const z_loaned_session_t *zs);
+/**
+ * Activate the batching mechanism.
+ * Any message that would have been sent on the network by a subsequent api call (e.g z_put, z_get)
+ * will be instead stored until the batch is flushed with :c:func:`zp_batch_flush`.
+ *
+ * Parameters:
+ *   zs: Pointer to a :c:type:`z_loaned_session_t` that will start batching messages.
+ *
+ * Return:
+ *   ``0`` if batching started, ``negative value`` otherwise.
+ */
+z_result_t zp_batch_start(const z_loaned_session_t *zs);
+
+/**
+ * Deactivate the batching mechanism and flush the messages that were stored.
+ *
+ * Parameters:
+ *   zs: Pointer to a :c:type:`z_loaned_session_t` that will stop batching messages.
+ *
+ * Return:
+ *   ``0`` if batching stopped and batch successfully sent, ``negative value`` otherwise.
+ */
+z_result_t zp_batch_flush(const z_loaned_session_t *zs);
 #endif
 
 /************* Multi Thread Tasks helpers **************/

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -2056,6 +2056,11 @@ z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *subscriber);
 #endif
 
+#if Z_FEATURE_BATCHING == 1
+z_result_t zp_batching_start(const z_loaned_session_t *zs);
+z_result_t zp_batching_stop(const z_loaned_session_t *zs);
+#endif
+
 /************* Multi Thread Tasks helpers **************/
 /**
  * Builds a :c:type:`zp_task_read_options_t` with default value.

--- a/include/zenoh-pico/collections/vec.h
+++ b/include/zenoh-pico/collections/vec.h
@@ -29,8 +29,10 @@ typedef struct {
     void **_val;
 } _z_vec_t;
 
+static inline _z_vec_t _z_vec_null(void) { return (_z_vec_t){0}; }
 _z_vec_t _z_vec_make(size_t capacity);
 void _z_vec_copy(_z_vec_t *dst, const _z_vec_t *src, z_element_clone_f f);
+void _z_vec_steal(_z_vec_t *dst, _z_vec_t *src);
 
 size_t _z_vec_len(const _z_vec_t *v);
 bool _z_vec_is_empty(const _z_vec_t *v);
@@ -59,6 +61,7 @@ void _z_vec_release(_z_vec_t *v);
     static inline void name##_vec_copy(name##_vec_t *dst, const name##_vec_t *src) {                               \
         _z_vec_copy(dst, src, name##_elem_clone);                                                                  \
     }                                                                                                              \
+    static inline void name##_vec_steal(name##_vec_t *dst, name##_vec_t *src) { _z_vec_steal(dst, src); }          \
     static inline void name##_vec_reset(name##_vec_t *v) { _z_vec_reset(v, name##_elem_free); }                    \
     static inline void name##_vec_clear(name##_vec_t *v) { _z_vec_clear(v, name##_elem_free); }                    \
     static inline void name##_vec_free(name##_vec_t **v) { _z_vec_free(v, name##_elem_free); }                     \

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -44,6 +44,7 @@
 #define Z_FEATURE_TCP_NODELAY 1
 #define Z_FEATURE_LOCAL_SUBSCRIBER 0
 #define Z_FEATURE_PUBLISHER_SESSION_CHECK 1
+#define Z_FEATURE_BATCHING 1
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -44,6 +44,7 @@
 #define Z_FEATURE_TCP_NODELAY @Z_FEATURE_TCP_NODELAY@
 #define Z_FEATURE_LOCAL_SUBSCRIBER @Z_FEATURE_LOCAL_SUBSCRIBER@
 #define Z_FEATURE_PUBLISHER_SESSION_CHECK @Z_FEATURE_PUBLISHER_SESSION_CHECK@
+#define Z_FEATURE_BATCHING @Z_FEATURE_BATCHING@
 // End of CMake generation
 
 /*------------------ Runtime configuration properties ------------------*/

--- a/include/zenoh-pico/protocol/definitions/network.h
+++ b/include/zenoh-pico/protocol/definitions/network.h
@@ -302,5 +302,6 @@ _z_network_message_t _z_n_msg_make_response_final(_z_zint_t rid);
 _z_network_message_t _z_n_msg_make_declare(_z_declaration_t declaration, bool has_interest_id, uint32_t interest_id);
 _z_network_message_t _z_n_msg_make_push(_Z_MOVE(_z_keyexpr_t) key, _Z_MOVE(_z_push_body_t) body);
 _z_network_message_t _z_n_msg_make_interest(_z_interest_t interest);
+z_result_t _z_n_msg_copy(_z_network_message_t *dst, const _z_network_message_t *src);
 
 #endif /* INCLUDE_ZENOH_PICO_PROTOCOL_DEFINITIONS_NETWORK_H */

--- a/include/zenoh-pico/session/utils.h
+++ b/include/zenoh-pico/session/utils.h
@@ -33,6 +33,7 @@ z_result_t _z_session_close(_z_session_t *zn, uint8_t reason);
 z_result_t _z_handle_network_message(_z_session_rc_t *zsrc, _z_zenoh_message_t *z_msg, uint16_t local_peer_id);
 z_result_t _z_send_n_msg(_z_session_t *zn, _z_network_message_t *n_msg, z_reliability_t reliability,
                          z_congestion_control_t cong_ctrl);
+z_result_t _z_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl);
 
 void _zp_session_lock_mutex(_z_session_t *zn);
 void _zp_session_unlock_mutex(_z_session_t *zn);

--- a/include/zenoh-pico/transport/multicast/transport.h
+++ b/include/zenoh-pico/transport/multicast/transport.h
@@ -27,10 +27,32 @@ z_result_t _z_multicast_send_close(_z_transport_multicast_t *ztm, uint8_t reason
 z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t reason);
 void _z_multicast_transport_clear(_z_transport_t *zt);
 
-z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block);
-void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm);
-void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm);
-void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm);
-void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm);
-void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm);
-#endif /* ZENOH_PICO_MULTICAST_TRANSPORT_H */
+#if (Z_FEATURE_MULTICAST_TRANSPORT == 1 || Z_FEATURE_RAWETH_TRANSPORT == 1) && Z_FEATURE_MULTI_THREAD == 1
+static inline z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block) {
+    if (block) {
+        _z_mutex_lock(&ztm->_mutex_tx);
+        return _Z_RES_OK;
+    } else {
+        return _z_mutex_try_lock(&ztm->_mutex_tx);
+    }
+}
+static inline void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_tx); }
+static inline void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&ztm->_mutex_rx); }
+static inline void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_rx); }
+static inline void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&ztm->_mutex_peer); }
+static inline void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_peer); }
+
+#else
+static inline z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block) {
+    _ZP_UNUSED(ztm);
+    _ZP_UNUSED(block);
+    return _Z_RES_OK;
+}
+static inline void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+static inline void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+static inline void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+static inline void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+static inline void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+
+#endif  // (Z_FEATURE_MULTICAST_TRANSPORT == 1 || Z_FEATURE_RAWETH_TRANSPORT == 1) && Z_FEATURE_MULTI_THREAD == 1
+#endif  /* ZENOH_PICO_MULTICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/multicast/transport.h
+++ b/include/zenoh-pico/transport/multicast/transport.h
@@ -31,4 +31,6 @@ z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block)
 void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm);
 void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm);
 void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm);
+void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm);
+void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm);
 #endif /* ZENOH_PICO_MULTICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/multicast/transport.h
+++ b/include/zenoh-pico/transport/multicast/transport.h
@@ -26,4 +26,9 @@ z_result_t _z_multicast_open_client(_z_transport_multicast_establish_param_t *pa
 z_result_t _z_multicast_send_close(_z_transport_multicast_t *ztm, uint8_t reason, bool link_only);
 z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t reason);
 void _z_multicast_transport_clear(_z_transport_t *zt);
+
+z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block);
+void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm);
+void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm);
+void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm);
 #endif /* ZENOH_PICO_MULTICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/multicast/tx.h
+++ b/include/zenoh-pico/transport/multicast/tx.h
@@ -21,5 +21,6 @@
 z_result_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                                    z_congestion_control_t cong_ctrl);
 z_result_t _z_multicast_send_t_msg(_z_transport_multicast_t *ztm, const _z_transport_message_t *t_msg);
+z_result_t _z_multicast_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl);
 
 #endif /* ZENOH_PICO_MULTICAST_TX_H */

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -31,6 +31,11 @@ enum _z_dbuf_state_e {
     _Z_DBUF_STATE_OVERFLOW = 2,
 };
 
+enum _z_batching_state_e {
+    _Z_BATCHING_IDLE = 0,
+    _Z_BATCHING_ACTIVE = 1,
+};
+
 typedef struct {
 #if Z_FEATURE_FRAGMENTATION == 1
     // Defragmentation buffers
@@ -105,6 +110,12 @@ typedef struct {
     _z_zint_t _sn_rx_best_effort;
     volatile _z_zint_t _lease;
 
+// Transport batching
+#if Z_FEATURE_BATCHING == 1
+    uint8_t _batch_state;
+    _z_network_message_vec_t _batch;
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
     _z_task_t *_read_task;
     _z_task_t *_lease_task;
@@ -128,6 +139,12 @@ typedef struct _z_transport_multicast_t {
     // Peer list mutex
     _z_mutex_t _mutex_peer;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
+
+// Transport batching
+#if Z_FEATURE_BATCHING == 1
+    uint8_t _batch_state;
+    _z_network_message_vec_t _batch;
+#endif
 
     _z_link_t _link;
 
@@ -191,5 +208,10 @@ typedef struct {
 z_result_t _z_transport_close(_z_transport_t *zt, uint8_t reason);
 void _z_transport_clear(_z_transport_t *zt);
 void _z_transport_free(_z_transport_t **zt);
+
+#if Z_FEATURE_BATCHING == 1
+bool _z_transport_start_batching(_z_transport_t *zt);
+void _z_transport_stop_batching(_z_transport_t *zt);
+#endif
 
 #endif /* INCLUDE_ZENOH_PICO_TRANSPORT_TRANSPORT_H */

--- a/include/zenoh-pico/transport/unicast/transport.h
+++ b/include/zenoh-pico/transport/unicast/transport.h
@@ -27,8 +27,27 @@ z_result_t _z_unicast_send_close(_z_transport_unicast_t *ztu, uint8_t reason, bo
 z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reason);
 void _z_unicast_transport_clear(_z_transport_t *zt);
 
-z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, z_congestion_control_t cc);
-void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu);
-void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu);
-void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu);
-#endif /* ZENOH_PICO_UNICAST_TRANSPORT_H */
+#if Z_FEATURE_UNICAST_TRANSPORT == 1 && Z_FEATURE_MULTI_THREAD == 1
+static inline z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, bool block) {
+    if (block) {
+        _z_mutex_lock(&ztu->_mutex_tx);
+        return _Z_RES_OK;
+    } else {
+        return _z_mutex_try_lock(&ztu->_mutex_tx);
+    }
+}
+static inline void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_tx); }
+static inline void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _z_mutex_lock(&ztu->_mutex_rx); }
+static inline void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_rx); }
+
+#else
+static inline z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, bool block) {
+    _ZP_UNUSED(ztu);
+    _ZP_UNUSED(block);
+    return _Z_RES_OK;
+}
+static inline void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+static inline void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+static inline void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+#endif  // Z_FEATURE_UNICAST_TRANSPORT == 1 && Z_FEATURE_MULTI_THREAD == 1
+#endif  /* ZENOH_PICO_UNICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/unicast/transport.h
+++ b/include/zenoh-pico/transport/unicast/transport.h
@@ -26,4 +26,9 @@ z_result_t _z_unicast_open_peer(_z_transport_unicast_establish_param_t *param, c
 z_result_t _z_unicast_send_close(_z_transport_unicast_t *ztu, uint8_t reason, bool link_only);
 z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reason);
 void _z_unicast_transport_clear(_z_transport_t *zt);
+
+z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, z_congestion_control_t cc);
+void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu);
+void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu);
+void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu);
 #endif /* ZENOH_PICO_UNICAST_TRANSPORT_H */

--- a/include/zenoh-pico/transport/unicast/tx.h
+++ b/include/zenoh-pico/transport/unicast/tx.h
@@ -21,5 +21,6 @@
 z_result_t _z_unicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                                  z_congestion_control_t cong_ctrl);
 z_result_t _z_unicast_send_t_msg(_z_transport_unicast_t *ztu, const _z_transport_message_t *t_msg);
+z_result_t _z_unicast_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl);
 
 #endif /* ZENOH_PICO_TRANSPORT_LINK_TX_H */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1439,7 +1439,7 @@ const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub)
 #endif
 
 #if Z_FEATURE_BATCHING == 1
-z_result_t zp_batching_start(const z_loaned_session_t *zs) {
+z_result_t zp_batch_start(const z_loaned_session_t *zs) {
     if (_Z_RC_IS_NULL(zs)) {
         return _Z_ERR_SESSION_CLOSED;
     }
@@ -1447,7 +1447,7 @@ z_result_t zp_batching_start(const z_loaned_session_t *zs) {
     return _z_transport_start_batching(&session->_tp) ? _Z_RES_OK : _Z_ERR_GENERIC;
 }
 
-z_result_t zp_batching_stop(const z_loaned_session_t *zs) {
+z_result_t zp_batch_flush(const z_loaned_session_t *zs) {
     _z_session_t *session = _Z_RC_IN_VAL(zs);
     if (_Z_RC_IS_NULL(zs)) {
         return _Z_ERR_SESSION_CLOSED;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1438,6 +1438,25 @@ const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *sub)
 }
 #endif
 
+#if Z_FEATURE_BATCHING == 1
+z_result_t zp_batching_start(const z_loaned_session_t *zs) {
+    if (_Z_RC_IS_NULL(zs)) {
+        return _Z_ERR_SESSION_CLOSED;
+    }
+    _z_session_t *session = _Z_RC_IN_VAL(zs);
+    return _z_transport_start_batching(&session->_tp) ? _Z_RES_OK : _Z_ERR_GENERIC;
+}
+
+z_result_t zp_batching_stop(const z_loaned_session_t *zs) {
+    _z_session_t *session = _Z_RC_IN_VAL(zs);
+    if (_Z_RC_IS_NULL(zs)) {
+        return _Z_ERR_SESSION_CLOSED;
+    }
+    _z_transport_stop_batching(&session->_tp);
+    return _z_send_n_batch(session, Z_RELIABILITY_DEFAULT, Z_CONGESTION_CONTROL_DEFAULT);
+}
+#endif
+
 /**************** Tasks ****************/
 void zp_task_read_options_default(zp_task_read_options_t *options) {
 #if Z_FEATURE_MULTI_THREAD == 1

--- a/src/collections/vec.c
+++ b/src/collections/vec.c
@@ -41,6 +41,11 @@ void _z_vec_copy(_z_vec_t *dst, const _z_vec_t *src, z_element_clone_f d_f) {
     }
 }
 
+void _z_vec_steal(_z_vec_t *dst, _z_vec_t *src) {
+    *dst = *src;
+    *src = _z_vec_null();
+}
+
 void _z_vec_reset(_z_vec_t *v, z_element_free_f free_f) {
     for (size_t i = 0; i < v->_len; i++) {
         free_f(&v->_val[i]);

--- a/src/protocol/codec/declarations.c
+++ b/src/protocol/codec/declarations.c
@@ -163,7 +163,6 @@ z_result_t _z_declaration_encode(_z_wbuf_t *wbf, const _z_declaration_t *decl) {
         case _Z_DECL_FINAL: {
             ret = _z_decl_final_encode(wbf);
         } break;
-            ;
     }
     return ret;
 }

--- a/src/protocol/codec/transport.c
+++ b/src/protocol/codec/transport.c
@@ -368,6 +368,7 @@ z_result_t _z_frame_decode(_z_t_msg_frame_t *msg, _z_zbuf_t *zbf, uint8_t header
                 _z_network_message_vec_append(&msg->_messages, nm);
             } else {
                 _z_n_msg_free(&nm);
+                _z_network_message_vec_clear(&msg->_messages);
 
                 _z_zbuf_set_rpos(zbf, r_pos);  // Restore the reading position of the iobfer
 

--- a/src/protocol/definitions/network.c
+++ b/src/protocol/definitions/network.c
@@ -73,6 +73,16 @@ _z_push_body_t _z_push_body_steal(_z_push_body_t *msg) {
     return ret;
 }
 
+static z_result_t _z_push_body_copy(_z_push_body_t *dst, const _z_push_body_t *src) {
+    if (src->_is_put) {
+        _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._put._attachment, &src->_body._put._attachment));
+        _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._put._payload, &src->_body._put._payload));
+    } else {
+        _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._del._attachment, &src->_body._del._attachment));
+    }
+    return _Z_RES_OK;
+}
+
 void _z_n_msg_response_final_clear(_z_n_msg_response_final_t *msg) { (void)(msg); }
 
 void _z_n_msg_push_clear(_z_n_msg_push_t *msg) {
@@ -222,6 +232,124 @@ _z_network_message_t _z_n_msg_make_interest(_z_interest_t interest) {
                 ._interest = interest,
             },
     };
+}
+
+static z_result_t _z_n_msg_push_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst->_body._push._key, &src->_body._push._key));
+    return _z_push_body_copy(&dst->_body._push._body, &src->_body._push._body);
+}
+
+static z_result_t _z_n_msg_request_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst->_body._request._key, &src->_body._request._key));
+    switch (src->_body._request._tag) {
+        case _Z_REQUEST_QUERY:
+            _Z_RETURN_IF_ERR(_z_slice_copy(&dst->_body._request._body._query._parameters,
+                                           &src->_body._request._body._query._parameters));
+            _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._request._body._query._ext_attachment,
+                                           &src->_body._request._body._query._ext_attachment));
+            _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._request._body._query._ext_value.payload,
+                                           &src->_body._request._body._query._ext_value.payload));
+            break;
+        case _Z_REQUEST_PUT:
+            _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._request._body._put._attachment,
+                                           &src->_body._request._body._put._attachment));
+            _Z_RETURN_IF_ERR(
+                _z_bytes_copy(&dst->_body._request._body._put._payload, &src->_body._request._body._put._payload));
+            break;
+        case _Z_REQUEST_DEL:
+            _Z_RETURN_IF_ERR(_z_bytes_copy(&dst->_body._request._body._del._attachment,
+                                           &src->_body._request._body._del._attachment));
+            break;
+    }
+    return _Z_RES_OK;
+}
+
+static z_result_t _z_n_msg_response_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst->_body._response._key, &src->_body._response._key));
+    switch (src->_body._response._tag) {
+        case _Z_RESPONSE_BODY_REPLY:
+            _Z_RETURN_IF_ERR(
+                _z_push_body_copy(&dst->_body._response._body._reply._body, &src->_body._response._body._reply._body));
+            break;
+        case _Z_RESPONSE_BODY_ERR:
+            _Z_RETURN_IF_ERR(
+                _z_bytes_copy(&dst->_body._response._body._err._payload, &src->_body._response._body._err._payload));
+            break;
+    }
+    return _Z_RES_OK;
+}
+
+static z_result_t _z_n_msg_response_final_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    return _Z_RES_OK;
+}
+
+static z_result_t _z_n_msg_declare_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    const _z_declaration_t *src_decl = &src->_body._declare._decl;
+    _z_declaration_t *dst_decl = &dst->_body._declare._decl;
+    switch (src_decl->_tag) {
+        case _Z_DECL_KEXPR: {
+            _Z_RETURN_IF_ERR(
+                _z_keyexpr_copy(&dst_decl->_body._decl_kexpr._keyexpr, &src_decl->_body._decl_kexpr._keyexpr));
+        } break;
+        case _Z_DECL_SUBSCRIBER: {
+            _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst_decl->_body._decl_subscriber._keyexpr,
+                                             &src_decl->_body._decl_subscriber._keyexpr));
+        } break;
+        case _Z_UNDECL_SUBSCRIBER: {
+            _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst_decl->_body._undecl_subscriber._ext_keyexpr,
+                                             &src_decl->_body._undecl_subscriber._ext_keyexpr));
+        } break;
+        case _Z_DECL_QUERYABLE: {
+            _Z_RETURN_IF_ERR(
+                _z_keyexpr_copy(&dst_decl->_body._decl_queryable._keyexpr, &src_decl->_body._decl_queryable._keyexpr));
+        } break;
+        case _Z_UNDECL_QUERYABLE: {
+            _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst_decl->_body._undecl_queryable._ext_keyexpr,
+                                             &src_decl->_body._undecl_queryable._ext_keyexpr));
+        } break;
+        case _Z_DECL_TOKEN: {
+            _Z_RETURN_IF_ERR(
+                _z_keyexpr_copy(&dst_decl->_body._decl_token._keyexpr, &src_decl->_body._decl_token._keyexpr));
+        } break;
+        case _Z_UNDECL_TOKEN: {
+            _Z_RETURN_IF_ERR(_z_keyexpr_copy(&dst_decl->_body._undecl_token._ext_keyexpr,
+                                             &src_decl->_body._undecl_token._ext_keyexpr));
+        } break;
+        default:
+            break;
+    }
+    return _Z_RES_OK;
+}
+
+static z_result_t _z_n_msg_interest_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    memcpy(dst, src, sizeof(_z_network_message_t));
+    _Z_RETURN_IF_ERR(
+        _z_keyexpr_copy(&dst->_body._interest._interest._keyexpr, &src->_body._interest._interest._keyexpr));
+    return _Z_RES_OK;
+}
+
+z_result_t _z_n_msg_copy(_z_network_message_t *dst, const _z_network_message_t *src) {
+    switch (src->_tag) {
+        case _Z_N_PUSH:
+            return _z_n_msg_push_copy(dst, src);
+        case _Z_N_REQUEST:
+            return _z_n_msg_request_copy(dst, src);
+        case _Z_N_RESPONSE:
+            return _z_n_msg_response_copy(dst, src);
+        case _Z_N_RESPONSE_FINAL:
+            return _z_n_msg_response_final_copy(dst, src);
+        case _Z_N_DECLARE:
+            return _z_n_msg_declare_copy(dst, src);
+        case _Z_N_INTEREST:
+            return _z_n_msg_interest_copy(dst, src);
+        default:
+            return _Z_ERR_ENTITY_UNKNOWN;
+    }
 }
 
 void _z_msg_fix_mapping(_z_zenoh_message_t *msg, uint16_t mapping) {

--- a/src/session/tx.c
+++ b/src/session/tx.c
@@ -38,3 +38,24 @@ z_result_t _z_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_
     }
     return ret;
 }
+
+z_result_t _z_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl) {
+    z_result_t ret = _Z_RES_OK;
+    // Call transport function
+    switch (zn->_tp._type) {
+        case _Z_TRANSPORT_UNICAST_TYPE:
+            ret = _z_unicast_send_n_batch(zn, reliability, cong_ctrl);
+            break;
+        case _Z_TRANSPORT_MULTICAST_TYPE:
+            ret = _z_multicast_send_n_batch(zn, reliability, cong_ctrl);
+            break;
+        case _Z_TRANSPORT_RAWETH_TYPE:
+            _Z_INFO("Batching not yet supported on raweth transport");
+            ret = _Z_ERR_TRANSPORT_TX_FAILED;
+            break;
+        default:
+            ret = _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+            break;
+    }
+    return ret;
+}

--- a/src/session/tx.c
+++ b/src/session/tx.c
@@ -21,7 +21,6 @@
 z_result_t _z_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_reliability_t reliability,
                          z_congestion_control_t cong_ctrl) {
     z_result_t ret = _Z_RES_OK;
-    _Z_DEBUG(">> send network message");
     // Call transport function
     switch (zn->_tp._type) {
         case _Z_TRANSPORT_UNICAST_TYPE:

--- a/src/transport/multicast/rx.c
+++ b/src/transport/multicast/rx.c
@@ -117,7 +117,7 @@ static _z_transport_peer_entry_t *_z_find_peer_entry(_z_transport_peer_entry_lis
 z_result_t _z_multicast_handle_transport_message(_z_transport_multicast_t *ztm, _z_transport_message_t *t_msg,
                                                  _z_slice_t *addr) {
     z_result_t ret = _Z_RES_OK;
-    _z_multicast_rx_mutex_lock(ztm);
+    _z_multicast_peer_mutex_lock(ztm);
     // Mark the session that we have received data from this peer
     _z_transport_peer_entry_t *entry = _z_find_peer_entry(ztm->_peers, addr);
     switch (_Z_MID(t_msg->_header)) {
@@ -358,7 +358,7 @@ z_result_t _z_multicast_handle_transport_message(_z_transport_multicast_t *ztm, 
             break;
         }
     }
-    _z_multicast_rx_mutex_unlock(ztm);
+    _z_multicast_peer_mutex_unlock(ztm);
     return ret;
 }
 

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -52,6 +52,13 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
         default:
             return _Z_ERR_GENERIC;
     }
+
+// Initialize batching data
+#if Z_FEATURE_BATCHING == 1
+    ztm->_batch_state = _Z_BATCHING_IDLE;
+    ztm->_batch = _z_network_message_vec_make(0);
+#endif
+
 #if Z_FEATURE_MULTI_THREAD == 1
     // Initialize the mutexes
     ret = _z_mutex_init(&ztm->_mutex_tx);
@@ -198,6 +205,10 @@ void _z_multicast_transport_clear(_z_transport_t *zt) {
     _z_mutex_drop(&ztm->_mutex_rx);
     _z_mutex_drop(&ztm->_mutex_peer);
 #endif  // Z_FEATURE_MULTI_THREAD == 1
+
+#if Z_FEATURE_BATCHING == 1
+    _z_network_message_vec_clear(&ztm->_batch);
+#endif
 
     // Clean up the buffers
     _z_wbuf_clear(&ztm->_wbuf);

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -235,6 +235,10 @@ void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&
 
 void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_rx); }
 
+void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&ztm->_mutex_peer); }
+
+void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_peer); }
+
 #else
 z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, z_congestion_control_t cc) {
     _ZP_UNUSED(ztm);
@@ -246,6 +250,11 @@ void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(zt
 void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
 
 void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+
+void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+
+void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
+
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 #else

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -240,9 +240,9 @@ void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock
 void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_peer); }
 
 #else
-z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, z_congestion_control_t cc) {
+z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block) {
     _ZP_UNUSED(ztm);
-    _ZP_UNUSED(cc);
+    _ZP_UNUSED(block);
     return _Z_RES_OK;
 }
 void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -219,44 +219,6 @@ void _z_multicast_transport_clear(_z_transport_t *zt) {
     _z_link_clear(&ztm->_link);
 }
 
-#if Z_FEATURE_MULTI_THREAD == 1
-z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block) {
-    if (block) {
-        _z_mutex_lock(&ztm->_mutex_tx);
-        return _Z_RES_OK;
-    } else {
-        return _z_mutex_try_lock(&ztm->_mutex_tx);
-    }
-}
-
-void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_tx); }
-
-void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&ztm->_mutex_rx); }
-
-void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_rx); }
-
-void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _z_mutex_lock(&ztm->_mutex_peer); }
-
-void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _z_mutex_unlock(&ztm->_mutex_peer); }
-
-#else
-z_result_t _z_multicast_tx_mutex_lock(_z_transport_multicast_t *ztm, bool block) {
-    _ZP_UNUSED(ztm);
-    _ZP_UNUSED(block);
-    return _Z_RES_OK;
-}
-void _z_multicast_tx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
-
-void _z_multicast_rx_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
-
-void _z_multicast_rx_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
-
-void _z_multicast_peer_mutex_lock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
-
-void _z_multicast_peer_mutex_unlock(_z_transport_multicast_t *ztm) { _ZP_UNUSED(ztm); }
-
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
 #else
 
 z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
@@ -294,7 +256,6 @@ z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t r
     _ZP_UNUSED(ztm);
     _ZP_UNUSED(reason);
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
-    ;
 }
 
 void _z_multicast_transport_clear(_z_transport_t *zt) { _ZP_UNUSED(zt); }

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -52,7 +52,7 @@ static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *z
     // Fragment message
     while (_z_wbuf_len(fbf) > 0) {
         // Get fragment sequence number
-        if (is_first == false) {
+        if (!is_first) {
             sn = __unsafe_z_multicast_get_sn(ztm, reliability);
         }
         is_first = false;

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -128,6 +128,7 @@ static z_result_t __unsafe_z_multicast_message_batch(_z_transport_multicast_t *z
 }
 
 static z_result_t __unsafe_multicast_batch_send(_z_transport_multicast_t *ztm, z_reliability_t reliability) {
+    z_result_t ret = _Z_RES_OK;
     // Get network message number
     size_t msg_nb = _z_network_message_vec_len(&ztm->_batch);
     size_t msg_idx = 0;
@@ -151,21 +152,31 @@ static z_result_t __unsafe_multicast_batch_send(_z_transport_multicast_t *ztm, z
             _z_wbuf_set_wpos(&ztm->_wbuf, curr_wpos);
             // Handle case where one message is too big to fit in frame
             if (curr_msg_nb == 0) {
-                _Z_INFO("Dropping batch because one message is too big (need to be fragmented)");
-                return _Z_ERR_TRANSPORT_TX_FAILED;
+                _Z_INFO("Batch sending interrupted by a message needing to be fragmented.");
+                // Create an expandable wbuf for fragmentation
+                _z_wbuf_t fbf = _z_wbuf_make(_Z_FRAG_BUFF_BASE_SIZE, true);
+                // Send message as fragments
+                ret = __unsafe_z_multicast_send_fragment(ztm, &fbf, n_msg, reliability, sn);
+                // Clear the buffer as it's no longer required
+                _z_wbuf_clear(&fbf);
+                if (ret != _Z_RES_OK) {
+                    _Z_ERROR("Send fragmented message failed with err %d.", ret);
+                }
+                // Message is sent or skipped
+                msg_idx++;
             } else {  // Frame has messages but is full
                 _Z_INFO("Sending batch in multiple frames because it is too big for one");
                 // Send frame
                 __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
                 _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
                 ztm->_transmitted = true;
-                // Reset frame
-                __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-                sn = __unsafe_z_multicast_get_sn(ztm, reliability);
-                t_msg = _z_t_msg_make_frame_header(sn, reliability);
-                _Z_RETURN_IF_ERR(_z_transport_message_encode(&ztm->_wbuf, &t_msg));
                 curr_msg_nb = 0;
             }
+            // Reset frame
+            __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+            sn = __unsafe_z_multicast_get_sn(ztm, reliability);
+            t_msg = _z_t_msg_make_frame_header(sn, reliability);
+            _Z_RETURN_IF_ERR(_z_transport_message_encode(&ztm->_wbuf, &t_msg));
         } else {
             curr_wpos = _z_wbuf_get_wpos(&ztm->_wbuf);
             msg_idx++;
@@ -176,7 +187,7 @@ static z_result_t __unsafe_multicast_batch_send(_z_transport_multicast_t *ztm, z
     __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
     _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
     ztm->_transmitted = true;  // Tell session we transmitted data
-    return _Z_RES_OK;
+    return ret;
 }
 #endif
 

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -114,7 +114,7 @@ static z_result_t __unsafe_z_multicast_message_send(_z_transport_multicast_t *zt
 #if Z_FEATURE_BATCHING == 1
 static z_result_t __unsafe_z_multicast_message_batch(_z_transport_multicast_t *ztm, const _z_network_message_t *n_msg) {
     _Z_DEBUG("Batching network message");
-    // Copy network message (STEAL?)
+    // Copy network message
     _z_network_message_t *batch_msg = z_malloc(sizeof(_z_network_message_t));
     if (batch_msg == NULL) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -160,7 +160,6 @@ static z_result_t __unsafe_multicast_batch_send(_z_transport_multicast_t *ztm, z
                 _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
                 ztm->_transmitted = true;
                 // Reset frame
-                _z_wbuf_reset(&ztm->_wbuf);
                 __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
                 sn = __unsafe_z_multicast_get_sn(ztm, reliability);
                 t_msg = _z_t_msg_make_frame_header(sn, reliability);
@@ -239,7 +238,6 @@ z_result_t _z_multicast_send_n_batch(_z_session_t *zn, z_reliability_t reliabili
     // Send batch
     ret = __unsafe_multicast_batch_send(ztm, reliability);
     // Clean up
-    _z_wbuf_reset(&ztm->_wbuf);
     _z_network_message_vec_clear(&ztm->_batch);
     _z_multicast_tx_mutex_unlock(ztm);
     return ret;

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -17,6 +17,7 @@
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/protocol/codec/network.h"
 #include "zenoh-pico/protocol/codec/transport.h"
+#include "zenoh-pico/transport/multicast/transport.h"
 #include "zenoh-pico/transport/multicast/tx.h"
 #include "zenoh-pico/transport/utils.h"
 #include "zenoh-pico/utils/logging.h"
@@ -28,7 +29,7 @@
  * Make sure that the following mutexes are locked before calling this function:
  *  - ztm->_mutex_inner
  */
-_z_zint_t __unsafe_z_multicast_get_sn(_z_transport_multicast_t *ztm, z_reliability_t reliability) {
+static _z_zint_t __unsafe_z_multicast_get_sn(_z_transport_multicast_t *ztm, z_reliability_t reliability) {
     _z_zint_t sn;
     if (reliability == Z_RELIABILITY_RELIABLE) {
         sn = ztm->_sn_tx_reliable;
@@ -40,20 +41,153 @@ _z_zint_t __unsafe_z_multicast_get_sn(_z_transport_multicast_t *ztm, z_reliabili
     return sn;
 }
 
+#if Z_FEATURE_FRAGMENTATION == 1
+static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *ztm, _z_wbuf_t *fbf,
+                                                     const _z_network_message_t *n_msg, z_reliability_t reliability,
+                                                     _z_zint_t *first_sn) {
+    bool is_first = true;
+    _z_zint_t sn = *first_sn;
+    // Encode message on temp buffer
+    _Z_RETURN_IF_ERR(_z_network_message_encode(fbf, n_msg));
+    // Fragment message
+    while (_z_wbuf_len(fbf) > 0) {
+        // Get fragment sequence number
+        if (is_first == false) {
+            sn = __unsafe_z_multicast_get_sn(ztm, reliability);
+        }
+        is_first = false;
+        // Serialize fragment
+        __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+        z_result_t ret = __unsafe_z_serialize_zenoh_fragment(&ztm->_wbuf, fbf, reliability, sn);
+        if (ret != _Z_RES_OK) {
+            _Z_ERROR("Fragment serialization failed with err %d", ret);
+            return ret;
+        }
+        // Send fragment
+        __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+        _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
+        ztm->_transmitted = true;  // Tell session we have transmitted data
+    }
+    return _Z_RES_OK;
+}
+#else
+static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *ztm, _z_wbuf_t *fbf,
+                                                     const _z_network_message_t *n_msg, z_reliability_t reliability,
+                                                     _z_zint_t *first_sn) {
+    _ZP_UNUSED(ztm);
+    _ZP_UNUSED(fbf);
+    _ZP_UNUSED(n_msg);
+    _ZP_UNUSED(reliability);
+    _ZP_UNUSED(first_sn);
+    _Z_INFO("Sending the message required fragmentation feature that is deactivated.");
+    return _Z_RES_OK;
+}
+#endif  // Z_FEATURE_FRAGMENTATION == 1
+
+static z_result_t __unsafe_z_multicast_message_send(_z_transport_multicast_t *ztm, const _z_network_message_t *n_msg,
+                                                    z_reliability_t reliability) {
+    _Z_DEBUG("Send network message");
+    // Encode frame header
+    __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+    _z_zint_t sn = __unsafe_z_multicast_get_sn(ztm, reliability);
+    _z_transport_message_t t_msg = _z_t_msg_make_frame_header(sn, reliability);
+    _Z_RETURN_IF_ERR(_z_transport_message_encode(&ztm->_wbuf, &t_msg));
+    // Encode network message
+    z_result_t ret = _z_network_message_encode(&ztm->_wbuf, n_msg);
+    // The message does not fit in the current batch, let's fragment it
+    if (ret != _Z_RES_OK) {
+        // Create an expandable wbuf for fragmentation
+        _z_wbuf_t fbf = _z_wbuf_make(_Z_FRAG_BUFF_BASE_SIZE, true);
+        // Send message as fragments
+        ret = __unsafe_z_multicast_send_fragment(ztm, &fbf, n_msg, reliability, &sn);
+        // Clear the buffer as it's no longer required
+        _z_wbuf_clear(&fbf);
+        return ret;
+    }
+    // Send network message
+    __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+    _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
+    ztm->_transmitted = true;  // Tell session we transmitted data
+    return _Z_RES_OK;
+}
+
+#if Z_FEATURE_BATCHING == 1
+static z_result_t __unsafe_z_multicast_message_batch(_z_transport_multicast_t *ztm, const _z_network_message_t *n_msg) {
+    _Z_DEBUG("Batching network message");
+    // Copy network message (STEAL?)
+    _z_network_message_t *batch_msg = z_malloc(sizeof(_z_network_message_t));
+    if (batch_msg == NULL) {
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    if (_z_n_msg_copy(batch_msg, n_msg) != _Z_RES_OK) {
+        z_free(batch_msg);
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    _z_network_message_vec_append(&ztm->_batch, batch_msg);
+    return _Z_RES_OK;
+}
+
+static z_result_t __unsafe_multicast_batch_send(_z_transport_multicast_t *ztm, z_reliability_t reliability) {
+    // Get network message number
+    size_t msg_nb = _z_network_message_vec_len(&ztm->_batch);
+    size_t msg_idx = 0;
+    size_t curr_msg_nb = 0;
+    if (msg_nb == 0) {
+        return _Z_RES_OK;
+    }
+    // Encode the frame header
+    __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+    _z_zint_t sn = __unsafe_z_multicast_get_sn(ztm, reliability);
+    _z_transport_message_t t_msg = _z_t_msg_make_frame_header(sn, reliability);
+    _Z_RETURN_IF_ERR(_z_transport_message_encode(&ztm->_wbuf, &t_msg));
+    // Process batch
+    while (msg_idx < msg_nb) {
+        // Encode a network message
+        _z_network_message_t *n_msg = _z_network_message_vec_get(&ztm->_batch, msg_idx);
+        assert(n_msg != NULL);
+        if (_z_network_message_encode(&ztm->_wbuf, n_msg) != _Z_RES_OK) {
+            // Handle case where one message is too big to fit in frame
+            if (curr_msg_nb == 0) {
+                _Z_INFO("Dropping batch because one message is too big (need to be fragmented)");
+                return _Z_ERR_TRANSPORT_TX_FAILED;
+            } else {  // Frame has messages but is full
+                _Z_INFO("Sending batch in multiple frames because it is too big for one");
+                // Send frame
+                __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+                _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
+                ztm->_transmitted = true;
+                // Reset frame
+                _z_wbuf_reset(&ztm->_wbuf);
+                __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+                sn = __unsafe_z_multicast_get_sn(ztm, reliability);
+                t_msg = _z_t_msg_make_frame_header(sn, reliability);
+                _Z_RETURN_IF_ERR(_z_transport_message_encode(&ztm->_wbuf, &t_msg));
+                curr_msg_nb = 0;
+            }
+        } else {
+            msg_idx++;
+            curr_msg_nb++;
+        }
+    }
+    // Send frame
+    __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
+    _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztm->_link, &ztm->_wbuf));
+    ztm->_transmitted = true;  // Tell session we transmitted data
+    return _Z_RES_OK;
+}
+#endif
+
 z_result_t _z_multicast_send_t_msg(_z_transport_multicast_t *ztm, const _z_transport_message_t *t_msg) {
     z_result_t ret = _Z_RES_OK;
-    _Z_DEBUG(">> send session message");
-
+    _Z_DEBUG("Send session message");
     _z_multicast_tx_mutex_lock(ztm, true);
-    // Prepare the buffer eventually reserving space for the message length
-    __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
 
-    // Encode the session message
+    // Encode transport message
+    __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
     ret = _z_transport_message_encode(&ztm->_wbuf, t_msg);
     if (ret == _Z_RES_OK) {
-        // Write the message length in the reserved space if needed
+        // Send message
         __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-        // Send the wbuf on the socket
         ret = _z_link_send_wbuf(&ztm->_link, &ztm->_wbuf);
         if (ret == _Z_RES_OK) {
             ztm->_transmitted = true;  // Tell session we transmitted data
@@ -66,89 +200,52 @@ z_result_t _z_multicast_send_t_msg(_z_transport_multicast_t *ztm, const _z_trans
 z_result_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_msg, z_reliability_t reliability,
                                    z_congestion_control_t cong_ctrl) {
     z_result_t ret = _Z_RES_OK;
-    _Z_DEBUG(">> send network message");
-
     _z_transport_multicast_t *ztm = &zn->_tp._transport._multicast;
 
     // Acquire the lock and drop the message if needed
-    bool drop = false;
-    if (cong_ctrl == Z_CONGESTION_CONTROL_BLOCK) {
-#if Z_FEATURE_MULTI_THREAD == 1
-        _z_mutex_lock(&ztm->_mutex_tx);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
+    ret = _z_multicast_tx_mutex_lock(ztm, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because of congestion control");
+        return ret;
+    }
+    // Process batching
+#if Z_FEATURE_BATCHING == 1
+    if (ztm->_batch_state == _Z_BATCHING_ACTIVE) {
+        ret = __unsafe_z_multicast_message_batch(ztm, n_msg);
     } else {
-#if Z_FEATURE_MULTI_THREAD == 1
-        z_result_t locked = _z_mutex_try_lock(&ztm->_mutex_tx);
-        if (locked != 0) {
-            _Z_INFO("Dropping zenoh message because of congestion control");
-            // We failed to acquire the lock, drop the message
-            drop = true;
-        }
-#endif  // Z_FEATURE_MULTI_THREAD == 1
+        ret = __unsafe_z_multicast_message_send(ztm, n_msg, reliability);
     }
-
-    if (drop == false) {
-        // Prepare the buffer eventually reserving space for the message length
-        __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-
-        _z_zint_t sn = __unsafe_z_multicast_get_sn(ztm, reliability);  // Get the next sequence number
-
-        _z_transport_message_t t_msg = _z_t_msg_make_frame_header(sn, reliability);
-        ret = _z_transport_message_encode(&ztm->_wbuf, &t_msg);  // Encode the frame header
-        if (ret == _Z_RES_OK) {
-            ret = _z_network_message_encode(&ztm->_wbuf, n_msg);  // Encode the network message
-            if (ret == _Z_RES_OK) {
-                // Write the message length in the reserved space if needed
-                __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-
-                ret = _z_link_send_wbuf(&ztm->_link, &ztm->_wbuf);  // Send the wbuf on the socket
-                if (ret == _Z_RES_OK) {
-                    ztm->_transmitted = true;  // Mark the session that we have transmitted data
-                }
-            } else {
-#if Z_FEATURE_FRAGMENTATION == 1
-                // The message does not fit in the current batch, let's fragment it
-                // Create an expandable wbuf for fragmentation
-                _z_wbuf_t fbf = _z_wbuf_make(_Z_FRAG_BUFF_BASE_SIZE, true);
-
-                ret = _z_network_message_encode(&fbf, n_msg);  // Encode the message on the expandable wbuf
-                if (ret == _Z_RES_OK) {
-                    bool is_first = true;  // Fragment and send the message
-                    while (_z_wbuf_len(&fbf) > 0) {
-                        if (is_first == false) {  // Get the fragment sequence number
-                            sn = __unsafe_z_multicast_get_sn(ztm, reliability);
-                        }
-                        is_first = false;
-
-                        // Clear the buffer for serialization
-                        __unsafe_z_prepare_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-
-                        // Serialize one fragment
-                        ret = __unsafe_z_serialize_zenoh_fragment(&ztm->_wbuf, &fbf, reliability, sn);
-                        if (ret == _Z_RES_OK) {
-                            // Write the message length in the reserved space if needed
-                            __unsafe_z_finalize_wbuf(&ztm->_wbuf, ztm->_link._cap._flow);
-
-                            ret = _z_link_send_wbuf(&ztm->_link, &ztm->_wbuf);  // Send the wbuf on the socket
-                            if (ret == _Z_RES_OK) {
-                                ztm->_transmitted = true;  // Mark the session that we have transmitted data
-                            }
-                        } else {
-                            _Z_ERROR("Fragment serialization failed with err %d", ret);
-                        }
-                    }
-                }
-                // Clear the buffer as it's no longer required
-                _z_wbuf_clear(&fbf);
 #else
-                _Z_INFO("Sending the message required fragmentation feature that is deactivated.");
+    ret = __unsafe_z_multicast_message_send(ztm, n_msg, reliability);
 #endif
-            }
-        }
-
-    }
-
+    _z_multicast_tx_mutex_unlock(ztm);
     return ret;
+}
+
+z_result_t _z_multicast_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl) {
+#if Z_FEATURE_BATCHING == 1
+    _Z_DEBUG("Send network batch");
+    _z_transport_multicast_t *ztm = &zn->_tp._transport._multicast;
+    // Acquire the lock and drop the message if needed
+    z_result_t ret = _z_multicast_tx_mutex_lock(ztm, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh batch because of congestion control");
+        return ret;
+    }
+    // Send batch
+    ret = __unsafe_multicast_batch_send(ztm, reliability);
+    // Clean up
+    _z_wbuf_reset(&ztm->_wbuf);
+    _z_network_message_vec_clear(&ztm->_batch);
+    _z_multicast_tx_mutex_unlock(ztm);
+    return ret;
+#else
+    _ZP_UNUSED(zn);
+    _ZP_UNUSED(reliability);
+    _ZP_UNUSED(cong_ctrl);
+    _Z_ERROR("Tried to send batch but batching feature is deactivated.");
+    return _Z_ERR_TRANSPORT_TX_FAILED;
+#endif
 }
 
 #else
@@ -166,4 +263,12 @@ z_result_t _z_multicast_send_n_msg(_z_session_t *zn, const _z_network_message_t 
     _ZP_UNUSED(cong_ctrl);
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
+
+z_result_t _z_multicast_send_n_batch(_z_session_t *zn, z_reliability_t reliability, z_congestion_control_t cong_ctrl) {
+    _ZP_UNUSED(zn);
+    _ZP_UNUSED(reliability);
+    _ZP_UNUSED(cong_ctrl);
+    return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+}
+
 #endif  // Z_FEATURE_MULTICAST_TRANSPORT == 1

--- a/src/transport/multicast/tx.c
+++ b/src/transport/multicast/tx.c
@@ -44,9 +44,9 @@ static _z_zint_t __unsafe_z_multicast_get_sn(_z_transport_multicast_t *ztm, z_re
 #if Z_FEATURE_FRAGMENTATION == 1
 static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *ztm, _z_wbuf_t *fbf,
                                                      const _z_network_message_t *n_msg, z_reliability_t reliability,
-                                                     _z_zint_t *first_sn) {
+                                                     _z_zint_t first_sn) {
     bool is_first = true;
-    _z_zint_t sn = *first_sn;
+    _z_zint_t sn = first_sn;
     // Encode message on temp buffer
     _Z_RETURN_IF_ERR(_z_network_message_encode(fbf, n_msg));
     // Fragment message
@@ -73,7 +73,7 @@ static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *z
 #else
 static z_result_t __unsafe_z_multicast_send_fragment(_z_transport_multicast_t *ztm, _z_wbuf_t *fbf,
                                                      const _z_network_message_t *n_msg, z_reliability_t reliability,
-                                                     _z_zint_t *first_sn) {
+                                                     _z_zint_t first_sn) {
     _ZP_UNUSED(ztm);
     _ZP_UNUSED(fbf);
     _ZP_UNUSED(n_msg);
@@ -99,7 +99,7 @@ static z_result_t __unsafe_z_multicast_message_send(_z_transport_multicast_t *zt
         // Create an expandable wbuf for fragmentation
         _z_wbuf_t fbf = _z_wbuf_make(_Z_FRAG_BUFF_BASE_SIZE, true);
         // Send message as fragments
-        ret = __unsafe_z_multicast_send_fragment(ztm, &fbf, n_msg, reliability, &sn);
+        ret = __unsafe_z_multicast_send_fragment(ztm, &fbf, n_msg, reliability, sn);
         // Clear the buffer as it's no longer required
         _z_wbuf_clear(&fbf);
         return ret;

--- a/src/transport/raweth/rx.c
+++ b/src/transport/raweth/rx.c
@@ -22,6 +22,7 @@
 #include "zenoh-pico/protocol/core.h"
 #include "zenoh-pico/protocol/iobuf.h"
 #include "zenoh-pico/session/utils.h"
+#include "zenoh-pico/transport/multicast/transport.h"
 #include "zenoh-pico/transport/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
@@ -77,11 +78,7 @@ z_result_t _z_raweth_recv_t_msg_na(_z_transport_multicast_t *ztm, _z_transport_m
     _Z_DEBUG(">> recv session msg");
     z_result_t ret = _Z_RES_OK;
 
-#if Z_FEATURE_MULTI_THREAD == 1
-    // Acquire the lock
-    _z_mutex_lock(&ztm->_mutex_rx);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+    _z_multicast_rx_mutex_lock(ztm);
     // Prepare the buffer
     _z_zbuf_reset(&ztm->_zbuf);
 
@@ -105,11 +102,7 @@ z_result_t _z_raweth_recv_t_msg_na(_z_transport_multicast_t *ztm, _z_transport_m
         _Z_DEBUG(">> \t transport_message_decode: %ju", (uintmax_t)_z_zbuf_len(&ztm->_zbuf));
         ret = _z_transport_message_decode(t_msg, &ztm->_zbuf);
     }
-
-#if Z_FEATURE_MULTI_THREAD == 1
-    _z_mutex_unlock(&ztm->_mutex_rx);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+    _z_multicast_rx_mutex_unlock(ztm);
     return ret;
 }
 

--- a/src/transport/transport.c
+++ b/src/transport/transport.c
@@ -78,6 +78,48 @@ void _z_transport_free(_z_transport_t **zt) {
     *zt = NULL;
 }
 
+#if Z_FEATURE_BATCHING == 1
+bool _z_transport_start_batching(_z_transport_t *zt) {
+    uint8_t *batch_state = NULL;
+    switch (zt->_type) {
+        case _Z_TRANSPORT_UNICAST_TYPE:
+            batch_state = &zt->_transport._unicast._batch_state;
+            break;
+        case _Z_TRANSPORT_MULTICAST_TYPE:
+            batch_state = &zt->_transport._multicast._batch_state;
+            break;
+        case _Z_TRANSPORT_RAWETH_TYPE:
+            batch_state = &zt->_transport._raweth._batch_state;
+            break;
+        default:
+            break;
+    }
+    if (*batch_state == _Z_BATCHING_ACTIVE) {
+        return false;
+    }
+    *batch_state = _Z_BATCHING_ACTIVE;
+    return true;
+}
+
+void _z_transport_stop_batching(_z_transport_t *zt) {
+    uint8_t *batch_state = NULL;
+    switch (zt->_type) {
+        case _Z_TRANSPORT_UNICAST_TYPE:
+            batch_state = &zt->_transport._unicast._batch_state;
+            break;
+        case _Z_TRANSPORT_MULTICAST_TYPE:
+            batch_state = &zt->_transport._multicast._batch_state;
+            break;
+        case _Z_TRANSPORT_RAWETH_TYPE:
+            batch_state = &zt->_transport._raweth._batch_state;
+            break;
+        default:
+            break;
+    }
+    *batch_state = _Z_BATCHING_IDLE;
+}
+#endif
+
 /**
  * @brief Inserts an entry into `root`, allocating it a `_peer_id`
  *

--- a/src/transport/unicast/rx.c
+++ b/src/transport/unicast/rx.c
@@ -23,6 +23,7 @@
 #include "zenoh-pico/protocol/iobuf.h"
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/transport/unicast/rx.h"
+#include "zenoh-pico/transport/unicast/transport.h"
 #include "zenoh-pico/transport/utils.h"
 #include "zenoh-pico/utils/logging.h"
 
@@ -31,11 +32,7 @@
 z_result_t _z_unicast_recv_t_msg_na(_z_transport_unicast_t *ztu, _z_transport_message_t *t_msg) {
     _Z_DEBUG(">> recv session msg");
     z_result_t ret = _Z_RES_OK;
-#if Z_FEATURE_MULTI_THREAD == 1
-    // Acquire the lock
-    _z_mutex_lock(&ztu->_mutex_rx);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+    _z_unicast_rx_mutex_lock(ztu);
     size_t to_read = 0;
     do {
         switch (ztu->_link._cap._flow) {
@@ -84,11 +81,7 @@ z_result_t _z_unicast_recv_t_msg_na(_z_transport_unicast_t *ztu, _z_transport_me
             ztu->_received = true;
         }
     }
-
-#if Z_FEATURE_MULTI_THREAD == 1
-    _z_mutex_unlock(&ztu->_mutex_rx);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+    _z_unicast_rx_mutex_unlock(ztu);
     return ret;
 }
 

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -280,35 +280,6 @@ void _z_unicast_transport_clear(_z_transport_t *zt) {
     _z_link_clear(&ztu->_link);
 }
 
-#if Z_FEATURE_MULTI_THREAD == 1
-z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, bool block) {
-    if (block) {
-        _z_mutex_lock(&ztu->_mutex_tx);
-        return _Z_RES_OK;
-    } else {
-        return _z_mutex_try_lock(&ztu->_mutex_tx);
-    }
-}
-
-void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_tx); }
-
-void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _z_mutex_lock(&ztu->_mutex_rx); }
-
-void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_rx); }
-
-#else
-z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, z_congestion_control_t cc) {
-    _ZP_UNUSED(ztu);
-    _ZP_UNUSED(cc);
-    return _Z_RES_OK;
-}
-void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
-
-void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
-
-void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
 #else
 
 z_result_t _z_unicast_transport_create(_z_transport_t *zt, _z_link_t *zl,

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -270,6 +270,35 @@ void _z_unicast_transport_clear(_z_transport_t *zt) {
     _z_link_clear(&ztu->_link);
 }
 
+#if Z_FEATURE_MULTI_THREAD == 1
+z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, bool block) {
+    if (block) {
+        _z_mutex_lock(&ztu->_mutex_tx);
+        return _Z_RES_OK;
+    } else {
+        return _z_mutex_try_lock(&ztu->_mutex_tx);
+    }
+}
+
+void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_tx); }
+
+void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _z_mutex_lock(&ztu->_mutex_rx); }
+
+void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _z_mutex_unlock(&ztu->_mutex_rx); }
+
+#else
+z_result_t _z_unicast_tx_mutex_lock(_z_transport_unicast_t *ztu, z_congestion_control_t cc) {
+    _ZP_UNUSED(ztu);
+    _ZP_UNUSED(cc);
+    return _Z_RES_OK;
+}
+void _z_unicast_tx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+
+void _z_unicast_rx_mutex_lock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+
+void _z_unicast_rx_mutex_unlock(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+#endif  // Z_FEATURE_MULTI_THREAD == 1
+
 #else
 
 z_result_t _z_unicast_transport_create(_z_transport_t *zt, _z_link_t *zl,

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -55,7 +55,7 @@ static z_result_t __unsafe_z_unicast_send_fragment(_z_transport_unicast_t *ztu, 
     // Fragment message
     while (_z_wbuf_len(fbf) > 0) {
         // Get fragment sequence number
-        if (is_first == false) {
+        if (!is_first) {
             sn = __unsafe_z_unicast_get_sn(ztu, reliability);
         }
         is_first = false;

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -163,7 +163,6 @@ static z_result_t __unsafe_unicast_batch_send(_z_transport_unicast_t *ztu, z_rel
                 _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztu->_link, &ztu->_wbuf));
                 ztu->_transmitted = true;
                 // Reset frame
-                _z_wbuf_reset(&ztu->_wbuf);
                 __unsafe_z_prepare_wbuf(&ztu->_wbuf, ztu->_link._cap._flow);
                 sn = __unsafe_z_unicast_get_sn(ztu, reliability);
                 t_msg = _z_t_msg_make_frame_header(sn, reliability);
@@ -242,7 +241,6 @@ z_result_t _z_unicast_send_n_batch(_z_session_t *zn, z_reliability_t reliability
     // Send batch
     ret = __unsafe_unicast_batch_send(ztu, reliability);
     // Clean up
-    _z_wbuf_reset(&ztu->_wbuf);
     _z_network_message_vec_clear(&ztu->_batch);
     _z_unicast_tx_mutex_unlock(ztu);
     return ret;

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -154,7 +154,7 @@ static z_result_t __unsafe_unicast_batch_send(_z_transport_unicast_t *ztu, z_rel
                 _Z_INFO("Dropping batch because one message is too big (need to be fragmented)");
                 return _Z_ERR_TRANSPORT_TX_FAILED;
             } else {  // Frame has messages but is full
-                _Z_INFO("Sending batch in uniple frames because it is too big for one");
+                _Z_INFO("Sending batch in multiple frames because it is too big for one");
                 // Send frame
                 __unsafe_z_finalize_wbuf(&ztu->_wbuf, ztu->_link._cap._flow);
                 _Z_RETURN_IF_ERR(_z_link_send_wbuf(&ztu->_link, &ztu->_wbuf));

--- a/src/transport/unicast/tx.c
+++ b/src/transport/unicast/tx.c
@@ -47,9 +47,9 @@ static _z_zint_t __unsafe_z_unicast_get_sn(_z_transport_unicast_t *ztu, z_reliab
 #if Z_FEATURE_FRAGMENTATION == 1
 static z_result_t __unsafe_z_unicast_send_fragment(_z_transport_unicast_t *ztu, _z_wbuf_t *fbf,
                                                    const _z_network_message_t *n_msg, z_reliability_t reliability,
-                                                   _z_zint_t *first_sn) {
+                                                   _z_zint_t first_sn) {
     bool is_first = true;
-    _z_zint_t sn = *first_sn;
+    _z_zint_t sn = first_sn;
     // Encode message on temp buffer
     _Z_RETURN_IF_ERR(_z_network_message_encode(fbf, n_msg));
     // Fragment message
@@ -76,7 +76,7 @@ static z_result_t __unsafe_z_unicast_send_fragment(_z_transport_unicast_t *ztu, 
 #else
 static z_result_t __unsafe_z_unicast_send_fragment(_z_transport_unicast_t *ztu, _z_wbuf_t *fbf,
                                                    const _z_network_message_t *n_msg, z_reliability_t reliability,
-                                                   _z_zint_t *first_sn) {
+                                                   _z_zint_t first_sn) {
     _ZP_UNUSED(ztu);
     _ZP_UNUSED(fbf);
     _ZP_UNUSED(n_msg);
@@ -102,7 +102,7 @@ static z_result_t __unsafe_z_unicast_message_send(_z_transport_unicast_t *ztu, c
         // Create an expandable wbuf for fragmentation
         _z_wbuf_t fbf = _z_wbuf_make(_Z_FRAG_BUFF_BASE_SIZE, true);
         // Send message as fragments
-        ret = __unsafe_z_unicast_send_fragment(ztu, &fbf, n_msg, reliability, &sn);
+        ret = __unsafe_z_unicast_send_fragment(ztu, &fbf, n_msg, reliability, sn);
         // Clear the buffer as it's no longer required
         _z_wbuf_clear(&fbf);
         return ret;


### PR DESCRIPTION
Closes #298. This adds an API to do manual batching which yields improved throughput performance for smaller packets.

User can start batching with `zp_start_batching`, any subsequent api call that would have put a network message (`z_put`, `z_get`, `z_declare`...) is bufferized to be later sent as a batch (or multiple batches) when user calls `zp_stop_batching`.

While I was modifying the transports I decided to refactor a little because the functions were too complicated to parse.