### PR TITLE
fix(transport): return error when payload exceeds batch size with fragmentation disabled

### DIFF
--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -122,8 +122,8 @@ static z_result_t _z_transport_tx_send_fragment(_z_transport_common_t *ztc, cons
     _ZP_UNUSED(reliability);
     _ZP_UNUSED(first_sn);
     _ZP_UNUSED(peers);
-    _Z_INFO("Sending the message required fragmentation feature that is deactivated.");
-    return _Z_RES_OK;
+    _Z_ERROR("Message payload exceeds transport batch size and fragmentation is disabled (Z_FEATURE_FRAGMENTATION=0).");
+    return _Z_ERR_TRANSPORT_NO_SPACE;
 }
 #endif
 


### PR DESCRIPTION
Fixes #1200

## Problem

When `Z_FEATURE_FRAGMENTATION=0`, `_z_transport_tx_send_fragment()` returned `_Z_RES_OK` even though the payload was never sent. The stub was a silent no-op, so `z_put()` and `z_publisher_put()` reported success while the message was silently dropped.

This is a silent-failure: the caller has no way to distinguish a dropped put from a successful one, making the fragmentation-disabled build profile misleading for resource-constrained embedded targets.

## Fix

Two changes in `src/transport/common/tx.c` (2 lines):

1. Return `_Z_ERR_TRANSPORT_NO_SPACE` from the disabled-fragmentation stub instead of `_Z_RES_OK`.
2. Upgrade the log level from `_Z_INFO` to `_Z_ERROR`.

No API surface changes. No behavior change when `Z_FEATURE_FRAGMENTATION=1`.

*AI-assisted — authored with Claude, reviewed by Komada.*

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->