### PR TITLE
Handle copying of zero capacity svec correctly.

### DIFF
--- a/src/collections/vec.c
+++ b/src/collections/vec.c
@@ -164,6 +164,9 @@ void _z_svec_move(_z_svec_t *dst, _z_svec_t *src) {
 z_result_t _z_svec_copy(_z_svec_t *dst, const _z_svec_t *src, z_element_copy_f copy, size_t element_size,
                         bool use_elem_f) {
     *dst = _z_svec_null();
+    if (src->_capacity == 0) {
+        return _Z_RES_OK;
+    }
     dst->_val = z_malloc(element_size * src->_capacity);
     if (dst->_val == NULL) {
         _Z_ERROR_RETURN(_Z_ERR_SYSTEM_OUT_OF_MEMORY);


### PR DESCRIPTION
Such a copy can occur when a sample contains no attachments. Exact behaviour depends on how `malloc` behaves on a particular platform.