### PR TITLE
Keyexpr declare non-wild policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         timeout-minutes: 10
         shell: cmd
         env: 
-          ZENOH_LOG: DEBUG
+          ZENOH_LOG: INFO
           Z_FEATURE_UNSTABLE_API: 1
           
   

--- a/.github/workflows/cpp-check.yaml
+++ b/.github/workflows/cpp-check.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: build zenoh-pico
       run: |
         mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DZENOH_LOG=INFO -DCMAKE_INSTALL_PREFIX=~/local -DZ_FEATURE_UNSTABLE_API=${{ matrix.unstable }} -DZ_FEATURE_LIVELINESS=1 -DASAN=ON
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DZENOH_LOG=DEBUG -DCMAKE_INSTALL_PREFIX=~/local -DZ_FEATURE_UNSTABLE_API=${{ matrix.unstable }} -DZ_FEATURE_LIVELINESS=1 -DASAN=ON
         cmake --build . --target install --config Release
 
     - name: clone zenoh-cpp

--- a/include/zenoh-pico/protocol/core.h
+++ b/include/zenoh-pico/protocol/core.h
@@ -150,6 +150,7 @@ _z_keyexpr_t _z_rname(const char *rname);
  *     A :c:type:`_z_keyexpr_t` containing a new resource key.
  */
 _z_keyexpr_t _z_rid_with_suffix(uint16_t rid, const char *suffix);
