### PR TITLE
fix: prevent use-after-destroy of TX mutex during transport teardown

### DIFF
--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -18,6 +18,7 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "zenoh-pico/collections/atomic.h"
 #include "zenoh-pico/collections/element.h"
 #include "zenoh-pico/collections/refcount.h"
 #include "zenoh-pico/collections/slice.h"
@@ -186,6 +187,9 @@ typedef struct {
     // Here we assume the value is set only by the session _z_open
     // and after it only read by the transport tasks, so we don't need to make it atomic or protect it with mutexes.
     _z_transport_state_t _state;
+    // Atomic flag checked by send path before touching _mutex_tx.
+    // Set to false in _z_transport_common_clear to prevent use-after-destroy of mutex during reconnect.
+    _z_atomic_bool_t _tx_ready;
 #if Z_FEATURE_AUTO_RECONNECT == 1
     _z_transport_tasks_t _tasks;
 #endif
@@ -293,6 +297,13 @@ static inline bool _z_transport_batch_hold_peer_mutex(void) {
 #endif
 }
 #endif  // Z_FEATURE_BATCHING == 1
+
+static inline z_result_t _z_transport_tx_check_ready(_z_transport_common_t *ztc) {
+    if (!_z_atomic_bool_load(&ztc->_tx_ready, _z_memory_order_acquire)) {
+        return _Z_ERR_TRANSPORT_TX_FAILED;
+    }
+    return _Z_RES_OK;
+}
 
 #if Z_FEATURE_MULTI_THREAD == 1
 static inline z_result_t _z_transport_tx_mutex_lock(_z_transport_common_t *ztc, bool block) {

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -75,6 +75,8 @@ z_result_t _z_session_init(_z_session_t *zn, const _z_id_t *zid) {
 #endif
 #endif
     zn->_mode = Z_WHATAMI_CLIENT;
+    // Zero transport storage so reconnect-state checks never read uninitialized union bytes.
+    memset(&zn->_tp, 0, sizeof(_z_transport_t));
     zn->_tp._type = _Z_TRANSPORT_NONE;
     // Initialize the counters to 1
     zn->_entity_id = 1;
@@ -234,7 +236,16 @@ void _z_session_clear(_z_session_t *zn) {
     _z_config_clear(&zn->_config);
 #endif
     _z_session_transport_mutex_lock(zn);
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_transport_common_t *ztc = _z_transport_get_common(&zn->_tp);
+#endif
     _z_transport_clear(&zn->_tp);
+#if Z_FEATURE_MULTI_THREAD == 1
+    if (ztc != NULL) {
+        _z_mutex_drop(&ztc->_mutex_tx);
+        _z_mutex_rec_drop(&ztc->_mutex_peer);
+    }
+#endif
     _z_session_transport_mutex_unlock(zn);
 
 #if Z_FEATURE_MULTI_THREAD == 1

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -21,7 +21,13 @@
 #include "zenoh-pico/utils/result.h"
 
 void _z_transport_common_clear(_z_transport_common_t *ztc) {
+    // Prevent any further TX access before destroying the mutex
+    _z_atomic_bool_store(&ztc->_tx_ready, false, _z_memory_order_release);
 #if Z_FEATURE_MULTI_THREAD == 1
+    // Drain: _tx_ready=false prevents new lock attempts, so this only waits
+    // for at most one in-flight TX to release the mutex before we destroy it.
+    _z_mutex_lock(&ztc->_mutex_tx);
+    _z_mutex_unlock(&ztc->_mutex_tx);
     // Clean up the mutexes
     _z_mutex_drop(&ztc->_mutex_tx);
     _z_mutex_rec_drop(&ztc->_mutex_peer);

--- a/src/transport/common/transport.c
+++ b/src/transport/common/transport.c
@@ -21,16 +21,12 @@
 #include "zenoh-pico/utils/result.h"
 
 void _z_transport_common_clear(_z_transport_common_t *ztc) {
-    // Prevent any further TX access before destroying the mutex
+    // Prevent any further TX access before clearing transport resources.
     _z_atomic_bool_store(&ztc->_tx_ready, false, _z_memory_order_release);
 #if Z_FEATURE_MULTI_THREAD == 1
-    // Drain: _tx_ready=false prevents new lock attempts, so this only waits
-    // for at most one in-flight TX to release the mutex before we destroy it.
+    // Drain current TX critical section (if any) before clearing buffers/link.
     _z_mutex_lock(&ztc->_mutex_tx);
     _z_mutex_unlock(&ztc->_mutex_tx);
-    // Clean up the mutexes
-    _z_mutex_drop(&ztc->_mutex_tx);
-    _z_mutex_rec_drop(&ztc->_mutex_peer);
 #endif
     // Clean up the buffers
     _z_wbuf_clear(&ztc->_wbuf);

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -270,14 +270,14 @@ z_result_t _z_transport_tx_send_t_msg(_z_transport_common_t *ztc, const _z_trans
                                       _z_transport_peer_unicast_slist_t *peers) {
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG("Send session message");
-
+    // If sending to a peer list, make sure the peer mutex is locked
+    _z_transport_tx_mutex_lock(ztc, true);
     ret = _z_transport_tx_check_ready(ztc);
     if (ret != _Z_RES_OK) {
         _Z_INFO("Dropping zenoh message because transport is not ready");
+        _z_transport_tx_mutex_unlock(ztc);
         return ret;
     }
-    // If sending to a peer list, make sure the peer mutex is locked
-    _z_transport_tx_mutex_lock(ztc, true);
 
     ret = _z_transport_tx_send_t_msg_inner(ztc, t_msg, peers);
 
@@ -295,18 +295,21 @@ static z_result_t _z_transport_tx_send_n_msg(_z_transport_common_t *ztc, const _
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG("Send network message");
 
-    ret = _z_transport_tx_check_ready(ztc);
-    if (ret != _Z_RES_OK) {
-        _Z_INFO("Dropping zenoh message because transport is not ready");
-        return ret;
-    }
-
     // Acquire the lock and drop the message if needed
     if (!_z_transport_batch_hold_tx_mutex()) {
         ret = _z_transport_tx_mutex_lock(ztc, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK);
     }
     if (ret != _Z_RES_OK) {
         _Z_INFO("Dropping zenoh message because of congestion control");
+        return ret;
+    }
+
+    ret = _z_transport_tx_check_ready(ztc);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        if (!_z_transport_batch_hold_tx_mutex()) {
+            _z_transport_tx_mutex_unlock(ztc);
+        }
         return ret;
     }
     // Process message
@@ -321,13 +324,6 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
                                                _z_transport_peer_unicast_slist_t *peers) {
 #if Z_FEATURE_BATCHING == 1
     z_result_t ret = _Z_RES_OK;
-
-    ret = _z_transport_tx_check_ready(ztc);
-    if (ret != _Z_RES_OK) {
-        _Z_INFO("Dropping zenoh message because transport is not ready");
-        return ret;
-    }
-
     // Check batch size
     if (ztc->_batch_count > 0) {
         // Acquire the lock and drop the message if needed
@@ -336,6 +332,15 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
         }
         if (ret != _Z_RES_OK) {
             _Z_INFO("Dropping zenoh batch because of congestion control");
+            return ret;
+        }
+
+        ret = _z_transport_tx_check_ready(ztc);
+        if (ret != _Z_RES_OK) {
+            _Z_INFO("Dropping zenoh batch because transport is not ready");
+            if (!_z_transport_batch_hold_tx_mutex()) {
+                _z_transport_tx_mutex_unlock(ztc);
+            }
             return ret;
         }
         // Send batch

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -270,6 +270,12 @@ z_result_t _z_transport_tx_send_t_msg(_z_transport_common_t *ztc, const _z_trans
                                       _z_transport_peer_unicast_slist_t *peers) {
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG("Send session message");
+
+    ret = _z_transport_tx_check_ready(ztc);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        return ret;
+    }
     // If sending to a peer list, make sure the peer mutex is locked
     _z_transport_tx_mutex_lock(ztc, true);
 
@@ -288,6 +294,12 @@ static z_result_t _z_transport_tx_send_n_msg(_z_transport_common_t *ztc, const _
                                              _z_transport_peer_unicast_slist_t *peers) {
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG("Send network message");
+
+    ret = _z_transport_tx_check_ready(ztc);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        return ret;
+    }
 
     // Acquire the lock and drop the message if needed
     if (!_z_transport_batch_hold_tx_mutex()) {
@@ -309,6 +321,13 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
                                                _z_transport_peer_unicast_slist_t *peers) {
 #if Z_FEATURE_BATCHING == 1
     z_result_t ret = _Z_RES_OK;
+
+    ret = _z_transport_tx_check_ready(ztc);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        return ret;
+    }
+
     // Check batch size
     if (ztc->_batch_count > 0) {
         // Acquire the lock and drop the message if needed

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -58,12 +58,16 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
 #endif
 
 #if Z_FEATURE_MULTI_THREAD == 1
-    // Initialize the mutexes
-    ret = _z_mutex_init(&ztm->_common._mutex_tx);
-    if (ret == _Z_RES_OK) {
-        ret = _z_mutex_rec_init(&ztm->_common._mutex_peer);
-        if (ret != _Z_RES_OK) {
-            _z_mutex_drop(&ztm->_common._mutex_tx);
+    // If transport is reconnecting, mutexes are already initialized in previous call of this function
+    bool init_mutex = zt->_transport._multicast._common._state != _Z_TRANSPORT_STATE_RECONNECTING;
+    if (init_mutex) {
+        // Initialize the mutexes
+        ret = _z_mutex_init(&ztm->_common._mutex_tx);
+        if (ret == _Z_RES_OK) {
+            ret = _z_mutex_rec_init(&ztm->_common._mutex_peer);
+            if (ret != _Z_RES_OK) {
+                _z_mutex_drop(&ztm->_common._mutex_tx);
+            }
         }
     }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
@@ -82,8 +86,10 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
             _Z_ERROR("Not enough memory to allocate transport tx rx buffers!");
 
 #if Z_FEATURE_MULTI_THREAD == 1
-            _z_mutex_drop(&ztm->_common._mutex_tx);
-            _z_mutex_rec_drop(&ztm->_common._mutex_peer);
+            if (init_mutex) {
+                _z_mutex_drop(&ztm->_common._mutex_tx);
+                _z_mutex_rec_drop(&ztm->_common._mutex_peer);
+            }
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
             _z_wbuf_clear(&ztm->_common._wbuf);

--- a/src/transport/multicast/transport.c
+++ b/src/transport/multicast/transport.c
@@ -109,6 +109,9 @@ z_result_t _z_multicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
 
         // Transport link for multicast
         ztm->_common._link = zl;
+
+        // Mark TX as ready only after all init is complete
+        _z_atomic_bool_init(&ztm->_common._tx_ready, true);
     }
     return ret;
 }

--- a/src/transport/raweth/tx.c
+++ b/src/transport/raweth/tx.c
@@ -202,6 +202,11 @@ z_result_t _z_raweth_send_t_msg(_z_transport_common_t *ztc, const _z_transport_m
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG(">> send session message");
 
+    ret = _z_transport_tx_check_ready(ztc);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        return ret;
+    }
     _z_transport_tx_mutex_lock(ztc, true);
     // Reset wbuf
     _z_wbuf_reset(&ztc->_wbuf);
@@ -227,6 +232,12 @@ z_result_t _z_raweth_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_
     z_result_t ret = _Z_RES_OK;
     _z_transport_multicast_t *ztm = &zn->_tp._transport._raweth;
     _Z_DEBUG(">> send network message");
+
+    ret = _z_transport_tx_check_ready(&ztm->_common);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        return ret;
+    }
 
     // Acquire the lock and drop the message if needed
     ret = _z_transport_tx_mutex_lock(&ztm->_common, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK);

--- a/src/transport/raweth/tx.c
+++ b/src/transport/raweth/tx.c
@@ -202,12 +202,14 @@ z_result_t _z_raweth_send_t_msg(_z_transport_common_t *ztc, const _z_transport_m
     z_result_t ret = _Z_RES_OK;
     _Z_DEBUG(">> send session message");
 
+    _z_transport_tx_mutex_lock(ztc, true);
     ret = _z_transport_tx_check_ready(ztc);
     if (ret != _Z_RES_OK) {
         _Z_INFO("Dropping zenoh message because transport is not ready");
+        _z_transport_tx_mutex_unlock(ztc);
         return ret;
     }
-    _z_transport_tx_mutex_lock(ztc, true);
+
     // Reset wbuf
     _z_wbuf_reset(&ztc->_wbuf);
     // Set socket info
@@ -233,16 +235,16 @@ z_result_t _z_raweth_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_
     _z_transport_multicast_t *ztm = &zn->_tp._transport._raweth;
     _Z_DEBUG(">> send network message");
 
-    ret = _z_transport_tx_check_ready(&ztm->_common);
-    if (ret != _Z_RES_OK) {
-        _Z_INFO("Dropping zenoh message because transport is not ready");
-        return ret;
-    }
-
     // Acquire the lock and drop the message if needed
     ret = _z_transport_tx_mutex_lock(&ztm->_common, cong_ctrl == Z_CONGESTION_CONTROL_BLOCK);
     if (ret != _Z_RES_OK) {
         _Z_INFO("Dropping zenoh message because of congestion control");
+        return ret;
+    }
+    ret = _z_transport_tx_check_ready(&ztm->_common);
+    if (ret != _Z_RES_OK) {
+        _Z_INFO("Dropping zenoh message because transport is not ready");
+        _z_transport_tx_mutex_unlock(&ztm->_common);
         return ret;
     }
     const _z_keyexpr_t *keyexpr = NULL;

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -69,6 +69,9 @@ static z_result_t _z_unicast_transport_create_inner(_z_transport_unicast_t *ztu,
     ztu->_common._link = zl;
 
     ztu->_peers = _z_transport_peer_unicast_slist_new();
+
+    // Mark TX as ready only after all init is complete
+    _z_atomic_bool_init(&ztu->_common._tx_ready, true);
     return _Z_RES_OK;
 }
 

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -30,7 +30,7 @@
 
 #if Z_FEATURE_UNICAST_TRANSPORT == 1
 static z_result_t _z_unicast_transport_create_inner(_z_transport_unicast_t *ztu, _z_link_t *zl,
-                                                    _z_transport_unicast_establish_param_t *param) {
+                                                    _z_transport_unicast_establish_param_t *param, bool init_mutex) {
 // Initialize batching data
 #if Z_FEATURE_BATCHING == 1
     ztu->_common._batch_state = _Z_BATCHING_IDLE;
@@ -38,9 +38,13 @@ static z_result_t _z_unicast_transport_create_inner(_z_transport_unicast_t *ztu,
 #endif
 
 #if Z_FEATURE_MULTI_THREAD == 1
-    // Initialize the mutexes
-    _Z_RETURN_IF_ERR(_z_mutex_init(&ztu->_common._mutex_tx));
-    _Z_RETURN_IF_ERR(_z_mutex_rec_init(&ztu->_common._mutex_peer));
+    if (init_mutex) {
+        // Initialize the mutexes
+        _Z_RETURN_IF_ERR(_z_mutex_init(&ztu->_common._mutex_tx));
+        _Z_RETURN_IF_ERR(_z_mutex_rec_init(&ztu->_common._mutex_peer));
+    }
+#else
+    _ZP_UNUSED(init_mutex);
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
     // Initialize the read and write buffers
@@ -79,14 +83,20 @@ z_result_t _z_unicast_transport_create(_z_transport_t *zt, _z_link_t *zl,
                                        _z_transport_unicast_establish_param_t *param) {
     zt->_type = _Z_TRANSPORT_UNICAST_TYPE;
     _z_transport_unicast_t *ztu = &zt->_transport._unicast;
-    memset(ztu, 0, sizeof(_z_transport_unicast_t));
+    // If transport is reconnecting, mutexes are already initialized in previous call of this function
+    bool init_mutex = ztu->_common._state != _Z_TRANSPORT_STATE_RECONNECTING;
+    if (init_mutex) {
+        memset(ztu, 0, sizeof(_z_transport_unicast_t));
+    }
 
-    z_result_t ret = _z_unicast_transport_create_inner(ztu, zl, param);
+    z_result_t ret = _z_unicast_transport_create_inner(ztu, zl, param, init_mutex);
     if (ret != _Z_RES_OK) {
         // Clear alloc data
 #if Z_FEATURE_MULTI_THREAD == 1
-        _z_mutex_drop(&ztu->_common._mutex_tx);
-        _z_mutex_rec_drop(&ztu->_common._mutex_peer);
+        if (init_mutex) {
+            _z_mutex_drop(&ztu->_common._mutex_tx);
+            _z_mutex_rec_drop(&ztu->_common._mutex_peer);
+        }
 #endif
         _z_wbuf_clear(&ztu->_common._wbuf);
         _z_zbuf_clear(&ztu->_common._zbuf);


### PR DESCRIPTION
## Description
Adds an atomic _tx_ready guard to prevent use-after-destroy of the TX mutex during transport teardown.

### What does this PR do?

A new _z_atomic_bool_t _tx_ready field is added to _z_transport_common_t. It is set to true on transport creation and atomically set to false in _z_transport_common_clear before the mutex is destroyed. All TX send paths check this flag before acquiring the TX mutex, dropping the message with an info log if the transport is shutting down.


### Why is this change needed?

This change adresses race conditions in mutlithreaded app when executor thread is doing reconneciton while tx thread is still sending data.

There is a race between TX send paths and transport teardown: _z_transport_common_clear destroys the TX mutex while a concurrent send may still be holding or about to acquire it. This causes use-after-destroy of the mutex, leading to undefined behavior (segfaults, assertion failures, or silent corruption depending on the platform).

The atomic flag provides a lock-free check that is ordered before the mutex acquisition, so the teardown path can guarantee that no new senders will enter the critical section after _tx_ready is set to false. A subsequent drain (lock + unlock) ensures any in-flight sender has released the mutex before it is destroyed.

### Related Issues
Related to https://github.com/eclipse-zenoh/zenoh-pico/issues/1165 — segmentation fault when calling batching operations during transport reconnect. This PR guards the same TX send paths (including _z_transport_tx_send_n_batch) against concurrent teardown.

Related to https://github.com/eclipse-zenoh/zenoh-pico/issues/1103 — task cleanup race condition. While #1103's root cause is in the ESP-IDF task layer, the underlying pattern (resources accessed after teardown begins) is the same class of bug addressed here for the TX mutex.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [ ] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [ ] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->