### PR TITLE
seqnumber: Fix C++ interopability

### DIFF
--- a/include/zenoh-pico/collections/seqnumber.h
+++ b/include/zenoh-pico/collections/seqnumber.h
@@ -21,30 +21,22 @@
 #include "zenoh-pico/system/platform.h"
 #include "zenoh-pico/utils/result.h"
 
-#if Z_FEATURE_MULTI_THREAD == 1 && ZENOH_C_STANDARD != 99
-#ifndef __cplusplus
-#include <stdatomic.h>
-#define _Z_SEQNUMBER_TYPE _Atomic uint32_t
-#else
-#include <atomic>
-#define _Z_SEQNUMBER_TYPE std::atomic<uint32_t>
-#endif
-#else
-#define _Z_SEQNUMBER_TYPE uint32_t
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-    _Z_SEQNUMBER_TYPE _seq;
+#if (Z_FEATURE_MULTI_THREAD == 1) && (ZENOH_C_STANDARD != 99) && !defined(__cplusplus)
+    _Atomic uint32_t _seq;
+#else
+    uint32_t _seq;
+#endif
 #if Z_FEATURE_MULTI_THREAD == 1 && ZENOH_C_STANDARD == 99 && !defined(ZENOH_COMPILER_GCC)
     _z_mutex_t _mutex;
 #endif
 } _z_seqnumber_t;
 
-static inline _z_seqnumber_t _z_seqnumber_null(void) { return (_z_seqnumber_t){0}; }
+z_result_t _z_seqnumber_null(_z_seqnumber_t *seq);
 z_result_t _z_seqnumber_init(_z_seqnumber_t *seq);
 z_result_t _z_seqnumber_fetch(_z_seqnumber_t *seq, uint32_t *value);
 z_result_t _z_seqnumber_fetch_and_increment(_z_seqnumber_t *seq, uint32_t *value);

--- a/src/api/advanced_publisher.c
+++ b/src/api/advanced_publisher.c
@@ -31,7 +31,7 @@ static _ze_advanced_publisher_state_t _ze_advanced_publisher_state_null(void) {
     state._zn = _z_session_weak_null();
     z_internal_publisher_null(&state._publisher);
     state._state_publisher_task_id = _ZP_PERIODIC_SCHEDULER_INVALID_ID;
-    state._seqnumber = _z_seqnumber_null();
+    _z_seqnumber_null(&state._seqnumber);
     return state;
 }
 
@@ -57,7 +57,7 @@ void _ze_advanced_publisher_state_clear(_ze_advanced_publisher_state_t *state) {
     }
     _z_session_weak_drop(&state->_zn);
     state->_heartbeat_mode = ZE_ADVANCED_PUBLISHER_HEARTBEAT_MODE_NONE;
-    state->_seqnumber = _z_seqnumber_null();
+    _z_seqnumber_null(&state->_seqnumber);
     state->_last_published_sn = 0;
 }
 


### PR DESCRIPTION
`_Atomic` and `std::atomic` are not guaranteed to be compatible. Additionally, `std::atomic` introduces dependencies on the C++ standard library, which is often too large for resource-constrained embedded systems. 

This change moves all atomic operations into seqnumber.c and uses the C11 atomic_xx operations, which are safe for both C and C++ callers. It also fixes a bug where `_z_seqnumber_null` was not implemented as an atomic operation.

Supersedes #1087 and #1089