+_z_keyexpr_t _z_rid_with_substr_suffix(uint16_t rid, const char *suffix, size_t suffix_len);
 
 /**
  * QoS settings of zenoh message.

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -50,7 +50,7 @@ _z_keyexpr_t *_z_keyexpr_clone(const _z_keyexpr_t *src);
 /// or keyexpr defined by its suffix only, with 0 id and no mapping. This is to be used only when forwarding
 /// keyexpr in user api to properly separate declared keyexpr from its suffix.
 _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_declared);
-z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc);
+z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc, size_t *wild_suffix_size);
 static inline _z_keyexpr_t _z_keyexpr_steal(_Z_MOVE(_z_keyexpr_t) src) {
     _z_keyexpr_t stolen = *src;
     *src = _z_keyexpr_null();

--- a/include/zenoh-pico/protocol/keyexpr.h
+++ b/include/zenoh-pico/protocol/keyexpr.h
@@ -50,6 +50,7 @@ _z_keyexpr_t *_z_keyexpr_clone(const _z_keyexpr_t *src);
 /// or keyexpr defined by its suffix only, with 0 id and no mapping. This is to be used only when forwarding
 /// keyexpr in user api to properly separate declared keyexpr from its suffix.
 _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_declared);
+z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc);
 static inline _z_keyexpr_t _z_keyexpr_steal(_Z_MOVE(_z_keyexpr_t) src) {
     _z_keyexpr_t stolen = *src;
     *src = _z_keyexpr_null();

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -68,6 +68,7 @@ typedef void (*_z_closure_sample_callback_t)(_z_sample_t *sample, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
+    _z_keyexpr_t _declared_key;
     uint16_t _key_id;
     uint32_t _id;
     _z_closure_sample_callback_t _callback;
@@ -99,6 +100,7 @@ typedef void (*_z_closure_query_callback_t)(_z_query_rc_t *query, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
+    _z_keyexpr_t _declared_key;
     uint32_t _id;
     _z_closure_query_callback_t _callback;
     _z_drop_handler_t _dropper;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1625,14 +1625,12 @@ z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t
     if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         // Remove wilds
         char *wild_loc = NULL;
-        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc));
-        if (wild_loc != NULL) {
-            printf("Pouet: %s\n", wild_loc);
-        }
+        size_t wild_suffix_size = 0;
+        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc, &wild_suffix_size));
         // Declare resource if needed
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &base_key, NULL);
         uint16_t id = (r != NULL) ? r->_id : _z_declare_resource(_Z_RC_IN_VAL(zs), &base_key);
-        final_key = _z_rid_with_suffix(id, wild_loc);
+        final_key = _z_rid_with_substr_suffix(id, wild_loc, wild_suffix_size);
         _z_keyexpr_clear(&base_key);
     }
 
@@ -1898,11 +1896,12 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         // Remove wilds
         char *wild_loc = NULL;
-        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc));
+        size_t wild_suffix_size = 0;
+        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc, &wild_suffix_size));
         // Declare resource if needed
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &base_key, NULL);
         uint16_t id = (r != NULL) ? r->_id : _z_declare_resource(_Z_RC_IN_VAL(zs), &base_key);
-        final_key = _z_rid_with_suffix(id, wild_loc);
+        final_key = _z_rid_with_substr_suffix(id, wild_loc, wild_suffix_size);
         _z_keyexpr_clear(&base_key);
     }
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1612,22 +1612,51 @@ z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_
     return _Z_RES_OK;
 }
 
+static z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc) {
+    // Check suffix
+    if (!_z_keyexpr_has_suffix(base_key)) {
+        return _Z_RES_OK;
+    }
+    // Search for wilds
+    char *wild = _z_string_pbrk(&base_key->_suffix, "*$");
+    if (wild == NULL) {
+        return _Z_RES_OK;
+    } else if (wild == _z_string_data(&base_key->_suffix)) {
+        return _Z_ERR_INVALID;
+    }
+    // Remove wildcards from suffix
+    wild = _z_ptr_char_offset(wild, -1);
+    *wild_loc = wild;
+    size_t len = _z_ptr_char_diff(wild, _z_string_data(&base_key->_suffix));
+    // Copy non-wild prefix
+    _z_string_t new_suffix = _z_string_preallocate(len);
+    if (!_z_string_check(&new_suffix)) {
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    memcpy((char *)_z_string_data(&new_suffix), _z_string_data(&base_key->_suffix), len);
+    base_key->_suffix = new_suffix;
+    return _Z_RES_OK;
+}
+
 z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t *queryable,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options) {
     void *ctx = callback->_this._val.context;
     callback->_this._val.context = NULL;
 
-    _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
-    _z_keyexpr_t key = keyexpr_aliased;
+    _z_keyexpr_t base_key = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
+    _z_keyexpr_t final_key = _z_keyexpr_alias(&base_key);
 
     // TODO: Implement interest protocol for multicast transports
     if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
-        _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
-        if (r == NULL) {
-            uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
-            key = _z_rid_with_suffix(id, NULL);
-        }
+        // Remove wilds
+        char *wild_loc = NULL;
+        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc));
+        // Declare resource if needed
+        _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &base_key, NULL);
+        uint16_t id = (r != NULL) ? r->_id : _z_declare_resource(_Z_RC_IN_VAL(zs), &base_key);
+        final_key = _z_rid_with_suffix(id, wild_loc);
+        _z_keyexpr_clear(&base_key);
     }
 
     z_queryable_options_t opt;
@@ -1637,7 +1666,7 @@ z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t
     }
 
     queryable->_val =
-        _z_declare_queryable(zs, key, opt.complete, callback->_this._val.call, callback->_this._val.drop, ctx);
+        _z_declare_queryable(zs, final_key, opt.complete, callback->_this._val.call, callback->_this._val.drop, ctx);
 
     z_internal_closure_query_null(&callback->_this);
     return _Z_RES_OK;
@@ -1885,37 +1914,23 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     void *ctx = callback->_this._val.context;
     callback->_this._val.context = NULL;
 
-    _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
-    _z_keyexpr_t key = _z_keyexpr_alias(&keyexpr_aliased);
+    _z_keyexpr_t base_key = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
+    _z_keyexpr_t final_key = _z_keyexpr_alias(&base_key);
 
     // TODO: Implement interest protocol for multicast transports
     if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
-        _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
-        if (r == NULL) {
-            bool do_keydecl = true;
-            _z_keyexpr_t resource_key = _z_keyexpr_alias(&keyexpr_aliased);
-            // Remove wild
-            char *wild = _z_string_pbrk(&keyexpr_aliased._suffix, "*$");
-            if ((wild != NULL) && _z_keyexpr_has_suffix(&keyexpr_aliased)) {
-                wild = _z_ptr_char_offset(wild, -1);
-                size_t len = _z_ptr_char_diff(wild, _z_string_data(&keyexpr_aliased._suffix));
-                resource_key._suffix = _z_string_preallocate(len);
-
-                if (!_z_keyexpr_has_suffix(&resource_key)) {
-                    return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
-                }
-                memcpy((char *)_z_string_data(&resource_key._suffix), _z_string_data(&keyexpr_aliased._suffix), len);
-            }
-            // Declare resource
-            if (do_keydecl) {
-                uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), &resource_key);
-                key = _z_rid_with_suffix(id, wild);
-            }
-            _z_keyexpr_clear(&resource_key);
-        }
+        // Remove wilds
+        char *wild_loc = NULL;
+        _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc));
+        // Declare resource if needed
+        _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &base_key, NULL);
+        uint16_t id = (r != NULL) ? r->_id : _z_declare_resource(_Z_RC_IN_VAL(zs), &base_key);
+        final_key = _z_rid_with_suffix(id, wild_loc);
+        _z_keyexpr_clear(&base_key);
     }
 
-    _z_subscriber_t int_sub = _z_declare_subscriber(zs, key, callback->_this._val.call, callback->_this._val.drop, ctx);
+    _z_subscriber_t int_sub =
+        _z_declare_subscriber(zs, final_key, callback->_this._val.call, callback->_this._val.drop, ctx);
 
     z_internal_closure_sample_null(&callback->_this);
     sub->_val = int_sub;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1612,32 +1612,6 @@ z_result_t z_declare_background_queryable(const z_loaned_session_t *zs, const z_
     return _Z_RES_OK;
 }
 
-static z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc) {
-    // Check suffix
-    if (!_z_keyexpr_has_suffix(base_key)) {
-        return _Z_RES_OK;
-    }
-    // Search for wilds
-    char *wild = _z_string_pbrk(&base_key->_suffix, "*$");
-    if (wild == NULL) {
-        return _Z_RES_OK;
-    } else if (wild == _z_string_data(&base_key->_suffix)) {
-        return _Z_ERR_INVALID;
-    }
-    // Remove wildcards from suffix
-    wild = _z_ptr_char_offset(wild, -1);
-    *wild_loc = wild;
-    size_t len = _z_ptr_char_diff(wild, _z_string_data(&base_key->_suffix));
-    // Copy non-wild prefix
-    _z_string_t new_suffix = _z_string_preallocate(len);
-    if (!_z_string_check(&new_suffix)) {
-        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
-    }
-    memcpy((char *)_z_string_data(&new_suffix), _z_string_data(&base_key->_suffix), len);
-    base_key->_suffix = new_suffix;
-    return _Z_RES_OK;
-}
-
 z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t *queryable,
                                const z_loaned_keyexpr_t *keyexpr, z_moved_closure_query_t *callback,
                                const z_queryable_options_t *options) {

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1626,6 +1626,9 @@ z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t
         // Remove wilds
         char *wild_loc = NULL;
         _Z_RETURN_IF_ERR(_z_keyexpr_remove_wilds(&base_key, &wild_loc));
+        if (wild_loc != NULL) {
+            printf("Pouet: %s\n", wild_loc);
+        }
         // Declare resource if needed
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &base_key, NULL);
         uint16_t id = (r != NULL) ? r->_id : _z_declare_resource(_Z_RC_IN_VAL(zs), &base_key);

--- a/src/net/liveliness.c
+++ b/src/net/liveliness.c
@@ -73,6 +73,7 @@ _z_subscriber_t _z_declare_liveliness_subscriber(const _z_session_rc_t *zn, _z_k
     _z_subscription_t s;
     s._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     s._key_id = keyexpr->_id;
+    s._declared_key = _z_keyexpr_duplicate(keyexpr);
     s._key = _z_get_expanded_key_from_key(_Z_RC_IN_VAL(zn), keyexpr, NULL);
     s._callback = callback;
     s._dropper = dropper;

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -260,6 +260,7 @@ _z_subscriber_t _z_declare_subscriber(const _z_session_rc_t *zn, _z_keyexpr_t ke
     _z_subscription_t s;
     s._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
     s._key_id = keyexpr._id;
+    s._declared_key = _z_keyexpr_duplicate(&keyexpr);
     s._key = _z_get_expanded_key_from_key(_Z_RC_IN_VAL(zn), &keyexpr, NULL);
     s._callback = callback;
     s._dropper = dropper;
@@ -326,6 +327,7 @@ _z_queryable_t _z_declare_queryable(const _z_session_rc_t *zn, _z_keyexpr_t keye
                                     _z_closure_query_callback_t callback, _z_drop_handler_t dropper, void *arg) {
     _z_session_queryable_t q;
     q._id = _z_get_entity_id(_Z_RC_IN_VAL(zn));
+    q._declared_key = _z_keyexpr_duplicate(&keyexpr);
     q._key = _z_get_expanded_key_from_key(_Z_RC_IN_VAL(zn), &keyexpr, NULL);
     q._complete = complete;
     q._callback = callback;

--- a/src/protocol/keyexpr.c
+++ b/src/protocol/keyexpr.c
@@ -156,6 +156,32 @@ _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_decla
     }
 }
 
+z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc) {
+    // Check suffix
+    if (!_z_keyexpr_has_suffix(base_key)) {
+        return _Z_RES_OK;
+    }
+    // Search for wilds
+    char *wild = _z_string_pbrk(&base_key->_suffix, "*$");
+    if (wild == NULL) {
+        return _Z_RES_OK;
+    } else if (wild == _z_string_data(&base_key->_suffix)) {
+        return _Z_ERR_INVALID;
+    }
+    // Remove wildcards from suffix
+    wild = _z_ptr_char_offset(wild, -1);
+    *wild_loc = wild;
+    size_t len = _z_ptr_char_diff(wild, _z_string_data(&base_key->_suffix));
+    // Copy non-wild prefix
+    _z_string_t new_suffix = _z_string_preallocate(len);
+    if (!_z_string_check(&new_suffix)) {
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    memcpy((char *)_z_string_data(&new_suffix), _z_string_data(&base_key->_suffix), len);
+    base_key->_suffix = new_suffix;
+    return _Z_RES_OK;
+}
+
 /*------------------ Canonize helpers ------------------*/
 zp_keyexpr_canon_status_t __zp_canon_prefix(const char *start, size_t *len) {
     zp_keyexpr_canon_status_t ret = Z_KEYEXPR_CANON_SUCCESS;

--- a/src/protocol/keyexpr.c
+++ b/src/protocol/keyexpr.c
@@ -33,6 +33,14 @@ _z_keyexpr_t _z_rid_with_suffix(uint16_t rid, const char *suffix) {
     };
 }
 
