### PR TITLE
Fix transport tasks cleanup

### DIFF
--- a/include/zenoh-pico/system/common/platform.h
+++ b/include/zenoh-pico/system/common/platform.h
@@ -149,6 +149,7 @@ z_result_t _z_task_init(_z_task_t *task, z_task_attr_t *attr, void *(*fun)(void 
 z_result_t _z_task_join(_z_task_t *task);
 z_result_t _z_task_detach(_z_task_t *task);
 z_result_t _z_task_cancel(_z_task_t *task);
+void _z_task_exit(void);
 void _z_task_free(_z_task_t **task);
 
 /**

--- a/src/system/arduino/esp32/system.c
+++ b/src/system/arduino/esp32/system.c
@@ -97,6 +97,8 @@ z_result_t _z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
+void _z_task_exit(void) { vTaskDelete(NULL); }
+
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);

--- a/src/system/arduino/opencr/system.c
+++ b/src/system/arduino/opencr/system.c
@@ -71,6 +71,8 @@ z_result_t _z_task_detach(_z_task_t *task) { return -1; }
 
 z_result_t _z_task_cancel(_z_task_t *task) { return -1; }
 
+void _z_task_exit(void) {}
+
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -56,6 +56,8 @@ z_result_t _z_task_detach(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_detach(*ta
 
 z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*task)); }
 
+void _z_task_exit(void) { pthread_exit(NULL); }
+
 void _z_task_free(_z_task_t **task) { *task = NULL; }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -58,7 +58,11 @@ z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*ta
 
 void _z_task_exit(void) { pthread_exit(NULL); }
 
-void _z_task_free(_z_task_t **task) { *task = NULL; }
+void _z_task_free(_z_task_t **task) {
+    _z_task_t *ptr = *task;
+    z_free(ptr);
+    *task = NULL;
+}
 
 /*------------------ Mutex ------------------*/
 z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -126,6 +126,8 @@ z_result_t z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
+void _z_task_exit(void) { vTaskDelete(NULL); }
+
 void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -129,6 +129,7 @@ z_result_t z_task_cancel(_z_task_t *task) {
 void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);
+    *task = NULL;
 }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -129,8 +129,9 @@ z_result_t z_task_cancel(_z_task_t *task) {
 void _z_task_exit(void) { vTaskDelete(NULL); }
 
 void _z_task_free(_z_task_t **task) {
-    z_free((*task)->join_event);
-    z_free(*task);
+    _z_task_t *ptr = *task;
+    z_free(ptr->join_event);
+    z_free(ptr);
     *task = NULL;
 }
 

--- a/src/system/flipper/system.c
+++ b/src/system/flipper/system.c
@@ -91,6 +91,8 @@ z_result_t _z_task_detach(_z_task_t* task) { return -1; }
 
 z_result_t _z_task_cancel(_z_task_t* task) { return -1; }
 
+void _z_task_exit(void) {}
+
 void _z_task_free(_z_task_t** task) {
     if (task == NULL || *task == NULL) {
         return;

--- a/src/system/flipper/system.c
+++ b/src/system/flipper/system.c
@@ -98,6 +98,7 @@ void _z_task_free(_z_task_t** task) {
         return;
     }
     furi_thread_free(**task);
+    z_free(*task);
     *task = NULL;
 }
 

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -159,6 +159,8 @@ z_result_t _z_task_cancel(_z_task_t *task) {
     return _Z_RES_OK;
 }
 
+void _z_task_exit(void) { vTaskDelete(NULL); }
+
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     vEventGroupDelete(ptr->join_event);

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -164,6 +164,7 @@ void _z_task_exit(void) { vTaskDelete(NULL); }
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     vEventGroupDelete(ptr->join_event);
+    z_free(ptr);
     *task = NULL;
 }
 

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -142,8 +142,8 @@ z_result_t _z_task_join(_z_task_t *task) {
 }
 
 z_result_t _z_task_detach(_z_task_t *task) {
-    // Note: task/thread detach not supported on FreeRTOS API, so we force its deletion instead.
-    return _z_task_cancel(task);
+    _ZP_UNUSED(task);
+    return _Z_ERR_GENERIC;
 }
 
 z_result_t _z_task_cancel(_z_task_t *task) {

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -64,6 +64,8 @@ z_result_t _z_task_cancel(_z_task_t *task) {
     return res;
 }
 
+void _z_task_exit(void) {}
+
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     z_free(ptr);

--- a/src/system/rpi_pico/system.c
+++ b/src/system/rpi_pico/system.c
@@ -120,6 +120,7 @@ z_result_t _z_task_cancel(_z_task_t *task) {
 void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);
+    *task = NULL;
 }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/rpi_pico/system.c
+++ b/src/system/rpi_pico/system.c
@@ -120,8 +120,9 @@ z_result_t _z_task_cancel(_z_task_t *task) {
 void _z_task_exit(void) { vTaskDelete(NULL); }
 
 void _z_task_free(_z_task_t **task) {
-    z_free((*task)->join_event);
-    z_free(*task);
+    _z_task_t *ptr = *task;
+    z_free(ptr->join_event);
+    z_free(ptr);
     *task = NULL;
 }
 

--- a/src/system/rpi_pico/system.c
+++ b/src/system/rpi_pico/system.c
@@ -117,6 +117,8 @@ z_result_t _z_task_cancel(_z_task_t *task) {
     return 0;
 }
 
+void _z_task_exit(void) { vTaskDelete(NULL); }
+
 void _z_task_free(_z_task_t **task) {
     z_free((*task)->join_event);
     z_free(*task);

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -13,6 +13,7 @@
 //
 
 #include <errno.h>
+#include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -113,6 +114,8 @@ z_result_t _z_task_join(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_join(*task, 
 z_result_t _z_task_detach(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_detach(*task)); }
 
 z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*task)); }
