### PR TITLE
Fix null allocation in msgcodec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build & run tests
         run: |
           sudo apt install -y ninja-build
-          CMAKE_GENERATOR=Ninja ASAN=ON make test
+          CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
 
   check_format:
     name: Check codebase format with clang-format

--- a/src/collections/bytes.c
+++ b/src/collections/bytes.c
@@ -104,6 +104,7 @@ z_result_t _z_bytes_from_slice(_z_bytes_t *b, _z_slice_t s) {
 
 z_result_t _z_bytes_from_buf(_z_bytes_t *b, const uint8_t *src, size_t len) {
     *b = _z_bytes_null();
+    if (len == 0) return _Z_RES_OK;
     _z_slice_t s = _z_slice_copy_from_buf(src, len);
     if (s.len != len) return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     return _z_bytes_from_slice(b, s);

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -659,7 +659,7 @@ _z_keyexpr_t gen_keyexpr(void) {
     if (is_numerical == true) {
         key._suffix = _z_string_null();
     } else {
-        size_t len = gen_zint() % 16;
+        size_t len = gen_zint() % 16 + 1;
         key._suffix = _z_string_preallocate(len);
         char *suffix = gen_str(len);
         memcpy((char *)_z_string_data(&key._suffix), suffix, len);


### PR DESCRIPTION
* Unit tests were not run as DEBUG on CI.
* When run as DEBUG, issues related to the null allocation change (#877) appeared and are fixed with this PR.