+_z_keyexpr_t _z_rid_with_substr_suffix(uint16_t rid, const char *suffix, size_t suffix_len) {
+    return (_z_keyexpr_t){
+        ._id = rid,
+        ._mapping = _Z_KEYEXPR_MAPPING_LOCAL,
+        ._suffix = (suffix == NULL) ? _z_string_null() : _z_string_alias_substr(suffix, suffix_len),
+    };
+}
+
 int _z_keyexpr_compare(_z_keyexpr_t *first, _z_keyexpr_t *second) {
     // Compare ids only if they are valid and originate from the same location
     if ((first->_id != Z_RESOURCE_ID_NONE) && (second->_id != Z_RESOURCE_ID_NONE)) {
@@ -156,7 +164,7 @@ _z_keyexpr_t _z_keyexpr_alias_from_user_defined(_z_keyexpr_t src, bool try_decla
     }
 }
 
-z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc) {
+z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc, size_t *wild_suffix_size) {
     // Check suffix
     if (!_z_keyexpr_has_suffix(base_key)) {
         return _Z_RES_OK;
@@ -172,6 +180,7 @@ z_result_t _z_keyexpr_remove_wilds(_z_keyexpr_t *base_key, char **wild_loc) {
     wild = _z_ptr_char_offset(wild, -1);
     *wild_loc = wild;
     size_t len = _z_ptr_char_diff(wild, _z_string_data(&base_key->_suffix));
+    *wild_suffix_size = _z_string_len(&base_key->_suffix) - len;
     // Copy non-wild prefix
     _z_string_t new_suffix = _z_string_preallocate(len);
     if (!_z_string_check(&new_suffix)) {

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -61,7 +61,7 @@ static z_result_t _z_interest_send_decl_subscriber(_z_session_t *zn, uint32_t in
     while (xs != NULL) {
         _z_subscription_rc_t *sub = _z_subscription_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(sub)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(sub)->_declared_key);
         _z_declaration_t declaration = _z_make_decl_subscriber(&key, _Z_RC_IN_VAL(sub)->_id);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);
         if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, peer) != _Z_RES_OK) {
@@ -91,7 +91,7 @@ static z_result_t _z_interest_send_decl_queryable(_z_session_t *zn, uint32_t int
     while (xs != NULL) {
         _z_session_queryable_rc_t *qle = _z_session_queryable_rc_list_head(xs);
         // Build the declare message to send on the wire
-        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(qle)->_key);
+        _z_keyexpr_t key = _z_keyexpr_alias(&_Z_RC_IN_VAL(qle)->_declared_key);
         _z_declaration_t declaration = _z_make_decl_queryable(
             &key, _Z_RC_IN_VAL(qle)->_id, _Z_RC_IN_VAL(qle)->_complete, _Z_QUERYABLE_DISTANCE_DEFAULT);
         _z_network_message_t n_msg = _z_n_msg_make_declare(declaration, true, interest_id);

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -126,7 +126,8 @@ static z_result_t _z_trigger_query_reply_partial_inner(_z_session_t *zn, const _
     _z_keyexpr_t expanded_ke = __unsafe_z_get_expanded_key_from_key(zn, keyexpr, true, peer);
     if (!pen_qry->_anykey && !_z_keyexpr_suffix_intersects(&pen_qry->_key, keyexpr)) {
         _z_session_mutex_unlock(zn);
-        return _Z_ERR_QUERY_NOT_MATCH;
+        // Not concerned by the reply
+        return _Z_RES_OK;
     }
     // Build the reply
     _z_reply_t reply = _z_reply_steal_data(&expanded_ke, zn->_local_zid, &msg->_payload, &msg->_commons._timestamp,

--- a/src/session/queryable.c
+++ b/src/session/queryable.c
@@ -68,6 +68,7 @@ void _z_session_queryable_clear(_z_session_queryable_t *qle) {
         qle->_dropper(qle->_arg);
     }
     _z_keyexpr_clear(&qle->_key);
+    _z_keyexpr_clear(&qle->_declared_key);
 }
 
 /*------------------ Queryable ------------------*/

--- a/src/session/subscription.c
+++ b/src/session/subscription.c
@@ -69,6 +69,7 @@ void _z_subscription_clear(_z_subscription_t *sub) {
         sub->_dropper(sub->_arg);
     }
     _z_keyexpr_clear(&sub->_key);
+    _z_keyexpr_clear(&sub->_declared_key);
 }
 
 _z_subscription_rc_t *__z_get_subscription_by_id(_z_subscription_rc_list_t *subs, const _z_zint_t id) {

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -309,13 +309,6 @@ int main(int argc, char **argv) {
     z_sleep_s(SLEEP);
     assert_eq(datas, 2);
 
-    printf("Undeclaring Keyexpr...");
-    _ret_res = z_undeclare_keyexpr(z_loan(s1), z_move(_ret_expr));
-    printf(" %02x\n", _ret_res);
-    assert_eq(_ret_res, 0);
-    assert(!z_internal_check(_ret_expr));
-    printf("Ok\n");
-
     printf("Declaring Publisher...");
     z_publisher_options_t _ret_pub_opt;
     z_publisher_options_default(&_ret_pub_opt);
@@ -409,6 +402,13 @@ int main(int argc, char **argv) {
 
     printf("Undeclaring Queryable...");
     z_drop(z_move(qle));
+    printf("Ok\n");
+
+    printf("Undeclaring Keyexpr...");
+    _ret_res = z_undeclare_keyexpr(z_loan(s1), z_move(_ret_expr));
+    printf(" %02x\n", _ret_res);
+    assert_eq(_ret_res, 0);
+    assert(!z_internal_check(_ret_expr));
     printf("Ok\n");
 
 #ifdef ZENOH_PICO


### PR DESCRIPTION
Queryable weren't using the nonwild prefix mapping strategy while subscribers were. Zenoh rust use it for both so this PR implements the strategy for queryable.

The strategy had a lot of flaws (it was checking for the full ke to avoid duplicate declaration so it was duplicating declarations, there was room for segfaults...) and needed to be reworked.

With the interest profile, need to store a copy of the declared version of a sub/queryable ke to replay it as needed.