### PR TITLE
Fix ESP-IDF CI build

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -12,7 +12,9 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 import os
+import re
 import subprocess
+import sys
 
 Import('env', 'projenv')
 
@@ -22,16 +24,62 @@ ZP_PLATFORM = None
 
 BASE_SRC_FILTER = [
     "+<*>",
-    "-<tests/>",
-    "-<example/>",
-    "-<system/>",
-    "+<system/common/>",
-    "+<system/socket/>",
+    "-<tests/**>",
+    "-<test/**>",
+    "-<example/**>",
+    "-<examples/**>",
+
+    # Platform-selected sources are owned by the CMake platform profile.
+    # Do not let PlatformIO auto-discover every backend implementation.
+    "-<system/**>",
+    "-<link/transport/bt/**>",
+    "-<link/transport/serial/**>",
+    "-<link/transport/tcp/**>",
+    "-<link/transport/udp/**>",
+
+    # Shared sources that are safe for PlatformIO to discover directly.
+    "+<system/common/**>",
+    "+<link/transport/common/**>",
+    "+<link/transport/upper/**>",
+    "+<link/transport/tcp/address.c>",
+    "+<link/transport/udp/address.c>",
 ]
 
 
-def _platform_src_filter(system_dir):
-    return BASE_SRC_FILTER + [f"+<{system_dir}/>"]
+def _platform_source_filters(platform):
+    platform_file = os.path.join(
+        os.getcwd(),
+        "cmake",
+        "platforms",
+        f"{platform}.cmake",
+    )
+
+    if not os.path.exists(platform_file):
+        print(
+            f"warning: platform profile not found: {platform_file}",
+            file=sys.stderr,
+        )
+        return []
+
+    with open(platform_file, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    filters = []
+    seen = set()
+
+    for match in re.finditer(r'"\$\{PROJECT_SOURCE_DIR\}/src/([^"]+)"', content):
+        rel_path = match.group(1)
+        src_filter = f"+<{rel_path}>"
+
+        if src_filter not in seen:
+            seen.add(src_filter)
+            filters.append(src_filter)
+
+    return filters
+
+
+def _platform_src_filter(platform):
+    return BASE_SRC_FILTER + _platform_source_filters(platform)
 
 FRAMEWORK = env.get("PIOFRAMEWORK")[0]
 PLATFORM = env.get("PIOPLATFORM")
@@ -43,8 +91,8 @@ if ZENOH_GENERIC == "1":
     BOARD = 'generic'
 
 if FRAMEWORK == 'zephyr':
-    SRC_FILTER = _platform_src_filter("system/zephyr")
     ZP_PLATFORM = "zephyr"
+    SRC_FILTER = _platform_src_filter(ZP_PLATFORM)
     CPPDEFINES = [
         "ZENOH_ZEPHYR",
     ]
@@ -52,8 +100,8 @@ if FRAMEWORK == 'zephyr':
 elif FRAMEWORK == 'arduino':
     PLATFORM = env.get("PIOPLATFORM")
     if PLATFORM == 'espressif32':
-        SRC_FILTER = _platform_src_filter("system/arduino/esp32")
         ZP_PLATFORM = "arduino_esp32"
+        SRC_FILTER = _platform_src_filter(ZP_PLATFORM)
         CPPDEFINES = [
             "ZENOH_ARDUINO_ESP32",
             "ZENOH_COMPILER_GCC",
@@ -62,8 +110,8 @@ elif FRAMEWORK == 'arduino':
     if PLATFORM == 'ststm32':
         BOARD = env.get("PIOENV")
         if BOARD == 'opencr':
-            SRC_FILTER = _platform_src_filter("system/arduino/opencr")
             ZP_PLATFORM = "opencr"
+            SRC_FILTER = _platform_src_filter(ZP_PLATFORM)
             CPPDEFINES = [
                 "ZENOH_ARDUINO_OPENCR",
                 "ZENOH_C_STANDARD=99",
@@ -71,19 +119,20 @@ elif FRAMEWORK == 'arduino':
             ]
 
 elif FRAMEWORK == 'espidf':
-    SRC_FILTER = _platform_src_filter("system/espidf")
     ZP_PLATFORM = "espidf"
+    SRC_FILTER = _platform_src_filter(ZP_PLATFORM)
     CPPDEFINES = [
         "ZENOH_ESPIDF",
     ]
 
 elif FRAMEWORK == 'mbed':
-    SRC_FILTER = _platform_src_filter("system/mbed")
     ZP_PLATFORM = "mbed"
+    SRC_FILTER = _platform_src_filter(ZP_PLATFORM)
     CPPDEFINES = [
         "ZENOH_MBED",
         "ZENOH_C_STANDARD=99",
     ]
+
 elif FRAMEWORK == 'generic':
     SRC_FILTER = BASE_SRC_FILTER
     CPPDEFINES = ["ZENOH_GENERIC"]
@@ -134,5 +183,6 @@ for build_env in (env, projenv, global_env):  # pylint: disable=undefined-variab
     build_env.Prepend(CPPPATH=[generated_include_dir])
     build_env.Prepend(CCFLAGS=[f"-I{generated_include_dir}"])
 # Run the CMake command with the source and binary directories
+print("PlatformIO SRC_FILTER:", SRC_FILTER)
 print("Run command: cmake", source_dir, cmake_extra_args_list)
 subprocess.run(["cmake", source_dir] + cmake_extra_args_list, cwd=build_dir, check=True)


### PR DESCRIPTION
## Description

Fix PlatformIO source filtering so platform-specific backend files are selected consistently with the CMake platform profiles.

PlatformIO was auto-discovering sources outside `src/system/**`, including platform-specific transport backends under `src/link/transport/**`. This meant builds could include sources for the wrong platform, for example ESP-IDF builds attempting to compile Arduino ESP32 C++ transport files.

### What does this PR do?

This PR updates `extra_script.py` to:

- exclude platform-specific system and transport backend directories from PlatformIO’s default source discovery;
- read the selected CMake platform profile from `cmake/platforms/<platform>.cmake`;
- derive PlatformIO source-filter add-backs from the `ZP_PLATFORM_SOURCE_FILES` listed by that CMake profile;
- keep the CMake platform files as the source of truth for platform-specific source composition.

### Why is this change needed?

The previous PlatformIO filter treated `src/system/**` as the platform-specific boundary, but the platform-composition rework also has platform-specific files under `src/link/transport/**`, such as Arduino ESP32 Bluetooth and serial sources.

Because PlatformIO starts from `+<*>`, those files could be picked up even when the active platform profile did not select them. This caused incorrect cross-platform compilation, for example ESP-IDF builds trying to compile Arduino-specific C++ files.

Deriving the PlatformIO filter from the CMake platform profile avoids duplicating the source list in `extra_script.py` and keeps PlatformIO aligned with the existing CMake platform selection.

### Related Issues

Related to PlatformIO build failures where ESP-IDF attempted to compile Arduino ESP32 transport sources.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->