### PR TITLE
Fix build failure when disable flag Z_FEATURE_BATCHING

### DIFF
--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -209,12 +209,8 @@ z_result_t _z_transport_close(_z_transport_t *zt, uint8_t reason);
 void _z_transport_clear(_z_transport_t *zt);
 void _z_transport_free(_z_transport_t **zt);
 
-#if Z_FEATURE_BATCHING == 1
-bool _z_transport_start_batching(_z_transport_t *zt);
-void _z_transport_stop_batching(_z_transport_t *zt);
-
 static inline bool _z_transport_batch_hold_tx_mutex(void) {
-#if Z_FEATURE_BATCH_TX_MUTEX == 1
+#if Z_FEATURE_BATCHING == 1 && Z_FEATURE_BATCH_TX_MUTEX == 1
     return true;
 #else
     return false;
@@ -222,12 +218,16 @@ static inline bool _z_transport_batch_hold_tx_mutex(void) {
 }
 
 static inline bool _z_transport_batch_hold_peer_mutex(void) {
-#if Z_FEATURE_BATCH_PEER_MUTEX == 1
+#if Z_FEATURE_BATCHING == 1 && Z_FEATURE_BATCH_PEER_MUTEX == 1
     return true;
 #else
     return false;
 #endif
 }
+
+#if Z_FEATURE_BATCHING == 1
+bool _z_transport_start_batching(_z_transport_t *zt);
+void _z_transport_stop_batching(_z_transport_t *zt);
 #endif  // Z_FEATURE_BATCHING == 1
 
 #if Z_FEATURE_MULTI_THREAD == 1


### PR DESCRIPTION
Move batch mutex helper functions outside conditional compilation

## Description

This PR fixes build failures when `Z_FEATURE_BATCHING` is disabled by moving batch mutex helper functions outside conditional compilation blocks, making them always available regardless of the batching feature setting.

### What does this PR do?

Moves `_z_transport_batch_hold_tx_mutex()` and `_z_transport_batch_hold_peer_mutex()` function declarations from inside `#if Z_FEATURE_BATCHING == 1` blocks to always be available in `transport.h`.

When `Z_FEATURE_BATCHING=0`, these functions now return `false`, ensuring mutex lock/unlock operations are always performed in transmission paths.

When `Z_FEATURE_BATCHING=1`, the return value depends on `Z_FEATURE_BATCH_TX_MUTEX` and `Z_FEATURE_BATCH_PEER_MUTEX` configuration, allowing the batching mode to hold mutexes across multiple message operations for optimization.

### Why is this change needed?

Previously, these helper functions were only declared when `Z_FEATURE_BATCHING=1`, but the transmission code in `tx.c` always called them to determine mutex management behavior. This caused build failures when batching was disabled:

- Undefined reference errors for `_z_transport_batch_hold_tx_mutex()`
- Undefined reference errors for `_z_transport_batch_hold_peer_mutex()`

By making these functions always available (returning `false` when batching is disabled), we maintain a clean, unified code path in `tx.c` without conditional compilation, while ensuring correct mutex behavior in all configurations.

### Related Issues

Fixes #1135

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->