### PR TITLE
Fix task cancel race condition, on ESP32, causing core panic

### DIFF
--- a/include/zenoh-pico/system/platform/arduino/esp32.h
+++ b/include/zenoh-pico/system/platform/arduino/esp32.h
@@ -15,6 +15,10 @@
 #ifndef ZENOH_PICO_SYSTEM_ESP32_TYPES_H
 #define ZENOH_PICO_SYSTEM_ESP32_TYPES_H
 
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <freertos/task.h>
+
 #include "zenoh-pico/config.h"
 
 #if Z_FEATURE_MULTI_THREAD == 1
@@ -26,8 +30,20 @@ extern "C" {
 #endif
 
 #if Z_FEATURE_MULTI_THREAD == 1
-typedef void *_z_task_t;
-typedef void *z_task_attr_t;  // Not used in ESP32
+typedef struct {
+    const char *name;
+    UBaseType_t priority;
+    size_t stack_depth;
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+    bool static_allocation;
+    StackType_t *stack_buffer;
+    StaticTask_t *task_buffer;
+#endif /* SUPPORT_STATIC_ALLOCATION */
+} z_task_attr_t;
+typedef struct {
+    TaskHandle_t handle;
+    EventGroupHandle_t join_event;
+} _z_task_t;
 typedef pthread_mutex_t _z_mutex_t;
 typedef pthread_mutex_t _z_mutex_rec_t;
 typedef pthread_cond_t _z_condvar_t;


### PR DESCRIPTION
## System Setup

- `zenohd`: run with `ros2 run rmw_zenoh_cpp rmw_zenohd`
  - running `sudo apt-show-versions ros-jazzy-rmw-zenoh-cpp` gives `ros-jazzy-rmw-zenoh-cpp:amd64/noble 0.2.3-1noble.20250406.083344 uptodate`
- `zenoh-pico::arduino::esp32`: running zenoh-pico version 1.3.4 (however I saw this bug pop up a couple times with previous versions too)
- Both have a tx lease duration of 10,000ms and a lease factor of 3 (this is the default on Zenoh-Pico)

## Problem Description

The ESP32 is crashing when `zenohd` shuts down (hit ^C in terminal) and the ESP hits a lease expiration.
I never got it to crash with debug prints on, probably because the timing is so tight.

The crash happens because, in `_z_common_transport_clear`, it's setting the `read_task_running` var to false right before it goes to clean up the read task with `z_task_detatch`. The problem fully arises because in ESP FreeRTOS tasks are never supposed to just return. They must be cleaned up or self-deleted. When the `read_task_running` var is set to false, the `read_task` shuts down too quickly. The task fully returns with `return NULL;` which leads the scheduler to freak out.

Heres a stack trace

```bash
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x40384bd5  PS      : 0x00060a33  A0      : 0x80382f89  A1      : 0x3fcd08e0
A2      : 0x3fccf5f0  A3      : 0x00060a20  A4      : 0x00000000  A5      : 0x00060a23
A6      : 0xb33fffff  A7      : 0xb33fffff  A8      : 0x00000000  A9      : 0x3fca07d8
A10     : 0x3fca07d8  A11     : 0x00000000  A12     : 0xb33fffff  A13     : 0x00000000
A14     : 0x00000000  A15     : 0x00000000  SAR     : 0x00000001  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000004  LBEG    : 0x40056f5c  LEND    : 0x40056f72  LCOUNT  : 0xffffffff


Backtrace: 0x40384bd2:0x3fcd08e0 0x40382f86:0x3fcd0900 0x4201bc92:0x3fcd0920 0x4201c002:0x3fcd0940 0x4201dfad:0x3fcd0960 0x4201d496:0x3fcd0980 0x4201d553:0x3fcd09a0 0x4201bbef:0x3fcd09c0 0x40384216:0x3fcd09e0
  #0  0x40384bd2 in uxListRemove at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/FreeRTOS-Kernel/list.c:197
  #1  0x40382f86 in vTaskDelete at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/FreeRTOS-Kernel/tasks.c:1439 (discriminator 4)
  #2  0x4201bc92 in _z_task_detach at .pio/libdeps/motor-controller/zenoh-pico/src/system/arduino/esp32/system.c:90
  #3  0x4201c002 in _z_common_transport_clear at .pio/libdeps/motor-controller/zenoh-pico/src/transport/common/transport.c:28
  #4  0x4201dfad in _z_unicast_transport_clear at .pio/libdeps/motor-controller/zenoh-pico/src/transport/unicast/transport.c:356
  #5  0x4201d496 in _zp_unicast_failed at .pio/libdeps/motor-controller/zenoh-pico/src/transport/unicast/lease.c:47
  #6  0x4201d553 in _zp_unicast_lease_task at .pio/libdeps/motor-controller/zenoh-pico/src/transport/unicast/lease.c:82
  #7  0x4201bbef in z_task_wrapper at .pio/libdeps/motor-controller/zenoh-pico/src/system/arduino/esp32/system.c:61
  #8  0x40384216 in vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:162
```

## Solution

~~Adding a function `void _zp_task_prepare_for_cleanup(void);` that tasks should call before they return.~~

~~This can be a `nop` for systems that don't need this behavior, however for the ESP FreeRTOS systems the function needs to look like~~

```c
void _zp_task_prepare_for_cleanup(void)
{
  vTaskSuspend(NULL);
}
```

~~This puts the task in a safe state for the parrent task to be able to clean it up.~~

~~Additionally, specifically for the ESP, the `_z_task_cancel` needs to wait for the task to be in a suspended state.~~
~~This way it doesn't delete the task while stuff is still going on.~~

I took a look at how the ESPIDF and FreeRTOS platforms handle this, and made ESP32 follow a similar pattern.