### PR TITLE
Adjust rpi_pico default stack size

### DIFF
--- a/.github/workflows/rpi_pico.yaml
+++ b/.github/workflows/rpi_pico.yaml
@@ -50,6 +50,8 @@ jobs:
           mkdir -p $FREERTOS_KERNEL_PATH
           cd $FREERTOS_KERNEL_PATH
           git clone https://github.com/FreeRTOS/FreeRTOS-Kernel.git .
+          # Some version witch aleready supports the Pico SDK but not the latest, because sometimes latest is broken
+          git checkout e169442c29ba8e26faf033cc0886029dd5812979 
           git submodule update --init
           
       - name: Build examples

--- a/src/system/rpi_pico/system.c
+++ b/src/system/rpi_pico/system.c
@@ -72,7 +72,7 @@ static void z_task_wrapper(void *arg) {
 static z_task_attr_t z_default_task_attr = {
     .name = "",
     .priority = configMAX_PRIORITIES / 2,
-    .stack_depth = 5120,
+    .stack_depth = 1024,
 };
 
 /*------------------ Thread ------------------*/


### PR DESCRIPTION
The default stack is excessively large, for most tasks (including read and lease tasks) 1024 blocks (4kb) are enough
\+ fix FreeRTOS version in CI