### PR TITLE
Improve unicast tx

### DIFF
--- a/include/zenoh-pico/system/common/platform.h
+++ b/include/zenoh-pico/system/common/platform.h
@@ -69,6 +69,15 @@ void _z_report_system_error(int errcode);
         return _Z_RES_OK;                  \
     } while (false)
 
+#define _Z_RETURN_IF_SYS_ERR(expr)         \
+    do {                                   \
+        int __res = expr;                  \
+        if (__res != 0) {                  \
+            _z_report_system_error(__res); \
+            return _Z_ERR_SYSTEM_GENERIC;  \
+        }                                  \
+    } while (false)
+
 z_result_t _z_socket_set_non_blocking(const _z_sys_net_socket_t *sock);
 z_result_t _z_socket_accept(const _z_sys_net_socket_t *sock_in, _z_sys_net_socket_t *sock_out);
 void _z_socket_close(_z_sys_net_socket_t *sock);

--- a/include/zenoh-pico/system/common/platform.h
+++ b/include/zenoh-pico/system/common/platform.h
@@ -141,6 +141,7 @@ void z_free(void *ptr);
 // dummy types for correct macros work
 typedef void *_z_task_t;
 typedef void *_z_mutex_t;
+typedef void *_z_mutex_rec_t;
 typedef void *_z_condvar_t;
 typedef void *z_task_attr_t;
 #endif
@@ -213,6 +214,12 @@ z_result_t _z_mutex_drop(_z_mutex_t *m);
 z_result_t _z_mutex_lock(_z_mutex_t *m);
 z_result_t _z_mutex_try_lock(_z_mutex_t *m);
 z_result_t _z_mutex_unlock(_z_mutex_t *m);
+
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m);
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m);
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m);
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m);
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m);
 
 /**
  * Constructs a mutex.

--- a/include/zenoh-pico/system/platform/arduino/esp32.h
+++ b/include/zenoh-pico/system/platform/arduino/esp32.h
@@ -29,6 +29,7 @@ extern "C" {
 typedef void *_z_task_t;
 typedef void *z_task_attr_t;  // Not used in ESP32
 typedef pthread_mutex_t _z_mutex_t;
+typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/emscripten.h
+++ b/include/zenoh-pico/system/platform/emscripten.h
@@ -29,6 +29,7 @@ extern "C" {
 typedef pthread_t _z_task_t;
 typedef pthread_attr_t z_task_attr_t;
 typedef pthread_mutex_t _z_mutex_t;
+typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/espidf.h
+++ b/include/zenoh-pico/system/platform/espidf.h
@@ -44,6 +44,7 @@ typedef struct {
     EventGroupHandle_t join_event;
 } _z_task_t;
 typedef pthread_mutex_t _z_mutex_t;
+typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/flipper.h
+++ b/include/zenoh-pico/system/platform/flipper.h
@@ -34,6 +34,7 @@ extern "C" {
 typedef FuriThread* _z_task_t;
 typedef uint32_t z_task_attr_t;
 typedef FuriMutex* _z_mutex_t;
+typedef void* _z_mutex_t;
 typedef void* _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/freertos_plus_tcp.h
+++ b/include/zenoh-pico/system/platform/freertos_plus_tcp.h
@@ -52,6 +52,9 @@ typedef struct {
     StaticSemaphore_t buffer;
 #endif /* SUPPORT_STATIC_ALLOCATION */
 } _z_mutex_t;
