### PR TITLE
seqnumber: Fix C++ interopability and mutex cleanup

### DIFF
--- a/include/zenoh-pico/collections/seqnumber.h
+++ b/include/zenoh-pico/collections/seqnumber.h
@@ -36,8 +36,8 @@ typedef struct {
 #endif
 } _z_seqnumber_t;
 
-z_result_t _z_seqnumber_null(_z_seqnumber_t *seq);
 z_result_t _z_seqnumber_init(_z_seqnumber_t *seq);
+z_result_t _z_seqnumber_drop(_z_seqnumber_t *seq);
 z_result_t _z_seqnumber_fetch(_z_seqnumber_t *seq, uint32_t *value);
 z_result_t _z_seqnumber_fetch_and_increment(_z_seqnumber_t *seq, uint32_t *value);
 

--- a/src/api/advanced_publisher.c
+++ b/src/api/advanced_publisher.c
@@ -26,13 +26,16 @@
 // Space for 10 digits + NULL
 #define ZE_ADVANCED_PUBLISHER_UINT32_STR_BUF_LEN 11
 
-static _ze_advanced_publisher_state_t _ze_advanced_publisher_state_null(void) {
-    _ze_advanced_publisher_state_t state = {0};
-    state._zn = _z_session_weak_null();
-    z_internal_publisher_null(&state._publisher);
-    state._state_publisher_task_id = _ZP_PERIODIC_SCHEDULER_INVALID_ID;
-    _z_seqnumber_null(&state._seqnumber);
-    return state;
+static z_result_t _ze_advanced_publisher_state_init(_ze_advanced_publisher_state_t *state) {
+    if (state == NULL) {
+        _Z_ERROR_RETURN(_Z_ERR_INVALID);
+    }
+    state->_heartbeat_mode = ZE_ADVANCED_PUBLISHER_HEARTBEAT_MODE_NONE;
+    state->_last_published_sn = 0;
+    z_internal_publisher_null(&state->_publisher);
+    state->_state_publisher_task_id = _ZP_PERIODIC_SCHEDULER_INVALID_ID;
+    state->_zn = _z_session_weak_null();
+    return _z_seqnumber_init(&state->_seqnumber);
 }
 
 static bool _ze_advanced_publisher_state_check(const _ze_advanced_publisher_state_t *state) {
@@ -57,7 +60,7 @@ void _ze_advanced_publisher_state_clear(_ze_advanced_publisher_state_t *state) {
     }
     _z_session_weak_drop(&state->_zn);
     state->_heartbeat_mode = ZE_ADVANCED_PUBLISHER_HEARTBEAT_MODE_NONE;
-    _z_seqnumber_null(&state->_seqnumber);
+    _z_seqnumber_drop(&state->_seqnumber);
     state->_last_published_sn = 0;
 }
 
@@ -255,18 +258,17 @@ z_result_t ze_declare_advanced_publisher(const z_loaned_session_t *zs, ze_owned_
             z_publisher_drop(z_publisher_move(&pub->_val._publisher));
             _Z_ERROR_RETURN(_Z_ERR_SYSTEM_OUT_OF_MEMORY);
         }
-        *state = _ze_advanced_publisher_state_null();
+        _Z_CLEAN_RETURN_IF_ERR(_ze_advanced_publisher_state_init(state),
+                               z_publisher_drop(z_publisher_move(&pub->_val._publisher));
+                               z_free(state));
 
         pub->_val._state = _ze_advanced_publisher_state_rc_new(state);
         if (_Z_RC_IS_NULL(&pub->_val._state)) {
+            _ze_advanced_publisher_state_clear(state);
             z_free(state);
             z_publisher_drop(z_publisher_move(&pub->_val._publisher));
             _Z_ERROR_RETURN(_Z_ERR_SYSTEM_OUT_OF_MEMORY);
         }
-
-        _Z_CLEAN_RETURN_IF_ERR(_z_seqnumber_init(&state->_seqnumber),
-                               _ze_advanced_publisher_state_rc_drop(&pub->_val._state);
-                               z_publisher_drop(z_publisher_move(&pub->_val._publisher)));
     } else if (opt.cache.is_enabled) {
         pub->_val._sequencing = _ZE_ADVANCED_PUBLISHER_SEQUENCING_TIMESTAMP;
     } else {

--- a/src/collections/seqnumber.c
+++ b/src/collections/seqnumber.c
@@ -20,34 +20,6 @@
 #include <stdatomic.h>
 #endif
 
-z_result_t _z_seqnumber_null(_z_seqnumber_t *seq) {
-    if (seq == NULL) {
-        _Z_ERROR_RETURN(_Z_ERR_INVALID);
-    }
-
-#if Z_FEATURE_MULTI_THREAD == 1 && ZENOH_C_STANDARD == 99 && !defined(ZENOH_COMPILER_GCC)
-    z_result_t res = _z_mutex_lock(&seq->_mutex);
-    if (res != _Z_RES_OK) {
-        return res;
-    }
-#endif
-
-#if (Z_FEATURE_MULTI_THREAD == 1) && (ZENOH_C_STANDARD != 99)
-    atomic_store(&seq->_seq, 0);
-#else
-    seq->_seq = 0;
-#endif
-
-#if Z_FEATURE_MULTI_THREAD == 1 && ZENOH_C_STANDARD == 99 && !defined(ZENOH_COMPILER_GCC)
-    res = _z_mutex_unlock(&seq->_mutex);
-    if (res != _Z_RES_OK) {
-        return res;
-    }
-#endif
-
-    return _Z_RES_OK;
-}
-
 z_result_t _z_seqnumber_init(_z_seqnumber_t *seq) {
     if (seq == NULL) {
         _Z_ERROR_RETURN(_Z_ERR_INVALID);
@@ -67,6 +39,18 @@ z_result_t _z_seqnumber_init(_z_seqnumber_t *seq) {
 #endif
 
     return _Z_RES_OK;
+}
+
+z_result_t _z_seqnumber_drop(_z_seqnumber_t *seq) {
+    if (seq == NULL) {
+        _Z_ERROR_RETURN(_Z_ERR_INVALID);
+    }
+
+#if Z_FEATURE_MULTI_THREAD == 1 && ZENOH_C_STANDARD == 99 && !defined(ZENOH_COMPILER_GCC)
+    return _z_mutex_drop(&seq->_mutex);
+#else
+    return _Z_RES_OK;
+#endif
 }
 
 z_result_t _z_seqnumber_fetch(_z_seqnumber_t *seq, uint32_t *value) {


### PR DESCRIPTION
_Atomic and std::atomic are not guaranteed to be compatible. Additionally, std::atomic introduces dependencies on the C++ standard library, which is often too large for resource-constrained embedded systems.

This change moves all atomic operations into seqnumber.c and uses the C11 atomic_xx operations, which are safe for both C and C++ callers. It also removes `_z_seqnumber_null` in favour of `_z_seqnumber_init` and adds `_z_seqnumber_drop` to ensure the mutex is correctly cleaned up in the case of C99.

Supersedes https://github.com/eclipse-zenoh/zenoh-pico/pull/1087, https://github.com/eclipse-zenoh/zenoh-pico/pull/1089 and https://github.com/eclipse-zenoh/zenoh-pico/pull/1091.