### PR TITLE
Zenoh generic - make zenoh-pico generic across most platformio platforms

### DIFF
--- a/docs/generic_platform.md
+++ b/docs/generic_platform.md
@@ -1,0 +1,55 @@
+# How to add a new platform to zenoh-pico 
+- objective is to use the zenoh-pico tree as such and provide the platform specific implementation
+- provide all config.h setting specifically for your platform
+- tested for TI Tiva platform lm4f120h5qr libopencm3 single thread and stm32cube
+
+## Flags for zenoh-pico compilation
+- pass define ZENOH_GENERIC via compile flags
+- the below example uses the source tree zenoh-pico from github directly
+```ini
+[env:tiva]
+platform = titiva
+board = lplm4f120h5qr
+framework = libopencm3
+extra_scripts =
+    pre:set_library_vars.py  # Sets env variables
+
+platform_packages =
+  	toolchain-gccarmnoneeabi@~1.90201.0
+lib_deps = 
+	https://github.com/eclipse/zenoh-pico
+	lib/titiva_libopencm3
+	https://github.com/mpaland/printf
+
+build_flags = 
+	-D__GLIBCXX_ASSERTIONS
+	-DZENOH_GENERIC=1
+	-DZENOH_DEBUG=0
+	-std=gnu++17
+	-Wno-missing-braces
+	-Wno-missing-field-initializers
+	-Wno-missing-prototypes
+	-Ilib/titiva_libopencm3
+	-Ilib/zenoh-pico/zenoh-pico
+	-Iprintf
+
+build_unflags = 
+	-std=gnu++14
+	-Wredundant-decls
+```
+
+- pass environment variable ZENOH_GENERIC=1 via script
+```python
+Import("env")
+env.Append(ZENOH_GENERIC="1")
+```
+
+## Create platform specific files in your own library 
+- zenoh_generic_config.h
+- zenoh_generic_platform.h
+- network.c(pp)
+- system.c(pp)
+
+- these files should implement the API's needed for the specific transport and platform
+
+

--- a/extra_script.py
+++ b/extra_script.py
@@ -18,6 +18,14 @@ SRC_FILTER = []
 CPPDEFINES = []
 
 FRAMEWORK = env.get("PIOFRAMEWORK")[0]
+PLATFORM = env.get("PIOPLATFORM")
+BOARD = env.get("PIOENV")
+ZENOH_GENERIC = env.get("ZENOH_GENERIC", "0")
+if ZENOH_GENERIC == "1":
+    FRAMEWORK = 'generic'
+    PLATFORM = 'generic'
+    BOARD = 'generic'
+
 if FRAMEWORK == 'zephyr':
     SRC_FILTER = ["+<*>",
                   "-<tests/>",
@@ -97,6 +105,13 @@ elif FRAMEWORK == 'mbed':
                   "-<system/windows/>",
                   "-<system/zephyr/>"]
     CPPDEFINES = ["ZENOH_MBED", "ZENOH_C_STANDARD=99"]
+elif FRAMEWORK == 'generic':
+    SRC_FILTER = ["+<*>",
+                    "-<tests/>",
+                    "-<example/>",
+                    "-<system/*>",
+                    "+<system/common>"]
+    CPPDEFINES = ["ZENOH_GENERIC"]
 
 env.Append(SRC_FILTER=SRC_FILTER)
 env.Append(CPPDEFINES=CPPDEFINES)

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -15,6 +15,10 @@
 #ifndef INCLUDE_ZENOH_PICO_CONFIG_H
 #define INCLUDE_ZENOH_PICO_CONFIG_H
 
+#ifdef ZENOH_GENERIC
+#include <zenoh_generic_config.h>
+#else
+
 /*--- CMake generated config; pass values to CMake to change the following tokens ---*/
 #define Z_FRAG_MAX_SIZE 4096
 #define Z_BATCH_UNICAST_SIZE 2048
@@ -51,6 +55,8 @@
 #define Z_FEATURE_UNICAST_PEER 1
 #define Z_FEATURE_AUTO_RECONNECT 1
 // End of CMake generation
+
+#endif /* ZENOH_GENERIC */
 
 /*------------------ Runtime configuration properties ------------------*/
 /**

--- a/include/zenoh-pico/system/common/platform.h
+++ b/include/zenoh-pico/system/common/platform.h
@@ -48,6 +48,8 @@
 #include "zenoh-pico/system/platform/freertos_plus_tcp.h"
 #elif defined(ZENOH_RPI_PICO)
 #include "zenoh-pico/system/platform/rpi_pico.h"
+#elif defined(ZENOH_GENERIC)
+#include "zenoh_generic_platform.h"
 #else
 #include "zenoh-pico/system/platform/void.h"
 #error "Unknown platform"

--- a/library.json
+++ b/library.json
@@ -23,9 +23,12 @@
     "license": "Apache-2.0 OR EPL-2.0",
     "frameworks": [
         "arduino",
+        "libopencm3",
+        "stm32cube",
         "espidf",
         "mbed",
-        "zephyr"
+        "zephyr",
+        "spl"
     ],
     "headers": [
         "zenoh-pico.h"


### PR DESCRIPTION
This will enable developers to include zenoh-pico in their own platform. The developer needs to provide the platform specific functions for network and system platform. Tested this with single thread STM32CUBE and libopencm3