### PR TITLE
_ZP_KE_MATCH_TEMPLATE_INTERSECTS fix to use 1/0 instead of true/false…

### DIFF
--- a/include/zenoh-pico/session/keyexpr_match_template.h
+++ b/include/zenoh-pico/session/keyexpr_match_template.h
@@ -129,7 +129,7 @@ static inline const char *_z_keyexpr_get_next_verbatim_chunk(const char *begin, 
 #error "_ZP_KE_MATCH_TEMPLATE_INTERSECTS must be defined before including keyexpr_match_template.h"
 #endif
 
-#if _ZP_KE_MATCH_TEMPLATE_INTERSECTS == true
+#if _ZP_KE_MATCH_TEMPLATE_INTERSECTS == 1
 #define _ZP_KE_MATCH_OP intersects
 #define _ZP_KE_MATCH_TYPE_INTERSECTS true
 #define _ZP_KE_MATCH_TYPE_INCLUDES false

--- a/src/session/keyexpr.c
+++ b/src/session/keyexpr.c
@@ -562,9 +562,9 @@ z_result_t _z_declared_keyexpr_declare_non_wild_prefix(const _z_session_rc_t *zs
     }
 }
 
-#define _ZP_KE_MATCH_TEMPLATE_INTERSECTS true
+#define _ZP_KE_MATCH_TEMPLATE_INTERSECTS 1
 #include "zenoh-pico/session/keyexpr_match_template.h"
-#define _ZP_KE_MATCH_TEMPLATE_INTERSECTS false
+#define _ZP_KE_MATCH_TEMPLATE_INTERSECTS 0
 #include "zenoh-pico/session/keyexpr_match_template.h"
 
 bool _z_keyexpr_intersects(const _z_keyexpr_t *left, const _z_keyexpr_t *right) {


### PR DESCRIPTION
## Description
Fixes definition so that library can be compiled for NuttX

### What does this PR do?
Replace _ZP_KE_MATCH_TEMPLATE_INTERSECTS definition "true/false" to "1/0" instead


### Why is this change needed?
Without change compiling for nuttX platfrom (on STM32H7) throws error 
```
In file included from /home/src/PX4-Autopilot/src/modules/zenoh/zenoh-pico/include/zenoh-pico/session/keyexpr.h:17,
                 from /home/vuk-sfl/src/upstream/PX4-Autopilot/src/modules/zenoh/zenoh-pico/src/session/keyexpr.c:14:
/home/src/PX4-Autopilot/src/modules/zenoh/zenoh-pico/src/session/keyexpr.c:565:42: error: missing binary operator before token "1"
  565 | #define _ZP_KE_MATCH_TEMPLATE_INTERSECTS true
      |                                          ^~~~
/home/src/PX4-Autopilot/src/modules/zenoh/zenoh-pico/include/zenoh-pico/session/keyexpr_match_template.h:132:5: note: in expansion of macro '_ZP_KE_MATCH_TEMPLATE_INTERSECTS'
  132 | #if _ZP_KE_MATCH_TEMPLATE_INTERSECTS == true

```


### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->