+
+typedef _z_mutex_t _z_mutex_rec_t;
+
 typedef struct {
     SemaphoreHandle_t mutex;
     SemaphoreHandle_t sem;

--- a/include/zenoh-pico/system/platform/mbed.h
+++ b/include/zenoh-pico/system/platform/mbed.h
@@ -27,11 +27,12 @@ extern "C" {
 typedef int _z_socket_t;
 
 #if Z_FEATURE_MULTI_THREAD == 1
-typedef void *_z_task_t;      // Workaround as MBED is a C++ library
-typedef void *z_task_attr_t;  // Workaround as MBED is a C++ library
-typedef void *_z_mutex_t;     // Workaround as MBED is a C++ library
-typedef void *_z_condvar_t;   // Workaround as MBED is a C++ library
-#endif                        // Z_FEATURE_MULTI_THREAD == 1
+typedef void *_z_task_t;       // Workaround as MBED is a C++ library
+typedef void *z_task_attr_t;   // Workaround as MBED is a C++ library
+typedef void *_z_mutex_t;      // Workaround as MBED is a C++ library
+typedef void *_z_mutex_rec_t;  // Workaround as MBED is a C++ library
+typedef void *_z_condvar_t;    // Workaround as MBED is a C++ library
+#endif                         // Z_FEATURE_MULTI_THREAD == 1
 
 typedef struct timespec z_clock_t;
 typedef struct timeval z_time_t;

--- a/include/zenoh-pico/system/platform/rpi_pico.h
+++ b/include/zenoh-pico/system/platform/rpi_pico.h
@@ -45,6 +45,7 @@ typedef struct {
 } _z_task_t;
 
 typedef SemaphoreHandle_t _z_mutex_t;
+typedef SemaphoreHandle_t _z_mutex_rec_t;
 typedef struct {
     SemaphoreHandle_t mutex;
     SemaphoreHandle_t sem;

--- a/include/zenoh-pico/system/platform/unix.h
+++ b/include/zenoh-pico/system/platform/unix.h
@@ -33,6 +33,7 @@ extern "C" {
 typedef pthread_t _z_task_t;
 typedef pthread_attr_t z_task_attr_t;
 typedef pthread_mutex_t _z_mutex_t;
+typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/void.h
+++ b/include/zenoh-pico/system/platform/void.h
@@ -22,9 +22,10 @@ extern "C" {
 #endif
 
 #if Z_FEATURE_MULTI_THREAD == 1
-typedef void *_z_mutex_t;
 typedef void *_z_task_t;
 typedef void *z_task_attr_t;
+typedef void *_z_mutex_t;
+typedef void *_z_mutex_rec_t;
 typedef void *_z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/windows.h
+++ b/include/zenoh-pico/system/platform/windows.h
@@ -28,6 +28,7 @@ extern "C" {
 typedef HANDLE *_z_task_t;
 typedef void *z_task_attr_t;  // Not used in Windows
 typedef SRWLOCK _z_mutex_t;
+typedef CRITICAL_SECTION _z_mutex_rec_t;
 typedef CONDITION_VARIABLE _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/system/platform/zephyr.h
+++ b/include/zenoh-pico/system/platform/zephyr.h
@@ -38,6 +38,7 @@ extern "C" {
 typedef pthread_t _z_task_t;
 typedef pthread_attr_t z_task_attr_t;
 typedef pthread_mutex_t _z_mutex_t;
+typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -123,7 +123,7 @@ typedef struct {
     // TX and RX mutexes
     _z_mutex_t _mutex_rx;
     _z_mutex_t _mutex_tx;
-    _z_mutex_t _mutex_peer;
+    _z_mutex_rec_t _mutex_peer;
 
     _z_task_t *_read_task;
     _z_task_t *_lease_task;
@@ -212,9 +212,11 @@ static inline z_result_t _z_transport_tx_mutex_lock(_z_transport_common_t *ztc, 
 static inline void _z_transport_tx_mutex_unlock(_z_transport_common_t *ztc) { _z_mutex_unlock(&ztc->_mutex_tx); }
 static inline void _z_transport_rx_mutex_lock(_z_transport_common_t *ztc) { _z_mutex_lock(&ztc->_mutex_rx); }
 static inline void _z_transport_rx_mutex_unlock(_z_transport_common_t *ztc) { _z_mutex_unlock(&ztc->_mutex_rx); }
-static inline void _z_transport_peer_mutex_lock(_z_transport_common_t *ztc) { (void)_z_mutex_lock(&ztc->_mutex_peer); }
+static inline void _z_transport_peer_mutex_lock(_z_transport_common_t *ztc) {
+    (void)_z_mutex_rec_lock(&ztc->_mutex_peer);
+}
 static inline void _z_transport_peer_mutex_unlock(_z_transport_common_t *ztc) {
-    (void)_z_mutex_unlock(&ztc->_mutex_peer);
+    (void)_z_mutex_rec_unlock(&ztc->_mutex_peer);
 }
 #else
 static inline z_result_t _z_transport_tx_mutex_lock(_z_transport_common_t *ztc, bool block) {

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -72,6 +72,13 @@ _Z_LIST_DEFINE(_z_transport_peer_entry, _z_transport_peer_entry_t)
 _z_transport_peer_entry_list_t *_z_transport_peer_entry_list_insert(_z_transport_peer_entry_list_t *root,
                                                                     _z_transport_peer_entry_t *entry);
 
+typedef enum _z_unicast_peer_flow_state_e {
+    _Z_FLOW_STATE_INACTIVE = 0,
+    _Z_FLOW_STATE_PENDING_SIZE = 1,
+    _Z_FLOW_STATE_PENDING_DATA = 2,
+    _Z_FLOW_STATE_READY = 3,
+} _z_unicast_peer_flow_state_e;
+
 typedef struct {
     _z_sys_net_socket_t _socket;
     _z_id_t _remote_zid;
@@ -80,6 +87,9 @@ typedef struct {
     _z_zint_t _sn_rx_best_effort;
     volatile bool _received;
     bool _pending;
+    uint8_t flow_state;
+    uint16_t flow_curr_size;
+    _z_zbuf_t flow_buff;
 
 #if Z_FEATURE_FRAGMENTATION == 1
     // Defragmentation buffers

--- a/src/protocol/codec/ext.c
+++ b/src/protocol/codec/ext.c
@@ -96,7 +96,7 @@ z_result_t _z_msg_ext_encode(_z_wbuf_t *wbf, const _z_msg_ext_t *ext, bool has_n
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
+            _Z_INFO("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
         } break;
     }
 
@@ -120,7 +120,7 @@ z_result_t _z_msg_ext_unknown_body_decode(_z_msg_ext_body_t *body, uint8_t enc, 
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
+            _Z_INFO("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
         } break;
     }
 

--- a/src/protocol/codec/message.c
+++ b/src/protocol/codec/message.c
@@ -697,7 +697,7 @@ z_result_t _z_scouting_message_encode(_z_wbuf_t *wbf, const _z_scouting_message_
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to encode session message with unknown ID(%d)", _Z_MID(msg->_header));
+            _Z_INFO("WARNING: Trying to encode session message with unknown ID(%d)", _Z_MID(msg->_header));
             ret |= _Z_ERR_MESSAGE_TRANSPORT_UNKNOWN;
         } break;
     }
@@ -726,7 +726,7 @@ z_result_t _z_scouting_message_decode_na(_z_scouting_message_t *msg, _z_zbuf_t *
                 } break;
 
                 default: {
-                    _Z_DEBUG("WARNING: Trying to decode scouting message with unknown ID(0x%x)", mid);
+                    _Z_INFO("WARNING: Trying to decode scouting message with unknown ID(0x%x)", mid);
                     ret |= _Z_ERR_MESSAGE_TRANSPORT_UNKNOWN;
                     is_last = true;
                 } break;

--- a/src/protocol/codec/transport.c
+++ b/src/protocol/codec/transport.c
@@ -608,7 +608,7 @@ z_result_t _z_transport_message_encode(_z_wbuf_t *wbf, const _z_transport_messag
             ret |= _z_close_encode(wbf, msg->_header, &msg->_body._close);
         } break;
         default: {
-            _Z_DEBUG("WARNING: Trying to encode session message with unknown ID(%d)", _Z_MID(msg->_header));
+            _Z_INFO("WARNING: Trying to encode session message with unknown ID(%d)", _Z_MID(msg->_header));
             ret |= _Z_ERR_MESSAGE_TRANSPORT_UNKNOWN;
         } break;
     }
@@ -646,7 +646,7 @@ z_result_t _z_transport_message_decode(_z_transport_message_t *msg, _z_zbuf_t *z
                 ret |= _z_close_decode(&msg->_body._close, zbf, msg->_header);
             } break;
             default: {
-                _Z_DEBUG("WARNING: Trying to decode session message with unknown ID(0x%x) (header=0x%x)", mid,
+                _Z_INFO("WARNING: Trying to decode session message with unknown ID(0x%x) (header=0x%x)", mid,
                          msg->_header);
                 ret |= _Z_ERR_MESSAGE_TRANSPORT_UNKNOWN;
             } break;

--- a/src/protocol/codec/transport.c
+++ b/src/protocol/codec/transport.c
@@ -647,7 +647,7 @@ z_result_t _z_transport_message_decode(_z_transport_message_t *msg, _z_zbuf_t *z
             } break;
             default: {
                 _Z_INFO("WARNING: Trying to decode session message with unknown ID(0x%x) (header=0x%x)", mid,
-                         msg->_header);
+                        msg->_header);
                 ret |= _Z_ERR_MESSAGE_TRANSPORT_UNKNOWN;
             } break;
         }

--- a/src/protocol/definitions/transport.c
+++ b/src/protocol/definitions/transport.c
@@ -82,7 +82,7 @@ void _z_t_msg_clear(_z_transport_message_t *msg) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to clear transport message with unknown ID(%d)", mid);
+            _Z_INFO("WARNING: Trying to clear transport message with unknown ID(%d)", mid);
         } break;
     }
 }
@@ -395,7 +395,7 @@ void _z_t_msg_copy(_z_transport_message_t *clone, _z_transport_message_t *msg) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to copy transport message with unknown ID(%d)", mid);
+            _Z_INFO("WARNING: Trying to copy transport message with unknown ID(%d)", mid);
         } break;
     }
 }
@@ -412,7 +412,7 @@ void _z_s_msg_clear(_z_scouting_message_t *msg) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to clear session message with unknown ID(%d)", mid);
+            _Z_INFO("WARNING: Trying to clear session message with unknown ID(%d)", mid);
         } break;
     }
 }
