### PR TITLE
Fix tx.c error due to incorrect Z_FEATURE_BATCHING == 1 macro

### DIFF
--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -210,9 +210,10 @@ void _z_transport_free(_z_transport_t **zt);
 #if Z_FEATURE_BATCHING == 1
 bool _z_transport_start_batching(_z_transport_t *zt);
 void _z_transport_stop_batching(_z_transport_t *zt);
+#endif  // Z_FEATURE_BATCHING == 1
 
 static inline bool _z_transport_batch_hold_tx_mutex(void) {
-#if Z_FEATURE_BATCH_TX_MUTEX == 1
+#if Z_FEATURE_BATCHING == 1 && Z_FEATURE_BATCH_TX_MUTEX == 1
     return true;
 #else
     return false;
@@ -220,13 +221,12 @@ static inline bool _z_transport_batch_hold_tx_mutex(void) {
 }
 
 static inline bool _z_transport_batch_hold_peer_mutex(void) {
-#if Z_FEATURE_BATCH_PEER_MUTEX == 1
+#if Z_FEATURE_BATCHING == 1 && Z_FEATURE_BATCH_PEER_MUTEX == 1
     return true;
 #else
     return false;
 #endif
 }
-#endif  // Z_FEATURE_BATCHING == 1
 
 #if Z_FEATURE_MULTI_THREAD == 1
 static inline z_result_t _z_transport_tx_mutex_lock(_z_transport_common_t *ztc, bool block) {


### PR DESCRIPTION
## Description

The two inline functions `_z_transport_batch_hold_tx_mutex()` and `_z_transport_batch_hold_peer_mutex()` are called from tx.c unconditionally. They're outside of any `#if Z_FEATURE_BATCHING == 1` guard. When batching is disabled (`Z_FEATURE_BATCHING == 0`), these functions don't exist, and tx.c fails to compile.

### What does this PR do?

The patch corrects the `#if Z_FEATURE_BATCHING == 1` check macro and exposes two inline functions unconditionally.

### Why is this change needed?

Without this fix, zenoh-pico fails to compile.

### Related Issues

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->