### PR TITLE
Make channels ref-counted

### DIFF
--- a/include/zenoh-pico/api/olv_macros.h
+++ b/include/zenoh-pico/api/olv_macros.h
@@ -163,25 +163,28 @@
 #define _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_INLINE_IMPL(type, name, f_check, f_null, f_move, f_drop) \
     _Z_OWNED_FUNCTIONS_VALUE_NO_COPY_IMPL_PREFIX_INNER(z, type, name, f_check, f_null, f_move, f_drop, static inline)
 
-#define _Z_OWNED_FUNCTIONS_RC_IMPL(name)                                                                \
-    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                             \
-    void z_internal_##name##_null(z_owned_##name##_t *val) { val->_rc = _z_##name##_rc_null(); }        \
-    bool z_internal_##name##_check(const z_owned_##name##_t *val) { return !_Z_RC_IS_NULL(&val->_rc); } \
-    const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; }     \
-    z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }             \
-    z_result_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
-        z_result_t ret = _Z_RES_OK;                                                                     \
-        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                    \
-        if (_Z_RC_IS_NULL(&obj->_rc)) {                                                                 \
-            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                          \
-        }                                                                                               \
-        return ret;                                                                                     \
-    }                                                                                                   \
-    void z_##name##_drop(z_moved_##name##_t *obj) {                                                     \
-        if (!_Z_RC_IS_NULL(&obj->_this._rc)) {                                                          \
-            _z_##name##_rc_drop(&obj->_this._rc);                                                       \
-        }                                                                                               \
-    }
+#define _Z_OWNED_FUNCTIONS_RC_IMPL_INNER(name, attribute)                                                         \
+    attribute void z_internal_##name##_null(z_owned_##name##_t *val) { val->_rc = _z_##name##_rc_null(); }        \
+    attribute bool z_internal_##name##_check(const z_owned_##name##_t *val) { return !_Z_RC_IS_NULL(&val->_rc); } \
+    attribute const z_loaned_##name##_t *z_##name##_loan(const z_owned_##name##_t *val) { return &val->_rc; }     \
+    attribute z_loaned_##name##_t *z_##name##_loan_mut(z_owned_##name##_t *val) { return &val->_rc; }             \
+    attribute z_result_t z_##name##_clone(z_owned_##name##_t *obj, const z_loaned_##name##_t *src) {              \
+        z_result_t ret = _Z_RES_OK;                                                                               \
+        obj->_rc = _z_##name##_rc_clone((z_loaned_##name##_t *)src);                                              \
+        if (_Z_RC_IS_NULL(&obj->_rc)) {                                                                           \
+            ret = _Z_ERR_SYSTEM_OUT_OF_MEMORY;                                                                    \
+        }                                                                                                         \
+        return ret;                                                                                               \
+    }                                                                                                             \
+    attribute void z_##name##_drop(z_moved_##name##_t *obj) {                                                     \
+        if (!_Z_RC_IS_NULL(&obj->_this._rc)) {                                                                    \
+            _z_##name##_rc_drop(&obj->_this._rc);                                                                 \
+        }                                                                                                         \
+    }                                                                                                             \
+    _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE_PREFIX_INNER(z, name, attribute)
+
+#define _Z_OWNED_FUNCTIONS_RC_IMPL(name) _Z_OWNED_FUNCTIONS_RC_IMPL_INNER(name, _ZP_NOTHING)
+#define _Z_OWNED_FUNCTIONS_RC_INLINE_IMPL(name) _Z_OWNED_FUNCTIONS_RC_IMPL_INNER(name, static inline)
 
 #define _Z_OWNED_FUNCTIONS_SYSTEM_IMPL(type, name)                                                   \
     _Z_OWNED_FUNCTIONS_IMPL_MOVE_TAKE(name)                                                          \

--- a/include/zenoh-pico/collections/fifo_mt.h
+++ b/include/zenoh-pico/collections/fifo_mt.h
@@ -35,7 +35,7 @@ typedef struct {
 #endif
 } _z_fifo_mt_t;
 
-z_result_t _z_fifo_mti_init(size_t capacity);
+z_result_t _z_fifo_mt_init(_z_fifo_mt_t *fifo, size_t capacity);
 _z_fifo_mt_t *_z_fifo_mt_new(size_t capacity);
 
 z_result_t _z_fifo_mt_close(_z_fifo_mt_t *fifo);


### PR DESCRIPTION
Make channels ref-counted to make order of destruction of closure and handler irrelevant.