@@ -476,7 +476,7 @@ void _z_s_msg_copy(_z_scouting_message_t *clone, _z_scouting_message_t *msg) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to copy session message with unknown ID(%d)", mid);
+            _Z_INFO("WARNING: Trying to copy session message with unknown ID(%d)", mid);
         } break;
     }
 }

--- a/src/protocol/ext.c
+++ b/src/protocol/ext.c
@@ -88,7 +88,7 @@ void _z_msg_ext_copy(_z_msg_ext_t *clone, const _z_msg_ext_t *ext) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
+            _Z_INFO("WARNING: Trying to copy message extension with unknown encoding(%d)", enc);
         } break;
     }
 }
@@ -109,7 +109,7 @@ void _z_msg_ext_clear(_z_msg_ext_t *ext) {
         } break;
 
         default: {
-            _Z_DEBUG("WARNING: Trying to free message extension with unknown encoding(%d)", enc);
+            _Z_INFO("WARNING: Trying to free message extension with unknown encoding(%d)", enc);
         } break;
     }
 }

--- a/src/system/arduino/esp32/system.c
+++ b/src/system/arduino/esp32/system.c
@@ -118,9 +118,9 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unloc
 
 z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
     pthread_mutexattr_t attr;
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
-    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutex_init(m, &attr));
     _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
 }
 

