### PR TITLE
Pin Espressif32 platform in ESP-IDF CI

### DIFF
--- a/.github/workflows/espidf.yaml
+++ b/.github/workflows/espidf.yaml
@@ -40,10 +40,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install PlatformIO Core
-        run: |
-          # Temporary workaround: PlatformIO 6.1.19 exposes the platform source-selection issue.
-          # Remove this pin once PlatformIO/CMake platform source selection is fixed properly.
-          pip install "platformio==6.1.18"
+        run: pip install --upgrade platformio
 
       - name: Set up project
         run: |
@@ -53,7 +50,15 @@ jobs:
 
           mkdir -p $ESPIDF_BASE
           cd $ESPIDF_BASE
-          pio init -b az-delivery-devkit-v4 -O "board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1" --project-option="framework=espidf" --project-option="build_flags=-DZENOH_ESPIDF -DZENOH_LOG_DEBUG"
+          # Temporary workaround: espressif32@7.0.0 pulls in ESP-IDF 6.0 and exposes
+          # the existing PlatformIO source-selection issue after the platform
+          # restructuring from #1188. Remove this pin once PlatformIO integration is
+          # aligned with the new platform structure.
+          pio init -b az-delivery-devkit-v4 \
+            --project-option="platform=espressif32@6.13.0" \
+            --project-option="framework=espidf" \
+            --project-option="build_flags=-DZENOH_ESPIDF -DZENOH_LOG_DEBUG" \
+            -O "board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1"
 
           cd $ESPIDF_BASE/lib
           ln -s $ZENOH_PICO_BASE

--- a/.github/workflows/espidf.yaml
+++ b/.github/workflows/espidf.yaml
@@ -40,7 +40,10 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: |
+          # Temporary workaround: PlatformIO 6.1.19 exposes the platform source-selection issue.
+          # Remove this pin once PlatformIO/CMake platform source selection is fixed properly.
+          pip install "platformio==6.1.18"
 
       - name: Set up project
         run: |


### PR DESCRIPTION
## Description

This PR pins the PlatformIO Espressif32 platform used by the ESP-IDF CI workflow to `6.13.0`.

The workflow previously allowed PlatformIO to install the latest Espressif32 platform, which now resolves to `7.0.0`. That release pulls in ESP-IDF 6.0 and exposes the existing PlatformIO source-selection issue after the platform restructuring from #1188.

## What does this PR do?

- Pins the ESP-IDF CI workflow to `espressif32@6.13.0`.
- Avoids the recent `espressif32@7.0.0` behaviour in CI.
- Restores the previous CI behaviour as a short-term workaround.

## Why is this change needed?

`espressif32@7.0.0` causes the ESP-IDF PlatformIO build to compile platform-specific sources that are not valid for the selected build, including the Arduino ESP32 Bluetooth backend.

This pin is intended as a temporary workaround only. The proper fix should be handled separately by aligning the PlatformIO integration with the platform restructuring introduced by #1188.

## Related Issues

Follow-up to #1188.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->