### PR TITLE
Repeat the ZENOH_COMPILER_GCC flag for espressif32

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -63,7 +63,7 @@ elif FRAMEWORK == 'arduino':
             "-<system/windows/>",
             "-<system/zephyr/>",
         ]
-        CPPDEFINES = ["ZENOH_ARDUINO_ESP32", "ZENOH_C_STANDARD=99"]
+        CPPDEFINES = ["ZENOH_ARDUINO_ESP32", "ZENOH_COMPILER_GCC", "ZENOH_C_STANDARD=99"]
     if PLATFORM == 'ststm32':
         BOARD = env.get("PIOENV")
         if BOARD == 'opencr':


### PR DESCRIPTION
Fixes "Multi-thread refcount in C99 only exists for GCC, use GCC or C11 or deactivate multi-thread" when compiling for an ESP32