### PR TITLE
Fix: system call error processing

### DIFF
--- a/include/zenoh-pico/system/platform_common.h
+++ b/include/zenoh-pico/system/platform_common.h
@@ -55,16 +55,13 @@
 extern "C" {
 #endif
 
-void _z_report_system_error(int errcode);
-
-#define _Z_CHECK_SYS_ERR(expr)             \
-    do {                                   \
-        int __res = expr;                  \
-        if (__res != 0) {                  \
-            _z_report_system_error(__res); \
-            return _Z_ERR_SYSTEM_GENERIC;  \
-        }                                  \
-        return _Z_RES_OK;                  \
+#define _Z_CHECK_SYS_ERR(expr)            \
+    do {                                  \
+        int __res = expr;                 \
+        if (__res > 0) {                  \
+            return _Z_ERR_SYSTEM_GENERIC; \
+        }                                 \
+        return __res;                     \
     } while (false)
 
 /*------------------ Random ------------------*/

--- a/src/system/platform_common.c
+++ b/src/system/platform_common.c
@@ -16,8 +16,6 @@
 #include "zenoh-pico/api/olv_macros.h"
 #include "zenoh-pico/utils/logging.h"
 
-void _z_report_system_error(int errcode) { _Z_ERROR("System error: %i", errcode); }
-
 #if Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Thread ------------------*/


### PR DESCRIPTION
OK, found the issue, it relates to PR #586 ( Fix system calls return error processing) 

Causes compilation errors:
> C:/gnu_arm_embedded_13/bin/../lib/gcc/arm-none-eabi/13.3.1/../../../../arm-none-eabi/bin/ld.bfd.exe: modules/zenoh-pico/lib..__external__zenoh-pico__zephyr.a(system.c.obj): in function _z_task_init': C:/zephyr/external/zenoh-pico/src/system/zephyr/system.c:83:(.text._z_task_init+0x3c): undefined reference to _z_report_system_error'



They are calling a function within a Marco which causes a compilation problem:

```
void _z_report_system_error(int errcode);

#define _Z_CHECK_SYS_ERR(expr)             \
    do {                                   \
        int __res = expr;                  \
        if (__res != 0) {                  \
            _z_report_system_error(__res); \
            return _Z_ERR_SYSTEM_GENERIC;  \
        }                                  \
        return _Z_RES_OK;                  \
    } while (false)
```
Unfortunately, #define is a pre-processor directive used in C programs to define macros so the function has not been defined. Removing the function call and some logic amends it could be:

```
#define _Z_CHECK_SYS_ERR(expr)            \
    do {                                  \
        int __res = expr;                 \
        if (__res > 0) {                  \
            return _Z_ERR_SYSTEM_GENERIC; \
        }                                 \
        return __res;                     \
    } while (false)
```


Fixes Issue: #775 [Bug] zenoh-pico: zephyr: Compilation Errors

Billy..