### PR TITLE
ci: run apt-update before valgrind install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,9 @@ jobs:
           echo "zenohd-pid=$!" >> $GITHUB_OUTPUT
 
       - name: Install valgrind
-        run: sudo apt install -y valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
 
       - name: Build project
         run: |


### PR DESCRIPTION
Fix: https://github.com/eclipse-zenoh/zenoh-pico/actions/runs/16307349603/job/46056364735