### PR TITLE
Add generic platform to config.h.in

### DIFF
--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -15,6 +15,10 @@
 #ifndef INCLUDE_ZENOH_PICO_CONFIG_H
 #define INCLUDE_ZENOH_PICO_CONFIG_H
 
+#ifdef ZENOH_GENERIC
+#include <zenoh_generic_config.h>
+#else
+
 /*--- CMake generated config; pass values to CMake to change the following tokens ---*/
 #define Z_FRAG_MAX_SIZE @FRAG_MAX_SIZE@
 #define Z_BATCH_UNICAST_SIZE @BATCH_UNICAST_SIZE@
@@ -51,6 +55,8 @@
 #define Z_FEATURE_UNICAST_PEER @Z_FEATURE_UNICAST_PEER@
 #define Z_FEATURE_AUTO_RECONNECT @Z_FEATURE_AUTO_RECONNECT@
 // End of CMake generation
+
+#endif /* ZENOH_GENERIC */
 
 /*------------------ Runtime configuration properties ------------------*/
 /**


### PR DESCRIPTION
ZENOH_GENERIC wasn't in config.h.in and was overwritten when going through cmake.