### PR TITLE
Add querier matching support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1242,6 +1242,9 @@ Functions
 .. autocfunction:: primitives.h::z_undeclare_querier
 .. autocfunction:: primitives.h::z_querier_get
 .. autocfunction:: primitives.h::z_querier_keyexpr
+.. autocfunction:: primitives.h::z_querier_get_matching_status
+.. autocfunction:: primitives.h::z_querier_declare_matching_listener
+.. autocfunction:: primitives.h::z_querier_declare_background_matching_listener
 
 .. autocfunction:: primitives.h::z_querier_options_default
 .. autocfunction:: primitives.h::z_querier_get_options_default

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1843,6 +1843,55 @@ z_result_t z_querier_get(const z_loaned_querier_t *querier, const char *paramete
  * .. warning:: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
  */
 const z_loaned_keyexpr_t *z_querier_keyexpr(const z_loaned_querier_t *querier);
+
+#if Z_FEATURE_MATCHING == 1
+/**
+ * Declares a matching listener, registering a callback for notifying queryables matching the given querier key
+ * expression and target. The callback will be run in the background until the corresponding querier is dropped.
+ *
+ * Parameters:
+ *   querier: A querier to associate with matching listener.
+ *   callback: A closure that will be called every time the matching status of the querier changes (If last
+ *             queryable disconnects or when the first queryable connects).
+ *
+ * Return:
+ *   ``0`` if put operation is successful, ``negative value`` otherwise.
+ *
+ * .. warning:: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ */
+z_result_t z_querier_declare_background_matching_listener(const z_loaned_querier_t *querier,
+                                                          z_moved_closure_matching_status_t *callback);
+/**
+ * Constructs matching listener, registering a callback for notifying queryables matching with a given querier's
+ * key expression and target.
+ *
+ * Parameters:
+ *   querier: A querier to associate with matching listener.
+ *   matching_listener: An uninitialized memory location where matching listener will be constructed. The matching
+ *                      listener's callback will be automatically dropped when the querier is dropped.
+ *   callback: A closure that will be called every time the matching status of the querier changes (If last
+ *             queryable disconnects or when the first queryable connects).
+ *
+ * Return:
+ *   ``0`` if put operation is successful, ``negative value`` otherwise.
+ *
+ * .. warning:: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ */
+z_result_t z_querier_declare_matching_listener(const z_loaned_querier_t *querier,
+                                               z_owned_matching_listener_t *matching_listener,
+                                               z_moved_closure_matching_status_t *callback);
+/**
+ * Gets querier matching status - i.e. if there are any queryables matching its key expression and target.
+ *
+ * Return:
+ *   ``0`` if put operation is successful, ``negative value`` otherwise.
+ *
+ * .. warning:: This API has been marked as unstable: it works as advertised, but it may be changed in a future release.
+ */
+z_result_t z_querier_get_matching_status(const z_loaned_querier_t *querier, z_matching_status_t *matching_status);
+
+#endif  // Z_FEATURE_MATCHING == 1
+
 #endif  // Z_FEATURE_UNSTABLE_API
 
 /**

--- a/include/zenoh-pico/net/matching.h
+++ b/include/zenoh-pico/net/matching.h
@@ -29,7 +29,7 @@ typedef struct _z_matching_listener_t {
 
 #if Z_FEATURE_MATCHING == 1
 _z_matching_listener_t _z_matching_listener_declare(_z_session_rc_t *zn, const _z_keyexpr_t *key, _z_zint_t entity_id,
-                                                    _z_closure_matching_status_t callback);
+                                                    uint8_t interest_type_flag, _z_closure_matching_status_t callback);
 z_result_t _z_matching_listener_entity_undeclare(_z_session_t *zn, _z_zint_t entity_id);
 z_result_t _z_matching_listener_undeclare(_z_matching_listener_t *listener);
 // Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
@@ -37,8 +37,8 @@ static inline _z_matching_listener_t _z_matching_listener_null(void) { return (_
 static inline bool _z_matching_listener_check(const _z_matching_listener_t *matching_listener) {
     return !_Z_RC_IS_NULL(&matching_listener->_zn);
 }
-void _z_matching_listener_clear(_z_matching_listener_t *pub);
-void _z_matching_listener_free(_z_matching_listener_t **pub);
+void _z_matching_listener_clear(_z_matching_listener_t *listener);
+void _z_matching_listener_free(_z_matching_listener_t **listener);
 #endif  // Z_FEATURE_MATCHING == 1
 
 #ifdef __cplusplus

--- a/include/zenoh-pico/session/matching.h
+++ b/include/zenoh-pico/session/matching.h
@@ -36,6 +36,9 @@ typedef struct {
 } _z_closure_matching_status_t;
 
 #if Z_FEATURE_MATCHING == 1
+
+#define _Z_MATCHING_LISTENER_CTX_NULL_ID 0xFFFFFFFF
+
 typedef struct _z_matching_listener_ctx_t {
     uint32_t decl_id;
     _z_closure_matching_status_t callback;

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -541,6 +541,9 @@ z_result_t _z_undeclare_querier(_z_querier_t *querier) {
     if (querier == NULL || _Z_RC_IS_NULL(&querier->_zn)) {
         return _Z_ERR_ENTITY_UNKNOWN;
     }
+#if Z_FEATURE_MATCHING == 1
+    _z_matching_listener_entity_undeclare(_Z_RC_IN_VAL(&querier->_zn), querier->_id);
+#endif
     _z_write_filter_destroy(_Z_RC_IN_VAL(&querier->_zn), &querier->_filter);
     _z_undeclare_resource(_Z_RC_IN_VAL(&querier->_zn), querier->_key._id);
     return _Z_RES_OK;

--- a/src/session/matching.c
+++ b/src/session/matching.c
@@ -18,7 +18,7 @@
 _z_matching_listener_ctx_t *_z_matching_listener_ctx_new(_z_closure_matching_status_t callback) {
     _z_matching_listener_ctx_t *ctx = z_malloc(sizeof(_z_matching_listener_ctx_t));
 
-    ctx->decl_id = 0;
+    ctx->decl_id = _Z_MATCHING_LISTENER_CTX_NULL_ID;
     ctx->callback = callback;
 
     return ctx;


### PR DESCRIPTION
Add querier matching support.

New API methods:

- z_querier_declare_matching_listener
- z_querier_declare_background_matching_listener
- z_querier_get_matching_status

Test:
- z_api_matching_test

Example:
- z_querier with -a key

Additionally fixed bug with multiple sequential matching/unmatching