### PR TITLE
Make Z_TRANSPORT_LEASE_EXPIRE_FACTOR CMake configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ set(BATCH_UNICAST_SIZE 2048 CACHE STRING "Use this to override the maximum unica
 set(BATCH_MULTICAST_SIZE 2048 CACHE STRING "Use this to override the maximum multicast batch size")
 set(Z_CONFIG_SOCKET_TIMEOUT 100 CACHE STRING "Default socket timeout in milliseconds")
 set(Z_TRANSPORT_LEASE 10000 CACHE STRING "Link lease duration in milliseconds to announce to other zenoh nodes")
+set(Z_TRANSPORT_LEASE_EXPIRE_FACTOR 3 CACHE STRING "Default session lease expire factor.")
 set(ZP_PERIODIC_SCHEDULER_MAX_TASKS 64 CACHE STRING "Maximum number of tasks in the periodic scheduler")
 
 set(Z_FEATURE_UNSTABLE_API 0 CACHE STRING "Toggle unstable Zenoh-C API")

--- a/include/zenoh-pico/config.h
+++ b/include/zenoh-pico/config.h
@@ -25,6 +25,7 @@
 #define Z_BATCH_MULTICAST_SIZE 2048
 #define Z_CONFIG_SOCKET_TIMEOUT 100
 #define Z_TRANSPORT_LEASE 10000
+#define Z_TRANSPORT_LEASE_EXPIRE_FACTOR 3
 #define ZP_PERIODIC_SCHEDULER_MAX_TASKS 64
 
 /* #undef Z_FEATURE_UNSTABLE_API */
@@ -181,11 +182,6 @@
  * Do not change this value.
  */
 #define Z_PROTO_VERSION 0x09
-
-/**
- * Default session lease expire factor.
- */
-#define Z_TRANSPORT_LEASE_EXPIRE_FACTOR 3
 
 /**
  * Default multicast session join interval in milliseconds.

--- a/include/zenoh-pico/config.h.in
+++ b/include/zenoh-pico/config.h.in
@@ -25,6 +25,7 @@
 #define Z_BATCH_MULTICAST_SIZE @BATCH_MULTICAST_SIZE@
 #define Z_CONFIG_SOCKET_TIMEOUT @Z_CONFIG_SOCKET_TIMEOUT@
 #define Z_TRANSPORT_LEASE @Z_TRANSPORT_LEASE@
+#define Z_TRANSPORT_LEASE_EXPIRE_FACTOR @Z_TRANSPORT_LEASE_EXPIRE_FACTOR@
 #define ZP_PERIODIC_SCHEDULER_MAX_TASKS @ZP_PERIODIC_SCHEDULER_MAX_TASKS@
 
 #cmakedefine Z_FEATURE_UNSTABLE_API
@@ -181,11 +182,6 @@
  * Do not change this value.
  */
 #define Z_PROTO_VERSION 0x09
-
-/**
- * Default session lease expire factor.
- */
-#define Z_TRANSPORT_LEASE_EXPIRE_FACTOR 3
 
 /**
  * Default multicast session join interval in milliseconds.


### PR DESCRIPTION
This PR add CMake configuration as mention in #1013 which allows you override the router expire lease config to match the corresponding zenohd configuration. 
