### PR TITLE
fix: Add CI status and change build-check to ci

### DIFF
--- a/.github/workflows/build-shared.yaml
+++ b/.github/workflows/build-shared.yaml
@@ -14,10 +14,7 @@
 name: build-shared
 
 on:
-  push:
-    branches: [ '**' ]
-  pull_request:
-    branches: [ '**' ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build-static.yaml
+++ b/.github/workflows/build-static.yaml
@@ -14,10 +14,7 @@
 name: build-static
 
 on:
-  push:
-    branches: [ '**' ]
-  pull_request:
-    branches: [ '**' ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,10 @@ jobs:
           config: '.markdownlint.yaml'
           globs: '**/README.md'
 
+  build_shared:
+    name: Build shared libs
+    uses: ./.github/workflows/build-shared.yaml
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
     uses: ./.github/workflows/build-shared.yaml
 
   build_static:
-    name: Build shared libs
+    name: Build static libs
     uses: ./.github/workflows/build-static.yaml
 
   integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
     branches: ["**"]
   pull_request:
     branches: ["**"]
+  schedule:
+    - cron: "0 6 * * 1-5"
 
 jobs:
   run_tests:
@@ -309,6 +311,14 @@ jobs:
     name: Build shared libs
     uses: ./.github/workflows/build-shared.yaml
 
+  build_static:
+    name: Build shared libs
+    uses: ./.github/workflows/build-static.yaml
+
+  integration:
+    name: Run integration tests
+    uses: ./.github/workflows/integration.yaml
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -317,7 +327,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, markdown_lint]
+    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, markdown_lint, build_shared, build_static, integration]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
-name: build-check
+name: CI
 
 on:
   push:
@@ -304,3 +304,17 @@ jobs:
         with:
           config: '.markdownlint.yaml'
           globs: '**/README.md'
+
+  # NOTE: In GitHub repository settings, the "Require status checks to pass
+  # before merging" branch protection rule ensures that commits are only merged
+  # from branches where specific status checks have passed. These checks are
+  # specified manually as a list of workflow job names. Thus we use this extra
+  # job to signal whether all CI checks have passed.
+  ci:
+    name: CI status checks
+    runs-on: ubuntu-latest
+    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, markdown_lint]
+    if: always()
+    steps:
+      - name: Check whether all jobs pass
+        run: echo '${{ toJson(needs) }}' | jq -e 'all(.result == "success")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
         if: always()
         run: kill ${{ steps.run-zenoh.outputs.zenohd-pid }}
 
-  no_routeur:
+  no_router:
     name: Test examples without router
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,10 @@ jobs:
     name: Run integration tests
     uses: ./.github/workflows/integration.yaml
 
+  multicast:
+    name: Run multicast tests
+    uses: ./.github/workflows/multicast.yaml
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -327,7 +331,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, markdown_lint, build_shared, build_static, integration]
+    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, markdown_lint, build_shared, build_static, integration, multicast]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,12 +14,7 @@
 name: integration
 
 on:
-  push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
-  schedule:
-    - cron: "0 6 * * 1-5"
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/multicast.yaml
+++ b/.github/workflows/multicast.yaml
@@ -14,12 +14,7 @@
 name: multicast
 
 on:
-  push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
-  schedule:
-    - cron: "0 6 * * 1-5"
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
Align zenoh-pico with the rest of the zenoh ecosystem in terms of CI,
 - rename build-check.yml to ci.yml
 - Include CI status check to ci.yml