### PR TITLE
fix _z_open_serial_from_dev in zephyr

### DIFF
--- a/src/system/zephyr/network.c
+++ b/src/system/zephyr/network.c
@@ -598,7 +598,7 @@ z_result_t _z_open_serial_from_dev(_z_sys_net_socket_t *sock, char *dev, uint32_
         ret = _Z_ERR_GENERIC;
     }
 
-    return _z_connect_serial(*sock);
+    return (ret == _Z_RES_OK ? _z_connect_serial(*sock) : ret);
 }
 
 z_result_t _z_listen_serial_from_pins(_z_sys_net_socket_t *sock, uint32_t txpin, uint32_t rxpin, uint32_t baudrate) {

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -237,5 +237,8 @@ z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t r
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 
-void _z_multicast_transport_clear(_z_transport_multicast_t *ztm, bool detach_tasks) { _ZP_UNUSED(zt);_ZP_UNUSED(detach_tasks); }
+void _z_multicast_transport_clear(_z_transport_multicast_t *ztm, bool detach_tasks) {
+    _ZP_UNUSED(zt);
+    _ZP_UNUSED(detach_tasks);
+}
 #endif  // Z_FEATURE_MULTICAST_TRANSPORT == 1 || Z_FEATURE_RAWETH_TRANSPORT == 1

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -237,5 +237,5 @@ z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t r
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 
-void _z_multicast_transport_clear(_z_transport_t *zt) { _ZP_UNUSED(zt); }
+void _z_multicast_transport_clear(_z_transport_multicast_t *ztm, bool detach_tasks) { _ZP_UNUSED(zt);_ZP_UNUSED(detach_tasks); }
 #endif  // Z_FEATURE_MULTICAST_TRANSPORT == 1 || Z_FEATURE_RAWETH_TRANSPORT == 1

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -404,6 +404,6 @@ z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reaso
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 
-void _z_unicast_transport_clear(_z_transport_t *zt) { _ZP_UNUSED(zt); }
+void _z_unicast_transport_clear(_z_transport_unicast_t *ztu, bool detach_tasks) { _ZP_UNUSED(zt);_ZP_UNUSED(detach_tasks); }
 
 #endif  // Z_FEATURE_UNICAST_TRANSPORT == 1

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -404,6 +404,9 @@ z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reaso
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 
-void _z_unicast_transport_clear(_z_transport_unicast_t *ztu, bool detach_tasks) { _ZP_UNUSED(zt);_ZP_UNUSED(detach_tasks); }
+void _z_unicast_transport_clear(_z_transport_unicast_t *ztu, bool detach_tasks) {
+    _ZP_UNUSED(zt);
+    _ZP_UNUSED(detach_tasks);
+}
 
 #endif  // Z_FEATURE_UNICAST_TRANSPORT == 1


### PR DESCRIPTION
The `ret` variable is not returned, which will cause undefined behavior.