### PR TITLE
Fix liveliness declaration

### DIFF
--- a/src/api/liveliness.c
+++ b/src/api/liveliness.c
@@ -64,11 +64,15 @@ z_result_t z_liveliness_token_options_default(z_liveliness_token_options_t *opti
 z_result_t z_liveliness_declare_token(const z_loaned_session_t *zs, z_owned_liveliness_token_t *token,
                                       const z_loaned_keyexpr_t *keyexpr, const z_liveliness_token_options_t *options) {
     (void)options;
-#if Z_FEATURE_MULTICAST_DECLARATIONS == 0
     _z_keyexpr_t key;
-    _z_keyexpr_alias_from_user_defined(&key, keyexpr);
+#if Z_FEATURE_MULTICAST_DECLARATIONS == 0
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
+        _z_keyexpr_alias_from_user_defined(&key, keyexpr);
+    } else {
+        key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
+    }
 #else
-    _z_keyexpr_t key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
+    key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
 #endif
     return _z_declare_liveliness_token(zs, &token->_val, &key);
 }
@@ -97,11 +101,15 @@ z_result_t z_liveliness_declare_subscriber(const z_loaned_session_t *zs, z_owned
     } else {
         opt = *options;
     }
-#if Z_FEATURE_MULTICAST_DECLARATIONS == 0
     _z_keyexpr_t key;
-    _z_keyexpr_alias_from_user_defined(&key, keyexpr);
+#if Z_FEATURE_MULTICAST_DECLARATIONS == 0
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
+        _z_keyexpr_alias_from_user_defined(&key, keyexpr);
+    } else {
+        key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
+    }
 #else
-    _z_keyexpr_t key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
+    key = _z_update_keyexpr_to_declared(_Z_RC_IN_VAL(zs), *keyexpr);
 #endif
     _z_subscriber_t int_sub = _z_declare_liveliness_subscriber(zs, &key, callback->_this._val.call,
                                                                callback->_this._val.drop, opt.history, ctx);

--- a/src/net/liveliness.c
+++ b/src/net/liveliness.c
@@ -43,7 +43,7 @@ z_result_t _z_declare_liveliness_token(const _z_session_rc_t *zn, _z_liveliness_
     _z_liveliness_register_token(_Z_RC_IN_VAL(zn), id, keyexpr);
 
     ret_token->_id = id;
-    ret_token->_key = _z_keyexpr_steal(keyexpr);
+    ret_token->_key = _z_keyexpr_steal(&ke);
     ret_token->_zn = _z_session_rc_clone_as_weak(zn);
     return ret;
 }


### PR DESCRIPTION
* liveliness tokens ke weren't declare in unicast
* declared token weren't owning their keyexpr leading to use after free if original keyexpr was dropped before token.