### PR TITLE
Fix queryable and subscriber data races

### DIFF
--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -2359,6 +2359,7 @@ z_entity_global_id_t z_queryable_id(const z_loaned_queryable_t *queryable);
  * Return:
  *   The keyexpr wrapped as a :c:type:`z_loaned_keyexpr_t`. Will return NULL if
  *   corresponding session is closed or dropped.
+ *   The lifetime of key expression pointer is bound to those of queryable and its session.
  */
 const z_loaned_keyexpr_t *z_queryable_keyexpr(const z_loaned_queryable_t *queryable);
 
@@ -2559,7 +2560,9 @@ z_result_t z_declare_background_subscriber(const z_loaned_session_t *zs, const z
  *   subscriber: Pointer to a :c:type:`z_loaned_subscriber_t` to get the keyexpr from.
  *
  * Return:
- *   The keyexpr wrapped as a :c:type:`z_loaned_keyexpr_t`.
+ *   The keyexpr wrapped as a :c:type:`z_loaned_keyexpr_t`. Will return `NULL` if corresponding session
+ *   is closed or dropped.
+ *   The lifetime of key expression pointer is bound to those of subscriber and its session.
  */
 const z_loaned_keyexpr_t *z_subscriber_keyexpr(const z_loaned_subscriber_t *subscriber);
 

--- a/include/zenoh-pico/collections/refcount.h
+++ b/include/zenoh-pico/collections/refcount.h
@@ -243,6 +243,18 @@ static inline _z_void_rc_t _z_void_rc_rc_new(void *val, _z_void_rc_deleter delet
             return name##_rc_null();                                        \
         }                                                                   \
         return p;                                                           \
+    }                                                                       \
+    static inline name##_rc_t name##_rc_new_undefined(void) {               \
+        type##_t *v = (type##_t *)z_malloc(sizeof(type##_t));               \
+        if (v == NULL) {                                                    \
+            return name##_rc_null();                                        \
+        }                                                                   \
+        name##_rc_t p = name##_rc_new(v);                                   \
+        if (p._cnt == NULL) {                                               \
+            z_free(v);                                                      \
+            return name##_rc_null();                                        \
+        }                                                                   \
+        return p;                                                           \
     }
 
 #define _Z_SIMPLE_REFCOUNT_DEFINE(name, type)                                                                 \

--- a/include/zenoh-pico/session/queryable.h
+++ b/include/zenoh-pico/session/queryable.h
@@ -25,20 +25,13 @@ typedef struct _z_session_t _z_session_t;
 typedef struct _z_session_rc_t _z_session_rc_t;
 
 // Queryable infos
-typedef struct {
-    _z_closure_query_callback_t callback;
-    void *arg;
-} _z_queryable_infos_t;
-
-_Z_ELEM_DEFINE(_z_queryable_infos, _z_queryable_infos_t, _z_noop_size, _z_noop_clear, _z_noop_copy, _z_noop_move,
-               _z_noop_eq, _z_noop_cmp, _z_noop_hash)
-_Z_SVEC_DEFINE(_z_queryable_infos, _z_queryable_infos_t)
+_Z_SVEC_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
+_Z_REFCOUNT_DEFINE(_z_session_queryable_rc_svec, _z_session_queryable_rc_svec)
 
 typedef struct {
     _z_keyexpr_t ke_in;
     _z_keyexpr_t ke_out;
-    _z_queryable_infos_svec_t infos;
-    size_t qle_nb;
+    _z_session_queryable_rc_svec_rc_t infos;
 } _z_queryable_cache_data_t;
 
 void _z_queryable_cache_invalidate(_z_session_t *zn);

