### PR TITLE
add possibility to get contiguous view of z_bytes data when it is not fragmented

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,6 +223,7 @@ see details at :ref:`owned_types_concept`
 .. c:type:: z_moved_bytes_writter_t
 
 .. autoctype:: types.h::z_bytes_reader_t
+.. autoctype:: types.h::z_bytes_slice_iterator_t
 
 Functions
 ^^^^^^^^^
@@ -240,6 +241,10 @@ Functions
 .. autocfunction:: primitives.h::z_bytes_copy_from_string
 .. autocfunction:: primitives.h::z_bytes_to_slice
 .. autocfunction:: primitives.h::z_bytes_to_string
+
+.. autocfunction:: primitives.h::z_bytes_get_contiguous_view
+.. autocfunction:: primitives.h::z_bytes_get_slice_iterator
+.. autocfunction:: primitives.h::z_bytes_slice_iterator_next
 
 .. autocfunction:: primitives.h::z_bytes_get_reader
 .. autocfunction:: primitives.h::z_bytes_reader_read

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -457,7 +457,7 @@ z_result_t z_slice_from_buf(z_owned_slice_t *slice, uint8_t *data, size_t len,
  * Return:
  *   ``0`` if creation is successful, ``negative value`` otherwise.
  */
-z_result_t z_view_slice_from_buf(z_view_slice_t *slice, uint8_t *data, size_t len);
+z_result_t z_view_slice_from_buf(z_view_slice_t *slice, const uint8_t *data, size_t len);
 
 /**
  * Builds an empty :c:type:`z_owned_slice_t`.
@@ -684,6 +684,23 @@ size_t z_bytes_len(const z_loaned_bytes_t *bytes);
  *   ``true`` if conainer is empty,  ``false`` otherwise.
  */
 bool z_bytes_is_empty(const z_loaned_bytes_t *bytes);
+
+#if defined(Z_FEATURE_UNSTABLE_API)
+/**
+ * Attempts to get a contiguous view to the underlying bytes (unstable).
+ *
+ * This is only possible if data is not fragmented, otherwise the function will fail.
+ * In case of fragmented data, consider using `z_bytes_get_slice_iterator()`.
+ *
+ * Parameters:
+ *   bytes: An instance of Zenoh data.
+ *   view: An uninitialized memory location where a contiguous view on data will be constructed.
+ *
+ * Return:
+ *   ``0`` in case of success, ``negative value`` otherwise.
+ */
+z_result_t z_bytes_get_contiguous_view(const z_loaned_bytes_t *bytes, z_view_slice_t *view);
+#endif
 
 /**
  * Returns an iterator on raw bytes slices contained in the `z_loaned_bytes_t`.


### PR DESCRIPTION
add  z_bytes_get_contiguous_view function similar to https://github.com/eclipse-zenoh/zenoh-c/pull/865;
fix z_view_slice_from_buf signature to correspond to that of zenoh-c;
fix docs to include z_bytes_slice_iterator -related functionality;