### PR TITLE
Fix count of reply_final in p2p mode

### DIFF
--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -194,7 +194,7 @@ struct _z_pending_query_t {
     z_clock_t _start_time;
     uint64_t _timeout;
     void *_arg;
-    uint8_t _remaining_finals;
+    uint32_t _remaining_finals;
     _z_pending_reply_slist_t *_pending_replies;
     z_query_target_t _target;
     z_consolidation_mode_t _consolidation;

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -250,6 +250,7 @@ z_result_t _z_transport_peer_unicast_add(_z_transport_unicast_t *ztu, _z_transpo
                                          _z_sys_net_socket_t socket, bool owns_socket,
                                          _z_transport_peer_unicast_t **output_peer);
 _z_transport_common_t *_z_transport_get_common(_z_transport_t *zt);
+size_t _z_transport_get_peers_count(_z_transport_t *zt);
 z_result_t _z_transport_close(_z_transport_t *zt, uint8_t reason);
 void _z_transport_clear(_z_transport_t *zt);
 void _z_transport_free(_z_transport_t **zt);

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -548,6 +548,19 @@ z_result_t _z_query(const _z_session_rc_t *session, _z_optional_id_t querier_id,
         _Z_ERROR("Non-zero length string should not be NULL");
         return Z_EINVAL;
     }
+    bool allow_local = _z_locality_allows_local(allowed_destination);
+    bool allow_remote = _z_locality_allows_remote(allowed_destination);
+    size_t remote_targets = allow_remote ? _z_transport_get_peers_count(&zn->_tp) : 0;
+#if Z_FEATURE_LOCAL_QUERYABLE == 1
+    size_t remaining_finals = (allow_local ? 1 : 0) + remote_targets;
+#else
+    _ZP_UNUSED(allow_local);
+    size_t remaining_finals = remote_targets;
+#endif
+    if (remaining_finals == 0) {
+        _z_drop_handler_execute(dropper, arg);
+        return _z_session_is_closed(zn) ? _Z_ERR_SESSION_CLOSED : _Z_RES_OK;
+    }
     _z_keyexpr_t ke_query;
     _Z_CLEAN_RETURN_IF_ERR(_z_keyexpr_copy(&ke_query, &keyexpr->_inner), _z_drop_handler_execute(dropper, arg));
 
@@ -558,10 +571,6 @@ z_result_t _z_query(const _z_session_rc_t *session, _z_optional_id_t querier_id,
             consolidation = Z_CONSOLIDATION_MODE_LATEST;
         }
     }
-    bool allow_local = _z_locality_allows_local(allowed_destination);
-    bool allow_remote = _z_locality_allows_remote(allowed_destination);
-    _z_transport_common_t *common = _z_transport_get_common(&zn->_tp);
-    bool remote_possible = allow_remote && (common != NULL && common->_link != NULL);
 
     bool _anyke_in_parameters = _z_parameters_has_anyke(parameters, parameters_len);
     bool _anyke_option = accept_replies == Z_REPLY_KEYEXPR_ANY;
