### PR TITLE
Run memory leak on unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,29 @@ jobs:
       - name: Build & run tests
         run: |
           sudo apt install -y ninja-build
-          ASAN_OPTIONS=detect_leaks=1:report_objects=1 CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
-      
-      # - name: Install valgrind
-      #   run: sudo apt install -y valgrind
-      
-      # - name: Memory leak unit tests
-      #   run: |
-      #     cd build/tests
-      #     for test in *; do
-      #       if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
-      #         echo "Running Valgrind on $test"
-      #         valgrind --leak-check=full --error-exitcode=1 "ASAN=ON ./$test" || exit 1
-      #       fi
-      #     done
+          MAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
+  
+  memory_leak_unit_tests:
+    - name: Checkout code
+        uses: actions/checkout@v4
+
+    - name: Build tests
+      run: |
+        sudo apt install -y ninja-build
+        MAKE_GENERATOR=Ninja make BUILD_TYPE=Debug
+
+    - name: Install valgrind
+      run: sudo apt install -y valgrind
+    
+    - name: Memory leak unit tests
+      run: |
+        cd build/tests
+        for test in *; do
+          if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
+            echo "Running Valgrind on $test"
+            valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
+          fi
+        done
 
   check_format:
     name: Check codebase format with clang-format
@@ -367,7 +376,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [run_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, connection_restore_test, markdown_lint, build_shared, build_static, integration, multicast]
+    needs: [run_tests, memory_leak_unit_tests, check_format, c99_build, raweth_build, zenoh_build, modular_build, unstable_build, st_build, fragment_test, attachment_test, memory_leak_test, no_router, connection_restore_test, markdown_lint, build_shared, build_static, integration, multicast]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           for test in *_test; do
             if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
               echo "Running Valgrind on $test"
-              valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
+              valgrind --leak-check=full --error-exitcode=1 "./$test" > /dev/null || exit 1
             fi
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Memory leak unit tests
         run: |
           cd build/tests
-          for test in *; do
+          for test in *_test; do
             if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
               echo "Running Valgrind on $test"
               valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-          uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Build tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build & run tests
         run: |
           sudo apt install -y ninja-build
-          MAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
+          CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
   
   memory_leak_unit_tests:
     name: Memory leak unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,20 @@ jobs:
       - name: Build & run tests
         run: |
           sudo apt install -y ninja-build
-          CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
+          ASAN_OPTIONS=detect_leaks=1:report_objects=1 CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
       
-      - name: Install valgrind
-        run: sudo apt install -y valgrind
+      # - name: Install valgrind
+      #   run: sudo apt install -y valgrind
       
-      - name: Memory leak unit tests
-        run: |
-          cd build/tests
-          for test in *; do
-            if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
-              echo "Running Valgrind on $test"
-              valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
-            fi
-          done
+      # - name: Memory leak unit tests
+      #   run: |
+      #     cd build/tests
+      #     for test in *; do
+      #       if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
+      #         echo "Running Valgrind on $test"
+      #         valgrind --leak-check=full --error-exitcode=1 "ASAN=ON ./$test" || exit 1
+      #       fi
+      #     done
 
   check_format:
     name: Check codebase format with clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
         run: |
           sudo apt install -y ninja-build
           CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
+      
+      - name: Install valgrind
+        run: sudo apt install -y valgrind
+      
+      - name: Memory leak unit tests
+        run: |
+          cd build/tests
+          for test in *; do
+            if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
+              echo "Running Valgrind on $test"
+              valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
+            fi
+          done
 
   check_format:
     name: Check codebase format with clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,26 +35,29 @@ jobs:
           MAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
   
   memory_leak_unit_tests:
-    - name: Checkout code
-        uses: actions/checkout@v4
+    name: Memory leak unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+          uses: actions/checkout@v4
 
-    - name: Build tests
-      run: |
-        sudo apt install -y ninja-build
-        MAKE_GENERATOR=Ninja make BUILD_TYPE=Debug
+      - name: Build tests
+        run: |
+          sudo apt install -y ninja-build
+          MAKE_GENERATOR=Ninja make BUILD_TYPE=Debug
 
-    - name: Install valgrind
-      run: sudo apt install -y valgrind
-    
-    - name: Memory leak unit tests
-      run: |
-        cd build/tests
-        for test in *; do
-          if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
-            echo "Running Valgrind on $test"
-            valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
-          fi
-        done
+      - name: Install valgrind
+        run: sudo apt install -y valgrind
+      
+      - name: Memory leak unit tests
+        run: |
+          cd build/tests
+          for test in *; do
+            if [[ -x "$test" && ! -d "$test" ]]; then  # Run only executables
+              echo "Running Valgrind on $test"
+              valgrind --leak-check=full --error-exitcode=1 "./$test" || exit 1
+            fi
+          done
 
   check_format:
     name: Check codebase format with clang-format

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -1868,7 +1868,6 @@ void frame_message(void) {
     assert_eq_frame(&expected._body._frame, &decoded);
     _z_network_message_svec_clear(&msg);
     _z_arc_slice_svec_release(&arcs);
-    _z_t_msg_frame_clear(&decoded);
     _z_t_msg_clear(&expected);
     _z_zbuf_clear(&zbf);
     _z_wbuf_clear(&wbf);
@@ -1965,7 +1964,6 @@ void transport_message(void) {
     assert_eq_transport(&expected, &decoded);
     _z_network_message_svec_clear(&msg);
     _z_arc_slice_svec_release(&arcs);
-    _z_t_msg_clear(&decoded);
     _z_t_msg_clear(&expected);
     _z_zbuf_clear(&zbf);
     _z_wbuf_clear(&wbf);


### PR DESCRIPTION
It seems like ASan doesn't catch some use after frees... Added a valgrind job to CI in support of issue https://github.com/eclipse-zenoh/zenoh-pico/issues/911.