### PR TITLE
fix(advanced-subscriber): avoid double free when closing late-join background subscribers

### DIFF
--- a/src/api/advanced_subscriber.c
+++ b/src/api/advanced_subscriber.c
@@ -897,11 +897,14 @@ static z_result_t _ze_advanced_subscriber_run_query(_ze_advanced_subscriber_quer
                                                     const z_loaned_keyexpr_t *keyexpr, const char *params) {
     if (_Z_RC_IS_NULL(rc_state)) {
         _Z_ERROR("Failed to run query - state is NULL");
+        // Query context is still locally owned until the reply closure is handed to z_get().
+        _ze_advanced_subscriber_query_ctx_free(ctx);
         _Z_ERROR_RETURN(_Z_ERR_GENERIC);
     }
 
     _ze_advanced_subscriber_state_t *state = _Z_RC_IN_VAL(rc_state);
-    _Z_RETURN_IF_ERR(_ze_advanced_subscriber_state_rc_copy(&ctx->_statesref, rc_state));
+    _Z_CLEAN_RETURN_IF_ERR(_ze_advanced_subscriber_state_rc_copy(&ctx->_statesref, rc_state),
+                           _ze_advanced_subscriber_query_ctx_free(ctx));
 
     z_owned_closure_reply_t callback;
     z_closure_reply(&callback, _ze_advanced_subscriber_query_reply_handler, _ze_advanced_subscriber_query_drop_handler,
@@ -923,6 +926,7 @@ static z_result_t _ze_advanced_subscriber_run_query(_ze_advanced_subscriber_quer
                            _z_session_rc_drop(&sess_rc);
                            _ze_advanced_subscriber_query_ctx_free(ctx));
     get_opts.cancellation_token = z_cancellation_token_move(&ct);
+    // From this point on, the reply closure owns ctx and the drop handler must free it.
     z_result_t ret = z_get(&sess_rc, keyexpr, params, z_closure_reply_move(&callback), &get_opts);
     _z_session_rc_drop(&sess_rc);
     return ret;

--- a/src/api/advanced_subscriber.c
+++ b/src/api/advanced_subscriber.c
@@ -1206,11 +1206,6 @@ void _ze_advanced_subscriber_subscriber_drop_handler(void *ctx) {
         }
         // signal undeclaring state to prevent new queries or miss handlers from being added
         state->_is_undeclaring = true;
-        // clear miss handlers to release user callbacks
-        _ze_closure_miss_intmap_clear(&state->_miss_handlers);
-        // clear sequenced state to remove any periodic query tasks
-        _z_entity_global_id__ze_advanced_subscriber_sequenced_state_hashmap_clear(&state->_sequenced_states);
-        _z_id__ze_advanced_subscriber_timestamped_state_hashmap_clear(&state->_timestamped_states);
         _ze_advanced_subscriber_state_unlock_mutex(state);
         if (z_internal_cancellation_token_check(&state->_cancellation_token)) {
             z_cancellation_token_cancel(z_cancellation_token_loan_mut(&state->_cancellation_token));

--- a/src/api/advanced_subscriber.c
+++ b/src/api/advanced_subscriber.c
@@ -882,6 +882,16 @@ void _ze_advanced_subscriber_query_drop_handler(void *ctx) {
     z_free(ctx);
 }
 
+static void _ze_advanced_subscriber_query_ctx_free(_ze_advanced_subscriber_query_ctx_t *ctx) {
+    if (ctx == NULL) {
+        return;
+    }
+    if (!_Z_RC_IS_NULL(&ctx->_statesref)) {
+        _ze_advanced_subscriber_state_rc_drop(&ctx->_statesref);
+    }
+    z_free(ctx);
+}
+
 static z_result_t _ze_advanced_subscriber_run_query(_ze_advanced_subscriber_query_ctx_t *ctx,
                                                     _ze_advanced_subscriber_state_rc_t *rc_state,
                                                     const z_loaned_keyexpr_t *keyexpr, const char *params) {
@@ -904,14 +914,14 @@ static z_result_t _ze_advanced_subscriber_run_query(_ze_advanced_subscriber_quer
     get_opts.timeout_ms = state->_query_timeout;
     _z_session_rc_t sess_rc = _z_session_weak_upgrade_if_open(&state->_zn);
     if (_Z_RC_IS_NULL(&sess_rc)) {
-        _ze_advanced_subscriber_state_rc_drop(&ctx->_statesref);
+        _ze_advanced_subscriber_query_ctx_free(ctx);
         _Z_ERROR_RETURN(_Z_ERR_SESSION_CLOSED);
     }
 
     z_owned_cancellation_token_t ct;
     _Z_CLEAN_RETURN_IF_ERR(z_cancellation_token_clone(&ct, z_cancellation_token_loan(&state->_cancellation_token)),
                            _z_session_rc_drop(&sess_rc);
-                           _ze_advanced_subscriber_state_rc_drop(&ctx->_statesref));
+                           _ze_advanced_subscriber_query_ctx_free(ctx));
     get_opts.cancellation_token = z_cancellation_token_move(&ct);
     z_result_t ret = z_get(&sess_rc, keyexpr, params, z_closure_reply_move(&callback), &get_opts);
     _z_session_rc_drop(&sess_rc);
@@ -926,8 +936,7 @@ static inline z_result_t _ze_advanced_subscriber_initial_query(_ze_advanced_subs
     }
     *ctx = _ze_advanced_subscriber_query_ctx_null();
     ctx->_kind = _ZE_ADVANCED_SUBSCRIBER_QUERY_CTX_INITIAL;
-    _Z_CLEAN_RETURN_IF_ERR(_ze_advanced_subscriber_run_query(ctx, state, keyexpr, params), z_free(ctx));
-    return _Z_RES_OK;
+    return _ze_advanced_subscriber_run_query(ctx, state, keyexpr, params);
 }
 
 static inline z_result_t _ze_advanced_subscriber_sequenced_query(_ze_advanced_subscriber_state_rc_t *state,
@@ -940,8 +949,7 @@ static inline z_result_t _ze_advanced_subscriber_sequenced_query(_ze_advanced_su
     *ctx = _ze_advanced_subscriber_query_ctx_null();
     ctx->_kind = _ZE_ADVANCED_SUBSCRIBER_QUERY_CTX_SEQUENCED;
     ctx->_source_id = *source_id;
-    _Z_CLEAN_RETURN_IF_ERR(_ze_advanced_subscriber_run_query(ctx, state, keyexpr, params), z_free(ctx));
-    return _Z_RES_OK;
+    return _ze_advanced_subscriber_run_query(ctx, state, keyexpr, params);
 }
 
 static inline z_result_t _ze_advanced_subscriber_timestamped_query(_ze_advanced_subscriber_state_rc_t *state,
@@ -954,8 +962,7 @@ static inline z_result_t _ze_advanced_subscriber_timestamped_query(_ze_advanced_
     *ctx = _ze_advanced_subscriber_query_ctx_null();
     ctx->_kind = _ZE_ADVANCED_SUBSCRIBER_QUERY_CTX_TIMESTAMPED;
     ctx->_id = *id;
-    _Z_CLEAN_RETURN_IF_ERR(_ze_advanced_subscriber_run_query(ctx, state, keyexpr, params), z_free(ctx));
-    return _Z_RES_OK;
+    return _ze_advanced_subscriber_run_query(ctx, state, keyexpr, params);
 }
 
 typedef struct {


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This fixes a flaky failure in `z_api_callback_drop_on_undeclare_test`.

### What was happening

The failing CI run crashes with `free(): double free detected in tcache 2` while running the background late-join advanced-subscriber case in `test_advanced_subscriber_late_join_callback_drop_on_undeclare(true)` from `tests/z_api_callback_drop_on_undeclare_test.c`.

This case enables `detect_late_publishers`, so the advanced subscriber may still be holding internal late-join state and may also be starting history recovery queries while the background session is being closed.

### Root cause

There were two double-free paths in advanced-subscriber teardown.

1. `_ze_advanced_subscriber_subscriber_drop_handler()` was clearing advanced-subscriber internal containers during subscriber drop:
   - `_miss_handlers`
   - `_sequenced_states`
   - `_timestamped_states`

   Later, `_ze_advanced_subscriber_state_clear()` cleared the same containers again when the advanced-subscriber state itself was finally released. In the late-join background case those containers can be populated, so this duplicated cleanup could free the same allocations twice.

2. The late-join query path allocates a per-query `query_ctx` and passes it to `z_get()` through the reply closure.

   During `z_close()`, query startup can fail while `z_get()` is already consuming that closure. In that case, `z_get()` may trigger `_ze_advanced_subscriber_query_drop_handler()`, which frees `query_ctx`.

   But the advanced-subscriber query wrapper error paths were also freeing the same `query_ctx` in:
   - `_ze_advanced_subscriber_initial_query()`
   - `_ze_advanced_subscriber_sequenced_query()`
   - `_ze_advanced_subscriber_timestamped_query()`

   So session teardown could race with late-join query startup and both sides could free the same query context.

### Why it looked flaky

Both problems depend on teardown timing in the late-join background case. The failure only appears when session close overlaps with internal late-join cleanup and/or history query startup, which makes the crash intermittent in CI even though the underlying bugs are real double frees.

### What does this PR do?

This PR makes teardown ownership explicit in both places.

1. `_ze_advanced_subscriber_subscriber_drop_handler()` now only marks the state as undeclaring and cancels outstanding work. It no longer clears `_miss_handlers`, `_sequenced_states`, or `_timestamped_states` itself.
2. `_ze_advanced_subscriber_run_query()` now owns cleanup of `query_ctx` on pre-dispatch failures, and the individual query wrappers no longer free `query_ctx` themselves on error.

This leaves `_ze_advanced_subscriber_state_clear()` as the single owner of container cleanup and keeps query-context ownership consistent with the reply closure drop path, preventing both double-free races during late-join session close.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
 * https://github.com/eclipse-zenoh/zenoh-pico/actions/runs/24320585645/job/71005915340

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->