### PR TITLE
Fix ASAN build and enable it for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,13 +465,13 @@ if(UNIX)
   install(FILES "${CMAKE_SOURCE_DIR}/zenohpico.pc" CONFIGURATIONS Release RelWithDebInfo DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT Dev)
 endif()
 
-if(BUILD_EXAMPLES)
-  add_subdirectory(examples)
-endif()
-
 if(ASAN AND NOT MSVC)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+endif()
+
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()
 
 if(UNIX OR MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,7 +469,7 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-if(ASAN AND !MSVC)
+if(ASAN AND NOT MSVC)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
 endif()


### PR DESCRIPTION
Fix typo in CMakeLists.txt to enable ASAN build and enable it for examples