--- a/include/zenoh-pico/session/subscription.h
+++ b/include/zenoh-pico/session/subscription.h
@@ -27,22 +27,19 @@ extern "C" {
 // Forward declaration to avoid cyclical include
 typedef struct _z_session_t _z_session_t;
 
-// Subscription infos
-typedef struct {
-    _z_closure_sample_callback_t callback;
-    void *arg;
-} _z_subscription_infos_t;
-
-_Z_ELEM_DEFINE(_z_subscription_infos, _z_subscription_infos_t, _z_noop_size, _z_noop_clear, _z_noop_copy, _z_noop_move,
-               _z_noop_eq, _z_noop_cmp, _z_noop_hash)
-_Z_SVEC_DEFINE(_z_subscription_infos, _z_subscription_infos_t)
+_Z_SVEC_DEFINE(_z_subscription_rc, _z_subscription_rc_t)
+_Z_REFCOUNT_DEFINE(_z_subscription_rc_svec, _z_subscription_rc_svec)
 
 typedef struct {
     _z_keyexpr_t ke_in;
     _z_keyexpr_t ke_out;
-    _z_subscription_infos_svec_t infos;
-    size_t sub_nb;
+    _z_subscription_rc_svec_rc_t infos;
 } _z_subscription_cache_data_t;
+
+static inline _z_subscription_cache_data_t _z_subscription_cache_data_null(void) {
+    _z_subscription_cache_data_t ret = {0};
+    return ret;
+}
 
 void _z_subscription_cache_invalidate(_z_session_t *zn);
 int _z_subscription_cache_data_compare(const void *first, const void *second);

--- a/include/zenoh-pico/utils/result.h
+++ b/include/zenoh-pico/utils/result.h
@@ -93,6 +93,13 @@ typedef enum {
     _Z_ERR_GENERIC = -128
 } _z_res_t;
 
+#define _Z_SET_IF_OK(expr, value) \
+    {                             \
+        if (expr == _Z_RES_OK) {  \
+            expr = value;         \
+        }                         \
+    }
+
 #define _Z_RETURN_IF_ERR(expr)    \
     {                             \
         z_result_t __res = expr;  \
@@ -108,6 +115,21 @@ typedef enum {
             clean_expr;                               \
             return __res;                             \
         }                                             \
+    }
+
+#define _Z_RETURN_ERR_OOM_IF_TRUE(expr)         \
+    {                                           \
+        if (expr) {                             \
+            return _Z_ERR_SYSTEM_OUT_OF_MEMORY; \
+        }                                       \
+    }
+
+#define _Z_CLEAN_RETURN_ERR_OOM_IF_TRUE(expr, clean_expr) \
+    {                                                     \
+        if (expr) {                                       \
+            clean_expr;                                   \
+            return _Z_ERR_SYSTEM_OUT_OF_MEMORY;           \
+        }                                                 \
     }
 
 #define _Z_IS_OK(expr) (expr == _Z_RES_OK)

--- a/tests/z_refcount_test.c
+++ b/tests/z_refcount_test.c
@@ -86,6 +86,17 @@ void test_rc_new_from_val(void) {
     assert(val_foo == FOO_CLEARED_VALUE);
 }
 
+void test_rc_new_undefined(void) {
+    int val_foo = 42;
+    _dummy_rc_t drc = _dummy_rc_new_undefined();
+    assert(!_Z_RC_IS_NULL(&drc));
+    assert(_z_rc_strong_count(drc._cnt) == 1);
+    assert(_z_rc_weak_count(drc._cnt) == 1);
+    _Z_RC_IN_VAL(&drc)->foo = &val_foo;
+    assert(_dummy_rc_drop(&drc));
+    assert(val_foo == FOO_CLEARED_VALUE);
+}
+
 void test_rc_clone(void) {
     int val_foo = 42;
     _dummy_t val = {.foo = &val_foo};
@@ -409,6 +420,7 @@ int main(void) {
     test_rc_drop();
     test_rc_new();
     test_rc_new_from_val();
+    test_rc_new_undefined();
     test_rc_clone();
     test_rc_eq();
     test_rc_clone_as_ptr();


### PR DESCRIPTION
Fix data races when processing callbacks of subscriber or queryable
Fix data races in z_subscriber_keyexpr and z_queryable_keyexpr