### PR TITLE
Prevent int underflow in link write

### DIFF
--- a/src/link/link.c
+++ b/src/link/link.c
@@ -182,7 +182,7 @@ z_result_t _z_link_send_wbuf(const _z_link_t *link, const _z_wbuf_t *wbf, _z_sys
         size_t n = bs.len;
         do {
             size_t wb = link->_write_f(link, bs.start, n, socket);
-            if (wb == SIZE_MAX) {
+            if ((wb == SIZE_MAX) || (wb > n)) {
                 ret = _Z_ERR_TRANSPORT_TX_FAILED;
                 break;
             }


### PR DESCRIPTION
Int underflow could happen if the link function reported a higher sent bytes number than requested to send.