### PR TITLE
ci: add step to determine runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,27 @@ on:
     - cron: "0 6 * * 1-5"
 
 jobs:
+  determine-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.set-runner.outputs.runner }}
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Determine which runner to use
+        id: set-runner
+        run: |
+          if [[ -f ci/runners.json ]]; then
+            echo "runner=$(cat ci/runners.json)" >> $GITHUB_OUTPUT
+          else
+            echo "runner=['ubuntu-latest']" >> $GITHUB_OUTPUT
+          fi
+
   run_tests:
     name: Run unit tests on ubuntu-latest
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +54,8 @@ jobs:
 
   check_format:
     name: Check codebase format with clang-format
-    runs-on: ubuntu-24.04
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,6 +68,8 @@ jobs:
   c99_build:
     name: Check c99 compilation
     runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +82,8 @@ jobs:
   raweth_build:
     name: Build raweth transport on ubuntu-latest
     runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -73,6 +96,8 @@ jobs:
   zenoh_build:
     name: Build Zenoh from source
     runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     outputs:
       artifact-name: ${{ steps.main.outputs.artifact-name }}
     steps:
@@ -88,9 +113,9 @@ jobs:
             ^libzenoh_plugin_storage_manager.so$
 
   modular_build:
-    needs: zenoh_build
+    needs: [determine-runner, zenoh_build]
     name: Modular build on ubuntu-latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     strategy:
       matrix:
         feature_publication: [1, 0]
@@ -133,7 +158,8 @@ jobs:
 
   unstable_build:
     name: Check compilation with unstable API
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -145,9 +171,9 @@ jobs:
 
 
   st_build:
-    needs: zenoh_build
+    needs: [determine-runner,zenoh_build]
     name: Build and test in single thread on ubuntu-latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -180,9 +206,9 @@ jobs:
         run: kill ${{ steps.run-zenoh.outputs.zenohd-pid }}
 
   fragment_test:
-    needs: zenoh_build
+    needs: [determine-runner,zenoh_build]
     name: Test multicast and unicast fragmentation
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -214,9 +240,9 @@ jobs:
         run: kill ${{ steps.run-zenoh.outputs.zenohd-pid }}
 
   attachment_test:
-    needs: zenoh_build
+    needs: [determine-runner, zenoh_build]
     name: Test attachments
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -247,9 +273,9 @@ jobs:
         run: kill ${{ steps.run-zenoh.outputs.zenohd-pid }}
 
   memory_leak_test:
-    needs: zenoh_build
+    needs: [determine-runner, zenoh_build]
     name: Test examples memory leak
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -286,7 +312,8 @@ jobs:
 
   no_router:
     name: Test examples without router
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -299,9 +326,9 @@ jobs:
         timeout-minutes: 5
   
   connection_restore_test:
-    needs: zenoh_build
     name: Connection restore test 
-    runs-on: ubuntu-latest
+    needs: [determine-runner, zenoh_build]
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -322,7 +349,8 @@ jobs:
         timeout-minutes: 15
 
   markdown_lint:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v18


### PR DESCRIPTION
This allows internal forks to run on self-hosted runners, defaulting
 to the regular GH hosted runners labels.