### PR TITLE
*IMPORTANT* Change default behavior of zp_read

### DIFF
--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -450,7 +450,7 @@ typedef struct {
  * Represents the configuration used to configure a read operation started via :c:func:`zp_read`.
  */
 typedef struct {
-    uint8_t __dummy;  // Just to avoid empty structures that might cause undefined behavior
+    bool single_read;  // Read a single packet instead of the whole buffer
 } zp_read_options_t;
 
 /**

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -187,10 +187,11 @@ _z_config_t *_z_info(const _z_session_t *session);
  *
  * Parameters:
  *     session: The zenoh-net session. The caller keeps its ownership.
+ *     single_read: Read a single packet from the buffer instead of the whole buffer
  * Returns:
  *     ``0`` in case of success, ``-1`` in case of failure.
  */
-z_result_t _zp_read(_z_session_t *z);
+z_result_t _zp_read(_z_session_t *z, bool single_read);
 
 /**
  * Send a KeepAlive message.

--- a/include/zenoh-pico/transport/common/read.h
+++ b/include/zenoh-pico/transport/common/read.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-z_result_t _z_read(_z_transport_t *zt);
+z_result_t _z_read(_z_transport_t *zt, bool single_read);
 void *_zp_read_task(void *zt_arg);  // The argument is void* to avoid incompatible pointer types in tasks
 
 #ifdef __cplusplus

--- a/include/zenoh-pico/transport/multicast/read.h
+++ b/include/zenoh-pico/transport/multicast/read.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-z_result_t _zp_multicast_read(_z_transport_multicast_t *ztm);
+z_result_t _zp_multicast_read(_z_transport_multicast_t *ztm, bool single_read);
 z_result_t _zp_multicast_stop_read_task(_z_transport_t *zt);
 void *_zp_multicast_read_task(void *ztm_arg);  // The argument is void* to avoid incompatible pointer types in tasks
 

--- a/include/zenoh-pico/transport/raweth/read.h
+++ b/include/zenoh-pico/transport/raweth/read.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm);
+z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm, bool single_read);
 z_result_t _zp_raweth_stop_read_task(_z_transport_t *zt);
 void *_zp_raweth_read_task(void *ztm_arg);  // The argument is void* to avoid incompatible pointer types in tasks
 

--- a/include/zenoh-pico/transport/unicast/read.h
+++ b/include/zenoh-pico/transport/unicast/read.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu);
+z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu, bool single_read);
 z_result_t _zp_unicast_stop_read_task(_z_transport_t *zt);
 void *_zp_unicast_read_task(void *ztu_arg);  // The argument is void* to avoid incompatible pointer types in tasks
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -2082,11 +2082,16 @@ z_result_t zp_stop_lease_task(z_loaned_session_t *zs) {
 #endif
 }
 
-void zp_read_options_default(zp_read_options_t *options) { options->__dummy = 0; }
+void zp_read_options_default(zp_read_options_t *options) { options->single_read = false; }
 
 z_result_t zp_read(const z_loaned_session_t *zs, const zp_read_options_t *options) {
-    (void)(options);
-    return _zp_read(_Z_RC_IN_VAL(zs));
+    zp_read_options_t opt;
+    if (options != NULL) {
+        opt = *options;
+    } else {
+        zp_read_options_default(&opt);
+    }
+    return _zp_read(_Z_RC_IN_VAL(zs), opt.single_read);
 }
 
 void zp_send_keep_alive_options_default(zp_send_keep_alive_options_t *options) { options->__dummy = 0; }

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -344,7 +344,7 @@ _z_config_t *_z_info(const _z_session_t *zn) {
     return ps;
 }
 
-z_result_t _zp_read(_z_session_t *zn) { return _z_read(&zn->_tp); }
+z_result_t _zp_read(_z_session_t *zn, bool single_read) { return _z_read(&zn->_tp, single_read); }
 
 z_result_t _zp_send_keep_alive(_z_session_t *zn) { return _z_send_keep_alive(&zn->_tp); }
 

--- a/src/transport/common/read.c
+++ b/src/transport/common/read.c
@@ -20,17 +20,17 @@
 #include "zenoh-pico/transport/raweth/read.h"
 #include "zenoh-pico/transport/unicast/read.h"
 
-z_result_t _z_read(_z_transport_t *zt) {
+z_result_t _z_read(_z_transport_t *zt, bool single_read) {
     z_result_t ret = _Z_RES_OK;
     switch (zt->_type) {
         case _Z_TRANSPORT_UNICAST_TYPE:
-            ret = _zp_unicast_read(&zt->_transport._unicast);
+            ret = _zp_unicast_read(&zt->_transport._unicast, single_read);
             break;
         case _Z_TRANSPORT_MULTICAST_TYPE:
-            ret = _zp_multicast_read(&zt->_transport._multicast);
+            ret = _zp_multicast_read(&zt->_transport._multicast, single_read);
             break;
         case _Z_TRANSPORT_RAWETH_TYPE:
-            ret = _zp_raweth_read(&zt->_transport._raweth);
+            ret = _zp_raweth_read(&zt->_transport._raweth, single_read);
             break;
         default:
             ret = _Z_ERR_TRANSPORT_NOT_AVAILABLE;

--- a/src/transport/raweth/read.c
+++ b/src/transport/raweth/read.c
@@ -26,8 +26,9 @@
 
 #if Z_FEATURE_RAWETH_TRANSPORT == 1
 
-z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm) {
+z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm, bool single_read) {
     z_result_t ret = _Z_RES_OK;
+    _ZP_UNUSED(single_read);
 
     _z_slice_t addr;
     _z_transport_message_t t_msg;
@@ -45,8 +46,9 @@ z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm) {
 }
 #else
 
-z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm) {
+z_result_t _zp_raweth_read(_z_transport_multicast_t *ztm, bool single_read) {
     _ZP_UNUSED(ztm);
+    _ZP_UNUSED(single_read);
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
 #endif  // Z_FEATURE_RAWETH_TRANSPORT == 1

--- a/src/transport/unicast/read.c
+++ b/src/transport/unicast/read.c
@@ -32,33 +32,6 @@
 
 #if Z_FEATURE_UNICAST_TRANSPORT == 1
 
-z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu) {
-    z_result_t ret = _Z_RES_OK;
-
-    _z_transport_message_t t_msg;
-    _z_transport_peer_unicast_t *peer = _z_transport_peer_unicast_slist_value(ztu->_peers);
-    assert(peer != NULL);
-    ret = _z_unicast_recv_t_msg(ztu, &t_msg);
-    if (ret == _Z_RES_OK) {
-        ret = _z_unicast_handle_transport_message(ztu, &t_msg, peer);
-        _z_t_msg_clear(&t_msg);
-    }
-    ret = _z_unicast_update_rx_buffer(ztu);
-    if (ret != _Z_RES_OK) {
-        _Z_ERROR("Failed to allocate rx buffer");
-    }
-    return ret;
-}
-#else
-
-z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu) {
-    _ZP_UNUSED(ztu);
-    return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
-}
-#endif  // Z_FEATURE_UNICAST_TRANSPORT == 1
-
-#if Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1
-
 static z_result_t _z_unicast_process_messages(_z_transport_unicast_t *ztu, _z_transport_peer_unicast_t *peer,
                                               size_t to_read) {
     // Wrap the main buffer to_read bytes
@@ -136,7 +109,6 @@ static bool _z_unicast_client_read(_z_transport_unicast_t *ztu, _z_transport_pee
     return true;
 }
 
-#if Z_FEATURE_UNICAST_PEER == 1
 static z_result_t _z_unicast_handle_remaining_data(_z_transport_unicast_t *ztu, _z_transport_peer_unicast_t *peer,
                                                    size_t extra_size, size_t *to_read, bool *message_to_process) {
     *message_to_process = false;
@@ -252,7 +224,130 @@ static int _z_unicast_peer_read(_z_transport_unicast_t *ztu, _z_transport_peer_u
     }
     return _Z_UNICAST_PEER_READ_STATUS_OK;
 }
+
+static z_result_t _zp_unicast_process_peer_event(_z_transport_unicast_t *ztu) {
+    _z_transport_peer_mutex_lock(&ztu->_common);
+    _z_transport_peer_unicast_slist_t *curr_list = ztu->_peers;
+    _z_transport_peer_unicast_slist_t *prev = NULL;
+    _z_transport_peer_unicast_slist_t *prev_drop = NULL;
+    size_t to_read = 0;
+    while (curr_list != NULL) {
+        bool drop_peer = false;
+        _z_transport_peer_unicast_t *curr_peer = _z_transport_peer_unicast_slist_value(curr_list);
+        if (curr_peer->_pending) {
+            curr_peer->_pending = false;
+            // Read data from socket
+            int res = _z_unicast_peer_read(ztu, curr_peer, &to_read);
+            if (res == _Z_UNICAST_PEER_READ_STATUS_OK) {  // Messages to process
+                bool message_to_process = false;
+                do {
+                    message_to_process = false;
+                    // Process one message
+                    if (_z_unicast_process_messages(ztu, curr_peer, to_read) != _Z_RES_OK) {
+                        // Failed to process, drop peer
+                        drop_peer = true;
+                        prev_drop = prev;
+                        break;
+                    } else if (curr_peer->flow_state != _Z_FLOW_STATE_READY) {
+                        // Process remaining data
+                        size_t extra_data = _z_zbuf_len(&ztu->_common._zbuf);
+                        if (extra_data > 0) {
+                            _Z_RETURN_IF_ERR(_z_unicast_handle_remaining_data(ztu, curr_peer, extra_data, &to_read,
+                                                                              &message_to_process));
+                        }
+                    }
+                } while (message_to_process);
+            } else if (res == _Z_UNICAST_PEER_READ_STATUS_SOCKET_CLOSED) {
+                drop_peer = true;
+                prev_drop = prev;
+            } else if (res == _Z_UNICAST_PEER_READ_STATUS_CRITICAL_ERROR) {
+                return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+            }
+        }
+        // Update previous only if current node is not dropped
+        if (!drop_peer) {
+            prev = curr_list;
+        }
+        // Progress list
+        curr_list = _z_transport_peer_unicast_slist_next(curr_list);
+        // Drop peer if needed
+        if (drop_peer) {
+            _Z_DEBUG("Dropping peer");
+            _z_subscription_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
+            _z_queryable_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
+            _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztu->_common._session), &curr_peer->common);
+            ztu->_peers = _z_transport_peer_unicast_slist_drop_element(ztu->_peers, prev_drop);
+        }
+        _z_zbuf_reset(&ztu->_common._zbuf);
+    }
+    _z_transport_peer_mutex_unlock(&ztu->_common);
+    return _Z_RES_OK;
+}
+
+z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu, bool single_read) {
+    // Read & process a single message
+    if (single_read) {
+        _z_transport_message_t t_msg;
+        _z_transport_peer_unicast_t *peer = _z_transport_peer_unicast_slist_value(ztu->_peers);
+        if (peer == NULL) {
+            _Z_ERROR("Invalid router endpoint\n");
+            return _Z_ERR_TRANSPORT_RX_FAILED;
+        }
+        _Z_RETURN_IF_ERR(_z_unicast_recv_t_msg(ztu, &t_msg));
+        _Z_CLEAN_RETURN_IF_ERR(_z_unicast_handle_transport_message(ztu, &t_msg, peer), _z_t_msg_clear(&t_msg));
+        // Update buffer
+        _Z_RETURN_IF_ERR(_z_unicast_update_rx_buffer(ztu));
+    } else {
+        // Lock mutex
+        _z_mutex_lock(&ztu->_common._mutex_rx);
+
+        // Prepare buffer
+        _z_zbuf_reset(&ztu->_common._zbuf);
+        z_whatami_t mode = _Z_RC_IN_VAL(ztu->_common._session)->_mode;
+#if Z_FEATURE_UNICAST_PEER == 1
+        if (mode == Z_WHATAMI_PEER) {
+            // No peer connected
+            if (_z_transport_peer_unicast_slist_is_empty(ztu->_peers)) {
+                _Z_INFO("Currently no peer connected\n");
+                _z_mutex_unlock(&ztu->_common._mutex_rx);
+                return _Z_RES_OK;
+            }
+            // Wait for events on sockets
+            _Z_CLEAN_RETURN_IF_ERR(_z_socket_wait_event(&ztu->_peers, &ztu->_common._mutex_peer),
+                                   _z_mutex_unlock(&ztu->_common._mutex_rx));
+            // Process events for all peers
+            _Z_CLEAN_RETURN_IF_ERR(_zp_unicast_process_peer_event(ztu), _z_mutex_unlock(&ztu->_common._mutex_rx));
+        } else
 #endif
+        {
+            _z_transport_peer_unicast_t *curr_peer = _z_transport_peer_unicast_slist_value(ztu->_peers);
+            if (curr_peer == NULL) {
+                _Z_ERROR("Invalid router endpoint\n");
+                _z_mutex_unlock(&ztu->_common._mutex_rx);
+                return _Z_ERR_TRANSPORT_RX_FAILED;
+            }
+            size_t to_read = 0;
+            // Retrieve data if any
+            if (_z_unicast_client_read(ztu, curr_peer, &to_read)) {
+                // Process data
+                _Z_CLEAN_RETURN_IF_ERR(_z_unicast_process_messages(ztu, curr_peer, to_read),
+                                       _z_mutex_unlock(&ztu->_common._mutex_rx))
+            }
+        }
+        _z_mutex_unlock(&ztu->_common._mutex_rx);
+    }
+    return _Z_RES_OK;
+}
+#else
+
+z_result_t _zp_unicast_read(_z_transport_unicast_t *ztu, bool single_read) {
+    _ZP_UNUSED(ztu);
+    _ZP_UNUSED(single_read);
+    return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+}
+#endif  // Z_FEATURE_UNICAST_TRANSPORT == 1
+
+#if Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1
 
 void *_zp_unicast_read_task(void *ztu_arg) {
     _z_transport_unicast_t *ztu = (_z_transport_unicast_t *)ztu_arg;
@@ -269,9 +364,6 @@ void *_zp_unicast_read_task(void *ztu_arg) {
         assert(curr_peer != NULL);
     }
     while (ztu->_common._read_task_running) {
-        // Read bytes from socket to the main buffer
-        size_t to_read = 0;
-
 #if Z_FEATURE_UNICAST_PEER == 1
         if (mode == Z_WHATAMI_PEER) {
             // Wait for at least one peer
@@ -284,68 +376,14 @@ void *_zp_unicast_read_task(void *ztu_arg) {
                 continue;  // Might need to process errors other than timeout
             }
             // Process events for all peers
-            _z_transport_peer_mutex_lock(&ztu->_common);
-            _z_transport_peer_unicast_slist_t *curr_list = ztu->_peers;
-            _z_transport_peer_unicast_slist_t *prev = NULL;
-            _z_transport_peer_unicast_slist_t *prev_drop = NULL;
-            while (curr_list != NULL) {
-                bool drop_peer = false;
-                curr_peer = _z_transport_peer_unicast_slist_value(curr_list);
-                if (curr_peer->_pending) {
-                    curr_peer->_pending = false;
-                    // Read data from socket
-                    int res = _z_unicast_peer_read(ztu, curr_peer, &to_read);
-                    if (res == _Z_UNICAST_PEER_READ_STATUS_OK) {  // Messages to process
-                        bool message_to_process = false;
-                        do {
-                            message_to_process = false;
-                            // Process one message
-                            if (_z_unicast_process_messages(ztu, curr_peer, to_read) != _Z_RES_OK) {
-                                // Failed to process, drop peer
-                                drop_peer = true;
-                                prev_drop = prev;
-                                break;
-                            } else if (curr_peer->flow_state != _Z_FLOW_STATE_READY) {
-                                // Process remaining data
-                                size_t extra_data = _z_zbuf_len(&ztu->_common._zbuf);
-                                if (extra_data > 0) {
-                                    if (_z_unicast_handle_remaining_data(ztu, curr_peer, extra_data, &to_read,
-                                                                         &message_to_process) != _Z_RES_OK) {
-                                        // Irrecoverable error
-                                        ztu->_common._read_task_running = false;
-                                        continue;
-                                    }
-                                }
-                            }
-                        } while (message_to_process);
-                    } else if (res == _Z_UNICAST_PEER_READ_STATUS_SOCKET_CLOSED) {
-                        drop_peer = true;
-                        prev_drop = prev;
-                    } else if (res == _Z_UNICAST_PEER_READ_STATUS_CRITICAL_ERROR) {
-                        ztu->_common._read_task_running = false;
-                        continue;
-                    }
-                }
-                // Update previous only if current node is not dropped
-                if (!drop_peer) {
-                    prev = curr_list;
-                }
-                // Progress list
-                curr_list = _z_transport_peer_unicast_slist_next(curr_list);
-                // Drop peer if needed
-                if (drop_peer) {
-                    _Z_DEBUG("Dropping peer");
-                    _z_subscription_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
-                    _z_queryable_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
-                    _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztu->_common._session), &curr_peer->common);
-                    ztu->_peers = _z_transport_peer_unicast_slist_drop_element(ztu->_peers, prev_drop);
-                }
-                _z_zbuf_reset(&ztu->_common._zbuf);
+            if (_zp_unicast_process_peer_event(ztu) != _Z_RES_OK) {
+                ztu->_common._read_task_running = false;
+                continue;
             }
-            _z_transport_peer_mutex_unlock(&ztu->_common);
         } else
 #endif
         {
+            size_t to_read = 0;
             // Retrieve data
             if (!_z_unicast_client_read(ztu, curr_peer, &to_read)) {
                 continue;
@@ -380,7 +418,7 @@ z_result_t _zp_unicast_stop_read_task(_z_transport_t *zt) {
     return _Z_RES_OK;
 }
 
-#else
+#else   // Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1
 
 void *_zp_unicast_read_task(void *ztu_arg) {
     _ZP_UNUSED(ztu_arg);
@@ -398,4 +436,4 @@ z_result_t _zp_unicast_stop_read_task(_z_transport_t *zt) {
     _ZP_UNUSED(zt);
     return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
 }
-#endif
+#endif  //  Z_FEATURE_MULTI_THREAD == 1 && Z_FEATURE_UNICAST_TRANSPORT == 1


### PR DESCRIPTION
Default behavior of zp_read is now to read all messages in the buffer instead of a single one, added a "single_read" option to keep original behavior possible.