### PR TITLE
Close tls link only after cleaning all peers

### DIFF
--- a/include/zenoh-pico/transport/common/transport.h
+++ b/include/zenoh-pico/transport/common/transport.h
@@ -21,7 +21,11 @@
 extern "C" {
 #endif
 
-void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks);
+void _z_transport_common_stop_tasks(_z_transport_common_t *ztc, bool detach_tasks);
+
+// Important: This function does not stop the tasks, so when destroying transport, make sure to call
+// _z_transport_common_stop_tasks before calling this function
+void _z_transport_common_clear(_z_transport_common_t *ztc);
 
 #ifdef __cplusplus
 }

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -20,7 +20,7 @@
 #include "zenoh-pico/transport/unicast/accept.h"
 #include "zenoh-pico/utils/result.h"
 
-void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
+void _z_transport_common_stop_tasks(_z_transport_common_t *ztc, bool detach_tasks) {
 #if Z_FEATURE_MULTI_THREAD == 1
     // Clean up tasks
     if (ztc->_read_task != NULL) {
@@ -44,15 +44,19 @@ void _z_common_transport_clear(_z_transport_common_t *ztc, bool detach_tasks) {
         ztc->_lease_task = NULL;
     }
     _zp_unicast_stop_accept_task(ztc);
+#else
+    _ZP_UNUSED(ztc);
+    _ZP_UNUSED(detach_tasks);
+#endif  // Z_FEATURE_MULTI_THREAD == 1
+}
 
+void _z_transport_common_clear(_z_transport_common_t *ztc) {
+#if Z_FEATURE_MULTI_THREAD == 1
     // Clean up the mutexes
     _z_mutex_drop(&ztc->_mutex_tx);
     _z_mutex_drop(&ztc->_mutex_rx);
     _z_mutex_rec_drop(&ztc->_mutex_peer);
-#else
-    _ZP_UNUSED(detach_tasks);
-#endif  // Z_FEATURE_MULTI_THREAD == 1
-
+#endif
     // Clean up the buffers
     _z_wbuf_clear(&ztc->_wbuf);
     _z_zbuf_clear(&ztc->_zbuf);

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -188,8 +188,10 @@ z_result_t _z_multicast_transport_close(_z_transport_multicast_t *ztm, uint8_t r
 }
 
 void _z_multicast_transport_clear(_z_transport_multicast_t *ztm, bool detach_tasks) {
-    _z_common_transport_clear(&ztm->_common, detach_tasks);
+    _z_transport_common_stop_tasks(&ztm->_common, detach_tasks);
     _z_transport_peer_multicast_slist_free(&ztm->_peers);
+    _z_transport_common_clear(
+        &ztm->_common);  // free common in the very end, as peers might access the link data in common while being freed
 }
 
 #else

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -328,8 +328,10 @@ z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reaso
 }
 
 void _z_unicast_transport_clear(_z_transport_unicast_t *ztu, bool detach_tasks) {
-    _z_common_transport_clear(&ztu->_common, detach_tasks);
+    _z_transport_common_stop_tasks(&ztu->_common, detach_tasks);
     _z_transport_peer_unicast_slist_free(&ztu->_peers);
+    _z_transport_common_clear(
+        &ztu->_common);  // free common in the very end, as peers might access the link data in common while being freed
 }
 
 #else


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Split _z_common_tranport_clear into _z_transport_common_stop_tasks and _z_transport_common_clear to allow separation of stopping accept/lease/listen tasks from clearing common resources - this is needed in particular to be able to clean transport peers list before cleaning the link, since the data in latter (particularly in case of tis connection) can be referenced by the peers.

### What does this PR do?
Split _z_common_tranport_clear into _z_transport_common_stop_tasks and _z_transport_common_clear to allow separation of stopping accept/lease/listen tasks from clearing common resources.

### Why is this change needed?
When connecting a new peer via tls link, we call mbedtls_ssl_setup which takes a pointer to data inside tis _z_link_t. According to docs https://sourcevu.sysprogs.com/espressif/lib/mbedtls/symbols/mbedtls_ssl_setup this pointer is being kept until the peer is cleared - which leads to access after free in case if tls link is released before  its peers.


### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->