### PR TITLE
Use lowest lease value

### DIFF
--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -205,7 +205,7 @@ static z_result_t _z_unicast_handshake_open(_z_transport_unicast_establish_param
     }
     // THIS LOG STRING USED IN TEST, change with caution
     _Z_DEBUG("Received Z_OPEN(Ack)");
-    param->_lease = oam._body._open._lease;  // The session lease
+    param->_lease = (oam._body._open._lease < Z_TRANSPORT_LEASE) ? oam._body._open._lease : Z_TRANSPORT_LEASE;
     // The initial SN at RX side. Initialize the session as we had already received
     // a message with a SN equal to initial_sn - 1.
     param->_initial_sn_rx = oam._body._open._initial_sn;
@@ -276,7 +276,7 @@ z_result_t _z_unicast_handshake_listen(_z_transport_unicast_establish_param_t *p
     }
     _Z_DEBUG("Received Z_OPEN(Syn)");
     // Process message
-    param->_lease = tmsg._body._open._lease;
+    param->_lease = (tmsg._body._open._lease < Z_TRANSPORT_LEASE) ? tmsg._body._open._lease : Z_TRANSPORT_LEASE;
     param->_initial_sn_rx = tmsg._body._open._initial_sn;
     _z_t_msg_clear(&tmsg);
 


### PR DESCRIPTION
Currently we are taking the received lease value to calculate keep alive period, we should take the minimum of the two instead.