### PR TITLE
Fix z_random_fill: advance pointer across buffer

### DIFF
--- a/src/system/freertos/system.c
+++ b/src/system/freertos/system.c
@@ -57,8 +57,9 @@ uint64_t z_random_u64(void) {
 }
 
 void z_random_fill(void *buf, size_t len) {
+    uint8_t *p = (uint8_t *)buf;
     for (size_t i = 0; i < len; i++) {
-        *((uint8_t *)buf) = z_random_u8();
+        p[i] = z_random_u8();
     }
 }
 


### PR DESCRIPTION
Previous loop rewrote byte 0 `len` times instead of filling all `len` bytes — any caller reading past byte 0 got uninitialised memory (typically zeros). Affects zenoh session IDs, ephemeral port seeds, and any other entropy-consuming path on FreeRTOS.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->