### PR TITLE
docs: Fix debug log build flag format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ A publisher will start publishing over UDP multicast and the **zenoh** router wi
 
 ### Activate debug logs
 
-By default debug logs are deactivated but if you're encountering issues they can help you finding the cause. To activate them you need to pass the build flag value: `-DZENOH_LOG_DEBUG`
+By default debug logs are deactivated but if you're encountering issues they can help you finding the cause. To activate them you need to pass the build flag value: `-DZENOH_LOG=DEBUG`
 
 ### Error when opening a session on a microcontroller
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1741,7 +1741,7 @@ CMake build provides a variable ``ZENOH_LOG`` which accepts the following values
 
     ZENOH_LOG=debug make  # build zenoh-pico with debug and higher level messages enabled
 
-When building zenoh-pico from source, logging can be enabled by defining corresponding macro, like ``-DZENOH_LOG_DEBUG``.
+When building zenoh-pico from source, logging can be enabled by defining corresponding macro, like ``-DZENOH_LOG=DEBUG``.
 
 Override Logs printing
 ----------------------


### PR DESCRIPTION
Correct build flag from -DZENOH_LOG_DEBUG to -DZENOH_LOG=DEBUG
