### PR TITLE
Add z_entity_global_id_t type

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -442,6 +442,18 @@ Functions
 .. autocfunction:: primitives.h::z_timestamp_id
 .. autocfunction:: primitives.h::z_timestamp_ntp64_time
 
+
+Entity Global ID
+----------------
+Types
+^^^^^
+.. c:type:: z_entity_global_id_t
+
+Functions
+^^^^^^^^^
+.. autocfunction:: primitives.h::z_entity_global_id_eid
+.. autocfunction:: primitives.h::z_entity_global_id_zid
+
 Closures
 ========
 

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -875,6 +875,38 @@ uint64_t z_timestamp_ntp64_time(const z_timestamp_t *ts);
 z_id_t z_timestamp_id(const z_timestamp_t *ts);
 
 /**
+ * Creates an entity global id.
+ *
+ * Parameters:
+ *   gid: An uninitialized :c:type:`z_entity_global_id_t`.
+ *   zid: Pointer to a :c:type:`z_id_t` zenoh id.
+ *   eid: :c:type:`uint32_t` entity id.
+ */
+z_result_t z_entity_global_id_new(z_entity_global_id_t *gid, const z_id_t *zid, uint32_t eid);
+
+/**
+ * Returns the entity id of the entity global id.
+ *
+ * Parameters:
+ *   gid: Pointer to the valid :c:type:`z_entity_global_id_t`.
+ *
+ * Return:
+ *   Entity id represented by c:type:`uint32_t`.
+ */
+uint32_t z_entity_global_id_eid(const z_entity_global_id_t *gid);
+
+/**
+ * Returns the zenoh id of entity global id.
+ *
+ * Parameters:
+ *   gid: Pointer to the valid :c:type:`z_entity_global_id_t`.
+ *
+ * Return:
+ *   Zenoh id represented by c:type:`z_id_t`.
+ */
+z_id_t z_entity_global_id_zid(const z_entity_global_id_t *gid);
+
+/**
  * Builds a default query target.
  *
  * Return:

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -46,6 +46,11 @@ extern "C" {
  */
 typedef _z_id_t z_id_t;
 
+/**
+ *  Represents an ID globally identifying an entity in a Zenoh system.
+ */
+typedef _z_entity_global_id_t z_entity_global_id_t;
+
 /*
  * Represents timestamp value in Zenoh
  */

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -63,6 +63,14 @@ uint8_t _z_id_len(_z_id_t id);
 static inline bool _z_id_check(_z_id_t id) { return memcmp(&id, &empty_id, sizeof(id)) != 0; }
 static inline _z_id_t _z_id_empty(void) { return (_z_id_t){0}; }
 
+typedef struct {
+    _z_id_t zid;
+    uint32_t eid;
+} _z_entity_global_id_t;
+
+// Warning: None of the sub-types require a non-0 initialization. Add a init function if it changes.
+static inline _z_entity_global_id_t _z_entity_global_id_null(void) { return (_z_entity_global_id_t){0}; }
+
 /**
  * A zenoh timestamp.
  */

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -418,6 +418,17 @@ uint64_t z_timestamp_ntp64_time(const z_timestamp_t *ts) { return ts->time; }
 
 z_id_t z_timestamp_id(const z_timestamp_t *ts) { return ts->id; }
 
+z_result_t z_entity_global_id_new(z_entity_global_id_t *gid, const z_id_t *zid, uint32_t eid) {
+    *gid = _z_entity_global_id_null();
+    gid->zid = *zid;
+    gid->eid = eid;
+    return _Z_RES_OK;
+}
+
+uint32_t z_entity_global_id_eid(const z_entity_global_id_t *gid) { return gid->eid; }
+
+z_id_t z_entity_global_id_zid(const z_entity_global_id_t *gid) { return gid->zid; }
+
 z_query_target_t z_query_target_default(void) { return Z_QUERY_TARGET_DEFAULT; }
 
 z_query_consolidation_t z_query_consolidation_auto(void) {


### PR DESCRIPTION
Adds `z_entity_global_id_t` along with associated functions.

Closes #450.