### PR TITLE
clang-format: set PointerAlignment to Right

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,4 @@ Language: Cpp
 BasedOnStyle: Google
 IndentWidth: 4
 ColumnLimit: 120
-PointerAlignment: Left
+PointerAlignment: Right


### PR DESCRIPTION
Right * and & alignment is the current coding style, not left.