### PR TITLE
Implement condition variables for Mbed and FreeRTOS-Plus-TCP ports

### DIFF
--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -40,7 +40,15 @@ typedef struct {
 } _z_task_t;
 
 typedef SemaphoreHandle_t _z_mutex_t;
-typedef void *_z_condvar_t;
+typedef struct {
+    SemaphoreHandle_t mutex;
+    SemaphoreHandle_t sem;
+    int waiters;
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    StaticSemaphore_t mutex_buffer;
+    StaticSemaphore_t sem_buffer;
+#endif /* SUPPORT_STATIC_ALLOCATION */
+} _z_condvar_t;
 #endif  // Z_MULTI_THREAD == 1
 
 typedef TickType_t z_clock_t;

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -163,7 +163,7 @@ z_result_t _z_condvar_init(_z_condvar_t *cv) {
     }
 
 #if (configSUPPORT_STATIC_ALLOCATION == 1)
-    cv->mutex = xSemaphoreCreateRecursiveMutexStatic(&cv->mutex_buffer);
+    cv->mutex = xSemaphoreCreateMutexStatic(&cv->mutex_buffer);
     cv->sem = xSemaphoreCreateCountingStatic((UBaseType_t)(~0), 0, &cv->sem_buffer);
 #else
     cv->mutex = xSemaphoreCreateMutex();

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -149,7 +149,7 @@ z_result_t _z_condvar_signal_all(_z_condvar_t *cv) {
     }
     cond_var.mutex.unlock();
 
-    return _z_RES_OK;
+    return _Z_RES_OK;
 }
 
 z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) {


### PR DESCRIPTION
The current implementation of condition variables in mbed port is completely broken. The [ConditionVariable class](https://os.mbed.com/docs/mbed-os/v6.16/apis/rtos-apis.html) can't be used with z_condvar APIs as it requires passing a Mutex in the constructor. I got "inspired" by the implementation of this class and wrote a custom condition variable implementation that works with z_condvar interfaces. I also adapted this implementation for FreeRTOS-Plus-TCP port.