+
+void _z_task_exit(void) { pthread_exit(NULL); }
 
 void _z_task_free(_z_task_t **task) { *task = NULL; }
 

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -117,7 +117,11 @@ z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*ta
 
 void _z_task_exit(void) { pthread_exit(NULL); }
 
-void _z_task_free(_z_task_t **task) { *task = NULL; }
+void _z_task_free(_z_task_t **task) {
+    _z_task_t *ptr = *task;
+    z_free(ptr);
+    *task = NULL;
+}
 
 /*------------------ Mutex ------------------*/
 z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -88,6 +88,8 @@ z_result_t _z_task_cancel(_z_task_t *task) {
     return ret;
 }
 
+void _z_task_exit(void) { ExitThread(0); }
+
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
     CloseHandle(*ptr);

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -79,6 +79,7 @@ z_result_t _z_task_join(_z_task_t *task) {
 z_result_t _z_task_detach(_z_task_t *task) {
     z_result_t ret = _Z_RES_OK;
     CloseHandle(*task);
+    *task = 0;
     return ret;
 }
 
@@ -92,7 +93,9 @@ void _z_task_exit(void) { ExitThread(0); }
 
 void _z_task_free(_z_task_t **task) {
     _z_task_t *ptr = *task;
-    CloseHandle(*ptr);
+    if (*ptr != 0) {
+        CloseHandle(*ptr);
+    }
     z_free(ptr);
     *task = NULL;
 }

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -90,6 +90,8 @@ z_result_t _z_task_detach(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_detach(*ta
 
 z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*task)); }
 
+void _z_task_exit(void) { pthread_exit(NULL); }
+
 void _z_task_free(_z_task_t **task) { *task = NULL; }
 
 /*------------------ Mutex ------------------*/

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -92,7 +92,11 @@ z_result_t _z_task_cancel(_z_task_t *task) { _Z_CHECK_SYS_ERR(pthread_cancel(*ta
 
 void _z_task_exit(void) { pthread_exit(NULL); }
 
-void _z_task_free(_z_task_t **task) { *task = NULL; }
+void _z_task_free(_z_task_t **task) {
+    _z_task_t *ptr = *task;
+    z_free(ptr);
+    *task = NULL;
+}
 
 /*------------------ Mutex ------------------*/
 z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -30,7 +30,6 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
             _z_task_join(ztc->_read_task);
         }
         _z_task_free(&ztc->_read_task);
-        z_free(ztc->_read_task);
         ztc->_read_task = NULL;
     }
     if (ztc->_lease_task != NULL) {
@@ -41,7 +40,6 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
             _z_task_join(ztc->_lease_task);
         }
         _z_task_free(&ztc->_lease_task);
-        z_free(ztc->_lease_task);
         ztc->_lease_task = NULL;
     }
 

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -29,6 +29,7 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
         } else {
             _z_task_join(ztc->_read_task);
         }
+        _z_task_free(&ztc->_read_task);
         z_free(ztc->_read_task);
         ztc->_read_task = NULL;
     }
@@ -39,6 +40,7 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
         } else {
             _z_task_join(ztc->_lease_task);
         }
+        _z_task_free(&ztc->_lease_task);
         z_free(ztc->_lease_task);
         ztc->_lease_task = NULL;
     }

--- a/src/transport/unicast/lease.c
+++ b/src/transport/unicast/lease.c
@@ -57,6 +57,8 @@ static void _zp_unicast_failed(_z_transport_unicast_t *ztu) {
         _Z_ERROR("Reopen failed: %i", ret);
     }
 #endif
+
+    _z_task_exit();
 }
 
 void *_zp_unicast_lease_task(void *ztu_arg) {


### PR DESCRIPTION
 - Fully delegate task pointer memory cleanup to _z_task_free
 - Disables FreeRTOS task cancellation on detach
 - Introduce _z_task_exit() method to proper exit and cleanup from lease/read task especially for FreeRTOS


Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/864
Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/865