### PR TITLE
Make it possible to include zenoh-pico.h in C++14 files

### DIFF
--- a/include/zenoh-pico/collections/seqnumber.h
+++ b/include/zenoh-pico/collections/seqnumber.h
@@ -44,7 +44,7 @@ typedef struct {
 #endif
 } _z_seqnumber_t;
 
-static inline _z_seqnumber_t _z_seqnumber_null(void) { return (_z_seqnumber_t){0}; }
+_z_seqnumber_t _z_seqnumber_null(void);
 z_result_t _z_seqnumber_init(_z_seqnumber_t *seq);
 z_result_t _z_seqnumber_fetch(_z_seqnumber_t *seq, uint32_t *value);
 z_result_t _z_seqnumber_fetch_and_increment(_z_seqnumber_t *seq, uint32_t *value);

--- a/src/collections/seqnumber.c
+++ b/src/collections/seqnumber.c
@@ -16,6 +16,8 @@
 
 #include "zenoh-pico/utils/logging.h"
 
+_z_seqnumber_t _z_seqnumber_null(void) { return (_z_seqnumber_t){0}; }
+
 z_result_t _z_seqnumber_init(_z_seqnumber_t *seq) {
     if (seq == NULL) {
         _Z_ERROR_RETURN(_Z_ERR_INVALID);


### PR DESCRIPTION
Prior to C++17, `return (_z_seqnumber_t){0};` can cause compilers to try
to invoke std::atomic's deleted copy-ctor, and since `_z_seqnumber_null`
is called from inside `advanced_publisher.c` where `__cplusplus` never
will be true, this is always created as an _Atomic uint32_t or a plain
uint32_t.

Moving `_z_seqnumber_null` out of line preserves the same behaviour as
today, but also hides the implementation in a place where it'll only
ever be seen as C code, allowing C++14 compilers to include zenoh_pico.h
again.

```
In file included from zenoh-pico/include/zenoh-pico.h:26:
In file included from /zenoh-pico/include/zenoh-pico/api/advanced_publisher.h:23:
zenoh-pico/include/zenoh-pico/collections/seqnumber.h:47:80: error: copying member subobject of type 'std::atomic<uint32_t>' (aka 'atomic<unsigned int>') invokes deleted constructor
   47 | static inline _z_seqnumber_t _z_seqnumber_null(void) { return (_z_seqnumber_t){0}; }
      |                                                                                ^
/usr/include/c++/13/atomic:852:7: note: 'atomic' has been explicitly marked deleted here
  852 |       atomic(const atomic&) = delete;
      |       ^
```

To reproduce, include zenoh-pico.h in any .cpp-file and compile it w/ `-std=c++14`.