### PR TITLE
Make Z_TRANSPORT_LEASE CMake Configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ set(FRAG_MAX_SIZE 4096 CACHE STRING "Use this to override the maximum size for f
 set(BATCH_UNICAST_SIZE 2048 CACHE STRING "Use this to override the maximum unicast batch size")
 set(BATCH_MULTICAST_SIZE 2048 CACHE STRING "Use this to override the maximum multicast batch size")
 set(Z_CONFIG_SOCKET_TIMEOUT 100 CACHE STRING "Default socket timeout in milliseconds")
+set(Z_TRANSPORT_LEASE 10000 CACHE STRING "Link lease duration in milliseconds to announce to other zenoh nodes")
 
 set(Z_FEATURE_UNSTABLE_API 0 CACHE STRING "Toggle unstable Zenoh-C API")
 set(Z_FEATURE_PUBLICATION 1 CACHE STRING "Toggle publication feature")

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -24,6 +24,7 @@
 #define Z_BATCH_UNICAST_SIZE 2048
 #define Z_BATCH_MULTICAST_SIZE 2048
 #define Z_CONFIG_SOCKET_TIMEOUT 100
+#define Z_TRANSPORT_LEASE 10000
 
 /* #undef Z_FEATURE_UNSTABLE_API */
 #define Z_FEATURE_MULTI_THREAD 1
@@ -54,6 +55,7 @@
 #define Z_FEATURE_RX_CACHE 0
 #define Z_FEATURE_UNICAST_PEER 1
 #define Z_FEATURE_AUTO_RECONNECT 1
+
 // End of CMake generation
 
 #endif /* ZENOH_GENERIC */
@@ -158,11 +160,6 @@
  * Do not change this value.
  */
 #define Z_PROTO_VERSION 0x09
-
-/**
- * Default session lease in milliseconds.
- */
-#define Z_TRANSPORT_LEASE 10000
 
 /**
  * Default session lease expire factor.

--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -24,6 +24,7 @@
 #define Z_BATCH_UNICAST_SIZE @BATCH_UNICAST_SIZE@
 #define Z_BATCH_MULTICAST_SIZE @BATCH_MULTICAST_SIZE@
 #define Z_CONFIG_SOCKET_TIMEOUT @Z_CONFIG_SOCKET_TIMEOUT@
+#define Z_TRANSPORT_LEASE @Z_TRANSPORT_LEASE@
 
 #cmakedefine Z_FEATURE_UNSTABLE_API
 #define Z_FEATURE_MULTI_THREAD @Z_FEATURE_MULTI_THREAD@
@@ -54,6 +55,7 @@
 #define Z_FEATURE_RX_CACHE @Z_FEATURE_RX_CACHE@
 #define Z_FEATURE_UNICAST_PEER @Z_FEATURE_UNICAST_PEER@
 #define Z_FEATURE_AUTO_RECONNECT @Z_FEATURE_AUTO_RECONNECT@
+
 // End of CMake generation
 
 #endif /* ZENOH_GENERIC */
@@ -158,11 +160,6 @@
  * Do not change this value.
  */
 #define Z_PROTO_VERSION 0x09
-
-/**
- * Default session lease in milliseconds.
- */
-#define Z_TRANSPORT_LEASE 10000
 
 /**
  * Default session lease expire factor.


### PR DESCRIPTION
Zenohd can override the lease config using `XXX_ZENOH_ROUTER_CONFIG.json5` files. This PR allows you override the router lease config to match your coressponding zenohd config so that keepalive keeps working.