@@ -594,14 +603,7 @@ z_result_t _z_query(const _z_session_rc_t *session, _z_optional_id_t querier_id,
     pq->_arg = arg;
     pq->_timeout = timeout_ms;
     pq->_start_time = z_clock_now();
-    // Count how many finals we expect: one for the local path (if handled_locally)
-    // and one for the remote path (if remote is allowed). Keep at least 1 to avoid stuck pending.
-#if Z_FEATURE_LOCAL_QUERYABLE == 1
-    pq->_remaining_finals = (uint8_t)((allow_local ? 1 : 0) + (allow_remote ? 1 : 0));
-#else
-    _ZP_UNUSED(allow_local);
-    pq->_remaining_finals = 1;
-#endif
+    pq->_remaining_finals = (uint8_t)remaining_finals;
 #ifdef Z_FEATURE_UNSTABLE_API
     ret = _z_pending_query_register_cancellation(pq, opt_cancellation_token, session);
 #else
@@ -611,7 +613,7 @@ z_result_t _z_query(const _z_session_rc_t *session, _z_optional_id_t querier_id,
     // Send query message
     _z_slice_t params =
         (parameters == NULL) ? _z_slice_null() : _z_slice_alias_buf((uint8_t *)parameters, parameters_len);
-    if (ret == _Z_RES_OK && remote_possible) {
+    if (ret == _Z_RES_OK && remote_targets > 0) {
         _z_wireexpr_t wireexpr = _z_declared_keyexpr_alias_to_wire(keyexpr, zn);
         _z_zenoh_message_t z_msg;
         _z_n_msg_make_query(&z_msg, &wireexpr, &params, qid, Z_RELIABILITY_DEFAULT, consolidation, payload, encoding,

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -603,7 +603,7 @@ z_result_t _z_query(const _z_session_rc_t *session, _z_optional_id_t querier_id,
     pq->_arg = arg;
     pq->_timeout = timeout_ms;
     pq->_start_time = z_clock_now();
-    pq->_remaining_finals = (uint8_t)remaining_finals;
+    pq->_remaining_finals = (uint32_t)remaining_finals;
 #ifdef Z_FEATURE_UNSTABLE_API
     ret = _z_pending_query_register_cancellation(pq, opt_cancellation_token, session);
 #else

--- a/src/transport/transport.c
+++ b/src/transport/transport.c
@@ -24,6 +24,25 @@
 #include "zenoh-pico/transport/unicast/transport.h"
 #include "zenoh-pico/utils/logging.h"
 
+size_t _z_transport_get_peers_count(_z_transport_t *zt) {
+    size_t count = 0;
+    switch (zt->_type) {
+        case _Z_TRANSPORT_UNICAST_TYPE:
+            _z_transport_peer_mutex_lock(&zt->_transport._unicast._common);
+            count = _z_transport_peer_unicast_slist_len(zt->_transport._unicast._peers);
+            _z_transport_peer_mutex_unlock(&zt->_transport._unicast._common);
+            return count;
+        case _Z_TRANSPORT_MULTICAST_TYPE:
+        case _Z_TRANSPORT_RAWETH_TYPE:
+            _z_transport_peer_mutex_lock(&zt->_transport._multicast._common);
+            count = _z_transport_peer_multicast_slist_len(zt->_transport._multicast._peers);
+            _z_transport_peer_mutex_unlock(&zt->_transport._multicast._common);
+            return count;
+        default:
+            return 0;
+    }
+}
+
 _z_transport_common_t *_z_transport_get_common(_z_transport_t *zt) {
     switch (zt->_type) {
         case _Z_TRANSPORT_UNICAST_TYPE:

--- a/tests/z_api_local_queryable_test.c
+++ b/tests/z_api_local_queryable_test.c
@@ -22,7 +22,8 @@ static const char *QUERYABLE_EXPR = "zenoh-pico/locality/query";
 
 void test_queryable(z_locality_t get_allowed_destination, z_locality_t q1_allowed_origin,
                     z_locality_t q2_allowed_origin) {
-    printf("Testing: %d %d %d\n", get_allowed_destination, q1_allowed_origin, q2_allowed_origin);
+    printf("Testing Quryables: get_dest=%d q1_origin=%d q2_origin=%d\n", get_allowed_destination, q1_allowed_origin,
+           q2_allowed_origin);
     z_owned_session_t s1, s2;
     z_owned_config_t c1, c2;
     z_config_default(&c1);
@@ -142,6 +143,97 @@ void test_queryable(z_locality_t get_allowed_destination, z_locality_t q1_allowe
     z_session_drop(z_session_move(&s2));
 }
 
+void test_queryable_peer_mode(z_locality_t get_allowed_destination, z_locality_t q_allowed_origin) {
+    printf("Testing peer mode: get_dest=%d q_origin=%d\n", get_allowed_destination, q_allowed_origin);
+
+    z_owned_session_t s;
+    z_owned_config_t c;
+    z_config_default(&c);
+    assert(zp_config_insert(z_loan_mut(c), Z_CONFIG_MODE_KEY, "peer") == Z_OK);
+    assert(zp_config_insert(z_loan_mut(c), Z_CONFIG_LISTEN_KEY, "tcp/127.0.0.1:10000") == Z_OK);
+    assert(zp_config_insert(z_loan_mut(c), Z_CONFIG_MULTICAST_SCOUTING_KEY, "false") == Z_OK);
+
+    z_view_keyexpr_t ke;
+    z_view_keyexpr_from_str(&ke, QUERYABLE_EXPR);
+
+    assert(z_open(&s, z_config_move(&c), NULL) == Z_OK);
+
+    z_owned_queryable_t queryable;
+    z_queryable_options_t qopts;
+    z_queryable_options_default(&qopts);
+    qopts.allowed_origin = q_allowed_origin;
+
+    z_owned_closure_query_t query_callback;
+    z_owned_fifo_handler_query_t query_handler;
+    z_fifo_channel_query_new(&query_callback, &query_handler, 16);
+    z_declare_queryable(z_session_loan(&s), &queryable, z_view_keyexpr_loan(&ke), z_closure_query_move(&query_callback),
+                        &qopts);
+
+    z_owned_closure_reply_t reply_callback;
+    z_owned_fifo_handler_reply_t reply_handler;
+    z_fifo_channel_reply_new(&reply_callback, &reply_handler, 16);
+
+    z_get_options_t opts;
+    z_get_options_default(&opts);
+    opts.allowed_destination = get_allowed_destination;
+
+    z_get(z_session_loan(&s), z_view_keyexpr_loan(&ke), "", z_closure_reply_move(&reply_callback), &opts);
+
+    z_owned_query_t q;
+    z_result_t ret = z_fifo_handler_query_try_recv(z_fifo_handler_query_loan(&query_handler), &q);
+
+    bool expect_response =
+        _z_locality_allows_local(get_allowed_destination) && _z_locality_allows_local(q_allowed_origin);
+    size_t expect_responses = 0;
+
+    if (expect_response) {
+        assert(ret == Z_OK);
+        z_owned_bytes_t payload;
+        z_bytes_copy_from_str(&payload, "peer_reply");
+        z_query_reply(z_query_loan(&q), z_view_keyexpr_loan(&ke), z_bytes_move(&payload), NULL);
+        z_query_drop(z_query_move(&q));
+        expect_responses = 1;
+    } else {
+        assert(ret != Z_OK);
+    }
+
+    size_t reply_count = 0;
+    bool found_reply = false;
+
+    z_sleep_s(1);
+
+    z_owned_reply_t reply;
+    for (z_result_t res = z_fifo_handler_reply_recv(z_fifo_handler_reply_loan(&reply_handler), &reply);
+         res != Z_CHANNEL_DISCONNECTED;
+         res = z_fifo_handler_reply_recv(z_fifo_handler_reply_loan(&reply_handler), &reply)) {
+        assert(z_reply_is_ok(z_loan(reply)));
+        const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
+        z_view_string_t keystr;
+        z_keyexpr_as_view_string(z_sample_keyexpr(sample), &keystr);
+        z_owned_string_t replystr;
+        z_bytes_to_string(z_sample_payload(sample), &replystr);
+        // SAFETY: test.
+        // Flawfinder: ignore [CWE-126]
+        if (strncmp(z_string_data(z_loan(replystr)), "peer_reply", 10) == 0) {
+            found_reply = true;
+        }
+        reply_count++;
+        // SAFETY: test.
+        // Flawfinder: ignore [CWE-126]
+        assert(strncmp(z_string_data(z_loan(keystr)), QUERYABLE_EXPR, strlen(QUERYABLE_EXPR)) == 0);
+        z_reply_drop(z_reply_move(&reply));
+        z_string_drop(z_string_move(&replystr));
+    }
+
+    assert(reply_count == expect_responses);
+    assert(found_reply == expect_response);
+
+    z_fifo_handler_reply_drop(z_fifo_handler_reply_move(&reply_handler));
+    z_fifo_handler_query_drop(z_fifo_handler_query_move(&query_handler));
+    z_queryable_drop(z_queryable_move(&queryable));
+    z_session_drop(z_session_move(&s));
+}
+
 int main(int argc, char **argv) {
     (void)argc;
     (void)argv;
@@ -153,6 +245,8 @@ int main(int argc, char **argv) {
             }
         }
     }
+    // Test local query on a single session in peer mode
+    test_queryable_peer_mode(Z_LOCALITY_ANY, Z_LOCALITY_ANY);
 }
 
 #else


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Fixes calculation of expected number of ResponseFinal messages when sending a query in p2p mode

### What does this PR do?
<!-- Describe the changes and their purpose -->

Fix calculation of expected number of ResponseFinal messages when sending a query in p2p mode

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
It fixes a query replies delivery logic
### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
#1202

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->