### PR TITLE
ci: increase timeout for integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test debug
         run: make test
-        timeout-minutes: 20
+        timeout-minutes: 30
         env:
           BUILD_TYPE: Debug # Workaround for Windows as it seems the previous step is being ignored
           BUILD_TESTING: OFF # Workaround for Windows as it seems the previous step is being ignored


### PR DESCRIPTION
After adding Mbed TLS integration test that takes  quite a long time, CI started failing too often due to timeouts.