### PR TITLE
Fix memory leak in _z_liveliness_pending_query_reply in case of closed session

### DIFF
--- a/src/session/liveliness.c
+++ b/src/session/liveliness.c
@@ -158,7 +158,7 @@ static z_result_t _z_liveliness_pending_query_reply(_z_session_t *zn, uint32_t i
     _Z_RETURN_IF_ERR(_z_get_keyexpr_from_wireexpr(zn, &ke, wireexpr, peer, true));
     z_result_t ret = _Z_RES_OK;
 
-    _Z_RETURN_IF_ERR(_z_session_mutex_lock_if_open(zn));
+    _Z_CLEAN_RETURN_IF_ERR(_z_session_mutex_lock_if_open(zn), _z_keyexpr_clear(&ke));
 
     const _z_liveliness_pending_query_t *pq =
         _z_liveliness_pending_query_intmap_get(&zn->_liveliness_pending_queries, interest_id);


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
**⚠️ Please replace this section with your PR description**
Fix memory leak in _z_liveliness_pending_query_reply in case of closed session
### What does this PR do?
<!-- Describe the changes and their purpose -->
Fix memory leak in _z_liveliness_pending_query_reply in case of closed session
### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
To fix a memory leak
### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->