### PR TITLE
Fix read/lease task cleanup

### DIFF
--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -185,11 +185,11 @@ void _z_multicast_transport_clear(_z_transport_t *zt) {
     // Clean up tasks
     if (ztm->_read_task != NULL) {
         _z_task_join(ztm->_read_task);
-        _z_task_free(&ztm->_read_task);
+        z_free(ztm->_read_task);
     }
     if (ztm->_lease_task != NULL) {
         _z_task_join(ztm->_lease_task);
-        _z_task_free(&ztm->_lease_task);
+        z_free(ztm->_lease_task);
     }
     // Clean up the mutexes
     _z_mutex_drop(&ztm->_mutex_tx);

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -281,11 +281,11 @@ void _z_unicast_transport_clear(_z_transport_t *zt) {
     // Clean up tasks
     if (ztu->_read_task != NULL) {
         _z_task_join(ztu->_read_task);
-        _z_task_free(&ztu->_read_task);
+        z_free(ztu->_read_task);
     }
     if (ztu->_lease_task != NULL) {
         _z_task_join(ztu->_lease_task);
-        _z_task_free(&ztu->_lease_task);
+        z_free(ztu->_lease_task);
     }
 
     // Clean up the mutexes


### PR DESCRIPTION
The _lease_task and _read_task was allocated with `malloc` and should be cleaned with `free`