### PR TITLE
ci: fix bump-and-tag to not use pager on git log

### DIFF
--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -22,7 +22,7 @@ git commit version.txt -m "chore: Bump version to $version"
 if [[ ${live_run} == true ]]; then
   git tag --force "$version" -m "v$version"
 fi
-git log -10
+git --no-pager log -10
 git show-ref --tags
 git push --force origin
 git push --force origin "$version"


### PR DESCRIPTION
Possible fix for https://github.com/eclipse-zenoh/zenoh-pico/actions/runs/17389751311/job/49383258561