### PR TITLE
Resolve issue with invalid pointer dereference when dropping session when building with Address Sanitizer active.

### DIFF
--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -112,6 +112,7 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
 
 #if Z_FEATURE_MULTI_THREAD == 1
         // Tasks
+        ztm->_common._accept_task_running = NULL;
         ztm->_common._read_task_running = false;
         ztm->_common._read_task = NULL;
         ztm->_common._lease_task_running = false;

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -44,6 +44,7 @@ static z_result_t _z_unicast_transport_create_inner(_z_transport_unicast_t *ztu,
     _Z_RETURN_IF_ERR(_z_mutex_rec_init(&ztu->_common._mutex_peer));
 
     // Tasks
+    ztu->_common._accept_task_running = NULL;
     ztu->_common._read_task_running = false;
     ztu->_common._read_task = NULL;
     ztu->_common._lease_task_running = false;


### PR DESCRIPTION
Closes #939.