--- a/src/system/arduino/esp32/system.c
+++ b/src/system/arduino/esp32/system.c
@@ -116,6 +116,22 @@ z_result_t _z_mutex_try_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_try
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    pthread_mutexattr_t attr;
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
+
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {
     pthread_condattr_t attr;

--- a/src/system/arduino/opencr/system.c
+++ b/src/system/arduino/opencr/system.c
@@ -90,6 +90,16 @@ z_result_t _z_mutex_try_lock(_z_mutex_t *m) { return -1; }
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { return -1; }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) { return -1; }
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { return -1; }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { return -1; }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { return -1; }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { return -1; }
+
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) { return -1; }
 

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -65,7 +65,7 @@ void _z_task_free(_z_task_t **task) {
 }
 
 /*------------------ Mutex ------------------*/
-z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }
+z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, NULL)); }
 
 z_result_t _z_mutex_drop(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
 
@@ -74,6 +74,22 @@ z_result_t _z_mutex_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)
 z_result_t _z_mutex_try_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
+
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    pthread_mutexattr_t attr;
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
 
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {

--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -77,9 +77,9 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unloc
 
 z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
     pthread_mutexattr_t attr;
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
-    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutex_init(m, &attr));
     _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
 }
 

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -146,6 +146,22 @@ z_result_t _z_mutex_try_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_try
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    pthread_mutexattr_t attr;
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
+
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {
     pthread_condattr_t attr;

--- a/src/system/espidf/system.c
+++ b/src/system/espidf/system.c
@@ -148,9 +148,9 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unloc
 
 z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
     pthread_mutexattr_t attr;
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
-    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutex_init(m, &attr));
     _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
 }
 

