### PR TITLE
ci: run ctest with sudo to avoid permission error

### DIFF
--- a/.github/workflows/cpp-check.yaml
+++ b/.github/workflows/cpp-check.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         unstable: [0, 1]
 
     steps:
@@ -79,6 +79,12 @@ jobs:
         cmake --build . --target tests --config Release
 
     - name: run tests
+      shell: bash
       run: |
         cd zenoh-cpp/build
-        ctest -C Release --output-on-failure
+        # On macOS, sudo is required to run tests due to LAN access permissions
+        if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+          sudo ctest -C Release --output-on-failure
+        else
+          ctest -C Release --output-on-failure
+        fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -112,7 +112,11 @@ install: $(BUILD_DIR)/Makefile
 	cmake --install $(BUILD_DIR)
 
 test: make
-	ctest --verbose --test-dir build
+	if [ "$(shell uname -s)" = "Darwin" ]; then \
+		sudo ctest --verbose --test-dir build; \
+	else \
+		ctest --verbose --test-dir build; \
+	fi
 
 crossbuilds: $(CROSSBUILD_TARGETS)
 


### PR DESCRIPTION
On macos-15 LAN access is required but the regular gh runner user doesn't have permission. Workaround by running as root.

See actions/runner-images#10924