### PR TITLE
Fix _z_get_resource_by_key_inner

### DIFF
--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -165,7 +165,7 @@ uint16_t _z_register_resource_inner(_z_session_t *zn, const _z_wireexpr_t *expr,
     }
 
     if (id == Z_RESOURCE_ID_NONE) {
-        _z_resource_t *res = _z_get_resource_by_key_inner(resources, &new_key);
+        _z_resource_t *res = _z_get_resource_by_key_inner(*resources, &new_key);
         if (res != NULL) {  // declaration of already declared resource
             res->_refcount++;
             _z_string_clear(&new_key);


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Fix _z_get_resource_by_key_inner call.

### What does this PR do?
Fixes _z_get_resource_by_key_inner call.

### Why is this change needed?
It fixes a bug.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->