--- a/src/system/freertos_plus_tcp/system.c
+++ b/src/system/freertos_plus_tcp/system.c
@@ -195,6 +195,16 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) {
     return xSemaphoreGiveRecursive(m->handle) == pdTRUE ? _Z_RES_OK : _Z_ERR_GENERIC;
 }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) { return _z_mutex_init(m); }
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { return _z_mutex_drop(m); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { return _z_mutex_lock(m); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { return _z_mutex_try_lock(m); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { return _z_mutex_unlock(m); }
+
 /*------------------ CondVar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {
     if (!cv) {

--- a/src/system/mbed/system.cpp
+++ b/src/system/mbed/system.cpp
@@ -95,6 +95,16 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) {
     return 0;
 }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) { return _z_mutex_init(m); }
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { return _z_mutex_drop(m); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { return _z_mutex_lock(m); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { return _z_mutex_try_lock(m); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { return _z_mutex_unlock(m); }
+
 /*------------------ Condvar ------------------*/
 struct condvar {
     Mutex mutex;

--- a/src/system/rpi_pico/system.c
+++ b/src/system/rpi_pico/system.c
@@ -143,6 +143,16 @@ z_result_t _z_mutex_try_lock(_z_mutex_t *m) { return xSemaphoreTakeRecursive(*m,
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { return xSemaphoreGiveRecursive(*m) == pdTRUE ? 0 : -1; }
 
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) { return _z_mutex_init(m); }
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { return _z_mutex_drop(m); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { return _z_mutex_lock(m); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { return _z_mutex_try_lock(m); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { return _z_mutex_unlock(m); }
+
 /*------------------ CondVar ------------------*/
 static UBaseType_t CONDVAR_MAX_WAITERS_COUNT = UINT_MAX;
 

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -136,9 +136,9 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unloc
 
 z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
     pthread_mutexattr_t attr;
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
-    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutex_init(m, &attr));
     _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
 }
 

--- a/src/system/unix/system.c
+++ b/src/system/unix/system.c
@@ -124,7 +124,7 @@ void _z_task_free(_z_task_t **task) {
 }
 
 /*------------------ Mutex ------------------*/
-z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }
+z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, NULL)); }
 
 z_result_t _z_mutex_drop(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
 
@@ -133,6 +133,22 @@ z_result_t _z_mutex_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)
 z_result_t _z_mutex_try_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
+
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    pthread_mutexattr_t attr;
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m)); }
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
 
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {

--- a/src/system/windows/system.c
+++ b/src/system/windows/system.c
@@ -121,7 +121,7 @@ z_result_t _z_mutex_lock(_z_mutex_t *m) {
 
 z_result_t _z_mutex_try_lock(_z_mutex_t *m) {
     z_result_t ret = _Z_RES_OK;
-    if (TryAcquireSRWLockExclusive(m) == 0) {
+    if (!TryAcquireSRWLockExclusive(m)) {
         ret = _Z_ERR_GENERIC;
     }
     return ret;
@@ -131,6 +131,33 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) {
     z_result_t ret = _Z_RES_OK;
     ReleaseSRWLockExclusive(m);
     return ret;
+}
+
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    InitializeCriticalSection(m);
+    return _Z_RES_OK;
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) {
+    DeleteCriticalSection(m);
+    return _Z_RES_OK;
+}
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) {
+    EnterCriticalSection(m);
+    return _Z_RES_OK;
+}
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) {
+    if (!TryEnterCriticalSection(m)) {
+        return _Z_ERR_GENERIC;
+    }
+    return _Z_RES_OK;
+}
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) {
+    LeaveCriticalSection(m);
+    return _Z_RES_OK;
 }
 
 /*------------------ Condvar ------------------*/

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -99,7 +99,7 @@ void _z_task_free(_z_task_t **task) {
 }
 
 /*------------------ Mutex ------------------*/
