### PR TITLE
Split pr-label-checklists to different files

### DIFF
--- a/.github/workflows/pr-label-checklists-generate.yml
+++ b/.github/workflows/pr-label-checklists-generate.yml
@@ -2,21 +2,21 @@ name: PR Label Checklists
 
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled, edited, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 # Prevent duplicate runs when swapping labels (unlabeled + labeled events fire together)
 concurrency:
-  group: pr-checklists-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: pr-checklists-generate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   checklist:
-    name: PR Checklist
+    name: Generate
     permissions:
       pull-requests: write
       statuses: write
       contents: read
-    uses: eclipse-zenoh/ci/.github/workflows/pr-label-checklists.yml@main
+    uses: eclipse-zenoh/ci/.github/workflows/pr-label-checklists-generate.yml@main
     with:
       checklists-repo: eclipse-zenoh/ci
     secrets:

--- a/.github/workflows/pr-label-checklists-verify.yml
+++ b/.github/workflows/pr-label-checklists-verify.yml
@@ -1,0 +1,15 @@
+name: PR Label Checklists
+
+on:
+  pull_request_target:
+    types: [edited]
+
+jobs:
+  verify:
+    name: Verify
+    permissions:
+      statuses: write
+      contents: read
+    uses: eclipse-zenoh/ci/.github/workflows/pr-label-checklists-verify.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split pr-label-checklists workflows into different files for invoke them for different events (generation on label changing, checking only on editing) and avoids overhead and notifications about canceled runs when checking checkboxes.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->