### PR TITLE
FreeRTOS-Plus-TCP port fixes

### DIFF
--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -37,6 +37,11 @@ typedef struct {
 typedef struct {
     TaskHandle_t handle;
     EventGroupHandle_t join_event;
+    void *(*fun)(void *);
+    void *arg;
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    StaticEventGroup_t join_event_buffer;
+#endif /* SUPPORT_STATIC_ALLOCATION */
 } _z_task_t;
 
 typedef struct {

--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -14,6 +14,8 @@
 #ifndef ZENOH_PICO_SYSTEM_FREERTOS_PLUS_TCP_TYPES_H
 #define ZENOH_PICO_SYSTEM_FREERTOS_PLUS_TCP_TYPES_H
 
+#include <time.h>
+
 #include "FreeRTOS.h"
 #include "FreeRTOS_IP.h"
 #include "semphr.h"
@@ -62,7 +64,7 @@ typedef struct {
 #endif  // Z_MULTI_THREAD == 1
 
 typedef TickType_t z_clock_t;
-typedef TickType_t z_time_t;
+typedef struct timeval z_time_t;
 
 typedef struct {
     union {

--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -39,7 +39,12 @@ typedef struct {
     EventGroupHandle_t join_event;
 } _z_task_t;
 
-typedef SemaphoreHandle_t _z_mutex_t;
+typedef struct {
+    SemaphoreHandle_t handle;
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    StaticSemaphore_t buffer;
+#endif /* SUPPORT_STATIC_ALLOCATION */
+} _z_mutex_t;
 typedef struct {
     SemaphoreHandle_t mutex;
     SemaphoreHandle_t sem;

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -121,12 +121,16 @@ z_result_t _z_task_join(_z_task_t *task) {
 }
 
 z_result_t _z_task_detach(_z_task_t *task) {
-    // Not implemented
-    return _Z_ERR_GENERIC;
+    // Note: task/thread detach not supported on FreeRTOS API, so we force its deletion instead.
+    return _z_task_cancel(task);
 }
 
 z_result_t _z_task_cancel(_z_task_t *task) {
-    vTaskDelete(task->handle);
+    xEventGroupSetBits(task->join_event, 1);
+    if (task->handle != NULL) {
+        vTaskDelete(task->handle);
+        task->handle = NULL;
+    }
     return 0;
 }
 

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -117,7 +117,7 @@ z_result_t _z_task_init(_z_task_t *task, z_task_attr_t *attr, void *(*fun)(void 
 
 z_result_t _z_task_join(_z_task_t *task) {
     xEventGroupWaitBits(task->join_event, 1, pdFALSE, pdFALSE, portMAX_DELAY);
-    return 0;
+    return _Z_RES_OK;
 }
 
 z_result_t _z_task_detach(_z_task_t *task) {
@@ -131,7 +131,7 @@ z_result_t _z_task_cancel(_z_task_t *task) {
         vTaskDelete(task->handle);
         task->handle = NULL;
     }
-    return 0;
+    return _Z_RES_OK;
 }
 
 void _z_task_free(_z_task_t **task) {
@@ -249,17 +249,17 @@ z_result_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) {
 /*------------------ Sleep ------------------*/
 z_result_t z_sleep_us(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time / 1000));
-    return 0;
+    return _Z_RES_OK;
 }
 
 z_result_t z_sleep_ms(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time));
-    return 0;
+    return _Z_RES_OK;
 }
 
 z_result_t z_sleep_s(size_t time) {
     vTaskDelay(pdMS_TO_TICKS(time * 1000));
-    return 0;
+    return _Z_RES_OK;
 }
 
 /*------------------ Clock ------------------*/

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -135,8 +135,9 @@ z_result_t _z_task_cancel(_z_task_t *task) {
 }
 
 void _z_task_free(_z_task_t **task) {
-    z_free((*task)->join_event);
-    z_free(*task);
+    _z_task_t *ptr = *task;
+    vEventGroupDelete(ptr->join_event);
+    *task = NULL;
 }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -107,7 +107,7 @@ z_result_t _z_task_init(_z_task_t *task, z_task_attr_t *attr, void *(*fun)(void 
     } else {
 #endif /* SUPPORT_STATIC_ALLOCATION */
         if (xTaskCreate(z_task_wrapper, attr->name, attr->stack_depth, task, attr->priority, &task->handle) != pdPASS) {
-            return -1;
+            return _Z_ERR_GENERIC;
         }
 #if (configSUPPORT_STATIC_ALLOCATION == 1)
     }
@@ -321,5 +321,5 @@ z_result_t _z_get_time_since_epoch(_z_time_since_epoch *t) {
     gettimeofday(&now, NULL);
     t->secs = (uint32_t)now.tv_sec;
     t->nanos = (uint32_t)now.tv_usec * 1000;
-    return 0;
+    return _Z_RES_OK;
 }

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -128,10 +128,14 @@ z_result_t _z_task_detach(_z_task_t *task) {
 
 z_result_t _z_task_cancel(_z_task_t *task) {
     xEventGroupSetBits(task->join_event, 1);
+
+    taskENTER_CRITICAL();
     if (task->handle != NULL) {
         vTaskDelete(task->handle);
         task->handle = NULL;
     }
+    taskEXIT_CRITICAL();
+
     return _Z_RES_OK;
 }
 

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -51,6 +51,8 @@ void z_random_fill(void *buf, size_t len) {
 void *z_malloc(size_t size) { return pvPortMalloc(size); }
 
 void *z_realloc(void *ptr, size_t size) {
+    _ZP_UNUSED(ptr);
+    _ZP_UNUSED(size);
     // realloc not implemented in FreeRTOS
     return NULL;
 }


### PR DESCRIPTION
1. Fixed mutex drop by using vSemaphoreDelete instead of z_free.
2. Added static allocation support to mutexes.
3. Fixed _z_task_detach by pointing it to _z_task_cancel.
4. Fixed freeing task resources. The current implementation does not make much sense.
5. Fixed issues with task cancelling and joining.
6. Used gettimeofday for z_time functions. It doesn't really make sense to use tick count for this. If compiled with newlib for a target that does not support this function, user can just implement `_gettimeofday` if needed.