-z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, 0)); }
+z_result_t _z_mutex_init(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_init(m, NULL)); }
 
 z_result_t _z_mutex_drop(_z_mutex_t *m) {
     if (m == NULL) {
@@ -113,6 +113,27 @@ z_result_t _z_mutex_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)
 z_result_t _z_mutex_try_lock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
 
 z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
+
+z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
+    pthread_mutexattr_t attr;
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
+}
+
+z_result_t _z_mutex_rec_drop(_z_mutex_rec_t *m) {
+    if (m == NULL) {
+        return 0;
+    }
+    _Z_CHECK_SYS_ERR(pthread_mutex_destroy(m));
+}
+
+z_result_t _z_mutex_rec_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_lock(m)); }
+
+z_result_t _z_mutex_rec_try_lock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_trylock(m)); }
+
+z_result_t _z_mutex_rec_unlock(_z_mutex_rec_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unlock(m)); }
 
 /*------------------ Condvar ------------------*/
 z_result_t _z_condvar_init(_z_condvar_t *cv) {

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -116,9 +116,9 @@ z_result_t _z_mutex_unlock(_z_mutex_t *m) { _Z_CHECK_SYS_ERR(pthread_mutex_unloc
 
 z_result_t _z_mutex_rec_init(_z_mutex_rec_t *m) {
     pthread_mutexattr_t attr;
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_init(&attr));
-    _Z_CHECK_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
-    _Z_CHECK_SYS_ERR(pthread_mutex_init(m, &attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_init(&attr));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+    _Z_RETURN_IF_SYS_ERR(pthread_mutex_init(m, &attr));
     _Z_CHECK_SYS_ERR(pthread_mutexattr_destroy(&attr));
 }
 

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -46,7 +46,7 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
     // Clean up the mutexes
     _z_mutex_drop(&ztc->_mutex_tx);
     _z_mutex_drop(&ztc->_mutex_rx);
-    _z_mutex_drop(&ztc->_mutex_peer);
+    _z_mutex_rec_drop(&ztc->_mutex_peer);
 #else
     _ZP_UNUSED(detach_tasks);
 #endif  // Z_FEATURE_MULTI_THREAD == 1

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -199,6 +199,7 @@ static z_result_t _z_transport_tx_batch_overflow(_z_transport_common_t *ztc, con
     _ZP_UNUSED(reliability);
     _ZP_UNUSED(sn);
     _ZP_UNUSED(prev_wpos);
+    _ZP_UNUSED(peers);
     return _Z_RES_OK;
 #endif
 }
@@ -315,6 +316,7 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
 #else
     _ZP_UNUSED(ztc);
     _ZP_UNUSED(cong_ctrl);
+    _ZP_UNUSED(peers);
     return _Z_RES_OK;
 #endif
 }

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -470,8 +470,10 @@ z_result_t _z_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_
                 ret = _z_transport_tx_send_n_msg(&zn->_tp._transport._unicast._common, z_msg, reliability, cong_ctrl,
                                                  NULL);
             } else if (_z_transport_unicast_peer_list_len(zn->_tp._transport._unicast._peers) > 0) {
+                _z_transport_peer_mutex_lock(&zn->_tp._transport._unicast._common);
                 ret = _z_transport_tx_send_n_msg(&zn->_tp._transport._unicast._common, z_msg, reliability, cong_ctrl,
                                                  zn->_tp._transport._unicast._peers);
+                _z_transport_peer_mutex_unlock(&zn->_tp._transport._unicast._common);
             }
             break;
         case _Z_TRANSPORT_MULTICAST_TYPE:
@@ -496,8 +498,10 @@ z_result_t _z_send_n_batch(_z_session_t *zn, z_congestion_control_t cong_ctrl) {
             if (zn->_mode == Z_WHATAMI_CLIENT) {
                 ret = _z_transport_tx_send_n_batch(&zn->_tp._transport._unicast._common, cong_ctrl, NULL);
             } else if (_z_transport_unicast_peer_list_len(zn->_tp._transport._unicast._peers) > 0) {
+                _z_transport_peer_mutex_lock(&zn->_tp._transport._unicast._common);
                 ret = _z_transport_tx_send_n_batch(&zn->_tp._transport._unicast._common, cong_ctrl,
                                                    zn->_tp._transport._unicast._peers);
+                _z_transport_peer_mutex_unlock(&zn->_tp._transport._unicast._common);
             }
 
             break;

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -60,7 +60,7 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
     if (ret == _Z_RES_OK) {
         ret = _z_mutex_init(&ztm->_common._mutex_rx);
         if (ret == _Z_RES_OK) {
-            ret = _z_mutex_init(&ztm->_common._mutex_peer);
+            ret = _z_mutex_rec_init(&ztm->_common._mutex_peer);
             if (ret != _Z_RES_OK) {
                 _z_mutex_drop(&ztm->_common._mutex_tx);
                 _z_mutex_drop(&ztm->_common._mutex_rx);
@@ -91,7 +91,7 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
 #if Z_FEATURE_MULTI_THREAD == 1
             _z_mutex_drop(&ztm->_common._mutex_tx);
             _z_mutex_drop(&ztm->_common._mutex_rx);
-            _z_mutex_drop(&ztm->_common._mutex_peer);
+            _z_mutex_rec_drop(&ztm->_common._mutex_peer);
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
             _z_wbuf_clear(&ztm->_common._wbuf);

--- a/src/transport/peer_entry.c
+++ b/src/transport/peer_entry.c
@@ -56,6 +56,7 @@ bool _z_transport_peer_entry_eq(const _z_transport_peer_entry_t *left, const _z_
 }
 
 void _z_transport_unicast_peer_clear(_z_transport_unicast_peer_t *src) {
+    _z_zbuf_clear(&src->flow_buff);
 #if Z_FEATURE_FRAGMENTATION == 1
     _z_wbuf_clear(&src->_dbuf_reliable);
     _z_wbuf_clear(&src->_dbuf_best_effort);
@@ -96,6 +97,9 @@ z_result_t _z_transport_unicast_peer_add(_z_transport_unicast_t *ztu, _z_transpo
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
     }
     // Fill peer data
+    peer->flow_state = _Z_FLOW_STATE_INACTIVE;
+    peer->flow_curr_size = 0;
+    peer->flow_buff = _z_zbuf_null();
     peer->_pending = false;
     peer->_socket = socket;
     peer->_remote_zid = param->_remote_zid;

--- a/src/transport/unicast/rx.c
+++ b/src/transport/unicast/rx.c
@@ -300,7 +300,7 @@ z_result_t _z_unicast_handle_transport_message(_z_transport_unicast_t *ztu, _z_t
         }
 
         default: {
-            _Z_ERROR("Unknown transport message ID");
+            _Z_INFO("WARNING: Unknown transport message ID");
             _z_t_msg_clear(t_msg);
             break;
         }

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -41,7 +41,7 @@ static z_result_t _z_unicast_transport_create_inner(_z_transport_unicast_t *ztu,
     // Initialize the mutexes
     _Z_RETURN_IF_ERR(_z_mutex_init(&ztu->_common._mutex_tx));
     _Z_RETURN_IF_ERR(_z_mutex_init(&ztu->_common._mutex_rx));
-    _Z_RETURN_IF_ERR(_z_mutex_init(&ztu->_common._mutex_peer));
+    _Z_RETURN_IF_ERR(_z_mutex_rec_init(&ztu->_common._mutex_peer));
 
     // Tasks
     ztu->_common._read_task_running = false;
@@ -95,7 +95,7 @@ z_result_t _z_unicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
 #if Z_FEATURE_MULTI_THREAD == 1
         _z_mutex_drop(&ztu->_common._mutex_rx);
         _z_mutex_drop(&ztu->_common._mutex_tx);
-        _z_mutex_drop(&ztu->_common._mutex_peer);
+        _z_mutex_rec_drop(&ztu->_common._mutex_peer);
 #endif
         _z_wbuf_clear(&ztu->_common._wbuf);
         _z_zbuf_clear(&ztu->_common._zbuf);


### PR DESCRIPTION
* Add missing recursive mutex
* Add mechanism to handle fragmented data in case of high throughput

High throughput may still lead to full tcp windows and mangled packets as we have no crc type value to check packet integrity in the protocol.