### PR TITLE
ci: fetch-tags during checkout of release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.create-release-branch.outputs.branch }}
+          fetch-tags: true
 
       - name: Bump and tag project
         run: bash ci/scripts/bump-and-tag.bash


### PR DESCRIPTION
Possible fix for https://github.com/eclipse-zenoh/zenoh-pico/actions/runs/17389751311/job/49383258561