### PR TITLE
Reconnect to the last endpoint without restarting tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,8 +492,11 @@ jobs:
 
   connection_restore_test:
     needs: zenoh_build
-    name: Connection restore test
+    name: Connection restore test (multi-thread=${{ matrix.multi_thread }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        multi_thread: [1, 0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -510,8 +513,14 @@ jobs:
         run: |
           sudo apt install -y ninja-build
           CMAKE_GENERATOR=Ninja ASAN=ON CMAKE_BUILD_TYPE=Debug ZENOH_DEBUG=3 make
-          RUST_LOG=debug sudo python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
+          if [ "$Z_FEATURE_MULTI_THREAD" = "0" ]; then
+            RUST_LOG=debug sudo python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd --single-thread
+          else
+            RUST_LOG=debug sudo python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
+          fi
         timeout-minutes: 20
+        env:
+          Z_FEATURE_MULTI_THREAD: ${{ matrix.multi_thread }}
 
   routed_peer_client_test:
     needs: zenoh_build

--- a/include/zenoh-pico/net/session.h
+++ b/include/zenoh-pico/net/session.h
@@ -152,6 +152,7 @@ typedef struct _z_session_t {
 
 #if Z_FEATURE_AUTO_RECONNECT == 1
     _z_network_message_slist_t *_declaration_cache;
+    _z_string_t _last_connect_locator;
 #endif
 
     // Session subscriptions

--- a/include/zenoh-pico/transport/manager.h
+++ b/include/zenoh-pico/transport/manager.h
@@ -31,6 +31,9 @@ enum _z_peer_op_e {
 
 z_result_t _z_new_transport(_z_transport_t *zt, const _z_id_t *bs, const _z_string_t *locator, z_whatami_t mode,
                             int peer_op, const _z_config_t *session_cfg, _z_runtime_t *runtime);
+bool _z_transport_in_place_reconnect_supported(const _z_transport_t *zt, z_whatami_t mode);
+z_result_t _z_reopen_client_unicast_transport(_z_transport_unicast_t *ztu, const _z_id_t *local_zid,
+                                              const _z_string_t *locator, const _z_config_t *session_cfg);
 z_result_t _z_new_peer(_z_transport_t *zt, const _z_id_t *session_id, const _z_string_t *locator,
                        const _z_config_t *session_cfg);
 bool _z_transport_open_error_is_retryable(z_result_t ret);

--- a/include/zenoh-pico/transport/unicast/transport.h
+++ b/include/zenoh-pico/transport/unicast/transport.h
@@ -31,6 +31,8 @@ z_result_t _z_unicast_open_peer(_z_transport_unicast_establish_param_t *param, c
                                 const _z_id_t *local_zid, int peer_op, _z_sys_net_socket_t *socket);
 z_result_t _z_unicast_send_close(_z_transport_unicast_t *ztu, uint8_t reason, bool link_only);
 z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reason);
+void _z_unicast_transport_clear_connection(_z_transport_unicast_t *ztu);
+void _z_unicast_transport_replace_connection(_z_transport_unicast_t *dst, _z_transport_unicast_t *src);
 void _z_unicast_transport_clear(_z_transport_unicast_t *ztu);
 
 #ifdef __cplusplus

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -31,6 +31,7 @@
 #include "zenoh-pico/transport/common/lease.h"
 #include "zenoh-pico/transport/common/read.h"
 #include "zenoh-pico/transport/common/tx.h"
+#include "zenoh-pico/transport/manager.h"
 #include "zenoh-pico/transport/multicast.h"
 #include "zenoh-pico/transport/multicast/lease.h"
 #include "zenoh-pico/transport/multicast/read.h"
@@ -39,6 +40,7 @@
 #include "zenoh-pico/transport/unicast.h"
 #include "zenoh-pico/transport/unicast/lease.h"
 #include "zenoh-pico/transport/unicast/read.h"
+#include "zenoh-pico/transport/unicast/transport.h"
 #include "zenoh-pico/utils/config.h"
 #include "zenoh-pico/utils/logging.h"
 #include "zenoh-pico/utils/result.h"
@@ -130,6 +132,34 @@ static z_result_t _z_config_get_mode(const _z_config_t *config, z_whatami_t *mod
     return ret;
 }
 
+typedef enum {
+    _Z_OPEN_CONNECT_DEFAULT,
+#if Z_FEATURE_AUTO_RECONNECT == 1
+    _Z_OPEN_CONNECT_CLIENT_UNICAST_RECONNECT,
+#endif
+} _z_open_connect_mode_t;
+
+typedef struct {
+    const _z_string_t *_preferred_locator;
+    _z_open_connect_mode_t _connect_mode;
+#if Z_FEATURE_AUTO_RECONNECT == 1
+    _z_transport_unicast_t *_reconnect_unicast;
+#endif
+} _z_open_options_t;
+
+#if Z_FEATURE_AUTO_RECONNECT == 1
+static void _z_session_update_last_connect_locator(_z_session_t *s, const _z_string_t *locator) {
+    _z_string_t copy = _z_string_null();
+    if (_z_string_copy(&copy, locator) != _Z_RES_OK) {
+        _Z_DEBUG("Failed to update last successful connect locator");
+        _z_string_clear(&s->_last_connect_locator);
+        return;
+    }
+    _z_string_clear(&s->_last_connect_locator);
+    (void)_z_string_move(&s->_last_connect_locator, &copy);
+}
+#endif
+
 static z_result_t _z_open_inner(_z_session_rc_t *zs, _z_string_t *locator, const _z_id_t *zid, int peer_op,
                                 const _z_config_t *config) {
     z_result_t ret = _Z_RES_OK;
@@ -141,12 +171,87 @@ static z_result_t _z_open_inner(_z_session_rc_t *zs, _z_string_t *locator, const
     }
     _z_transport_get_common(&zn->_tp)->_session = _z_session_rc_clone_as_weak(zs);
     _z_transport_get_common(&zn->_tp)->_state = _Z_TRANSPORT_STATE_OPEN;
+#if Z_FEATURE_AUTO_RECONNECT == 1
+    if ((zn->_mode == Z_WHATAMI_CLIENT) && (peer_op == _Z_PEER_OP_OPEN)) {
+        _z_session_update_last_connect_locator(zn, locator);
+    }
+#endif
 #if Z_FEATURE_MULTICAST_DECLARATIONS == 1
     if (zn->_tp._type == _Z_TRANSPORT_MULTICAST_TYPE) {
         ret = _z_interest_pull_resource_from_peers(zn);
     }
 #endif
     return ret;
+}
+
+static void _z_open_options_default(_z_open_options_t *opts) {
+    opts->_preferred_locator = NULL;
+    opts->_connect_mode = _Z_OPEN_CONNECT_DEFAULT;
+#if Z_FEATURE_AUTO_RECONNECT == 1
+    opts->_reconnect_unicast = NULL;
+#endif
+}
+
+static bool _z_open_has_preferred_locator(const _z_open_options_t *opts) {
+    return (opts != NULL) && (opts->_preferred_locator != NULL) && _z_string_check(opts->_preferred_locator);
+}
+
+static z_result_t _z_open_connect_single_locator(_z_session_rc_t *zs, _z_string_t *locator, const _z_id_t *zid,
+                                                 const _z_config_t *config, const _z_open_options_t *opts) {
+    switch (opts->_connect_mode) {
+        case _Z_OPEN_CONNECT_DEFAULT:
+            return _z_open_inner(zs, locator, zid, _Z_PEER_OP_OPEN, config);
+#if Z_FEATURE_AUTO_RECONNECT == 1
+        case _Z_OPEN_CONNECT_CLIENT_UNICAST_RECONNECT: {
+            if (opts->_reconnect_unicast == NULL) {
+                return _Z_ERR_GENERIC;
+            }
+            z_result_t ret = _z_reopen_client_unicast_transport(opts->_reconnect_unicast, zid, locator, config);
+            if (ret != _Z_RES_OK) {
+                return ret;
+            }
+            _z_session_update_last_connect_locator(_Z_RC_IN_VAL(zs), locator);
+            return _Z_RES_OK;
+        }
+#endif
+        default:
+            return _Z_ERR_GENERIC;
+    }
+}
+
+static z_result_t _z_open_append_locator_copy(_z_string_svec_t *dst, const _z_string_t *locator) {
+    _z_string_t copy = _z_string_null();
+    _Z_RETURN_IF_ERR(_z_string_copy(&copy, locator));
+    z_result_t ret = _z_string_svec_append(dst, &copy, false);
+    if (ret != _Z_RES_OK) {
+        _z_string_clear(&copy);
+    }
+    return ret;
+}
+
+static z_result_t _z_open_order_connect_locators(_z_string_svec_t *ordered_locators,
+                                                 const _z_string_svec_t *connect_locators,
+                                                 const _z_open_options_t *opts) {
+    *ordered_locators = _z_string_svec_null();
+    const _z_string_t *preferred_locator = NULL;
+    if (_z_open_has_preferred_locator(opts)) {
+        preferred_locator = opts->_preferred_locator;
+        _Z_RETURN_IF_ERR(_z_open_append_locator_copy(ordered_locators, preferred_locator));
+    }
+
+    size_t connect_len = _z_string_svec_len(connect_locators);
+    for (size_t i = 0; i < connect_len; i++) {
+        _z_string_t *locator = _z_string_svec_get(connect_locators, i);
+        if ((preferred_locator != NULL) && _z_string_equals(locator, preferred_locator)) {
+            continue;
+        }
+        z_result_t ret = _z_open_append_locator_copy(ordered_locators, locator);
+        if (ret != _Z_RES_OK) {
+            _z_string_svec_clear(ordered_locators);
+            return ret;
+        }
+    }
+    return _Z_RES_OK;
 }
 
 static int32_t _z_get_remaining_timeout_ms(z_clock_t *start, int32_t timeout_ms) {
@@ -188,10 +293,13 @@ typedef struct {
  */
 static z_result_t _z_open_connect_locator(_z_session_rc_t *zn, _z_pending_peers_t *pending_peers, const _z_id_t *zid,
                                           _z_config_t *config, int32_t timeout_ms, bool exit_on_non_retryable_failure,
-                                          _z_open_connect_result_t *out) {
+                                          const _z_open_options_t *opts, _z_open_connect_result_t *out) {
     size_t connect_len = _z_pending_peer_svec_len(&pending_peers->_peers);
     z_result_t last_retryable_ret = _Z_ERR_TRANSPORT_OPEN_FAILED;
     z_result_t last_non_retryable_ret = _Z_RES_OK;
+    if (opts == NULL) {
+        return _Z_ERR_GENERIC;
+    }
 
     out->transport_opened = false;
     out->remaining_timeout_ms = timeout_ms;
@@ -215,7 +323,7 @@ static z_result_t _z_open_connect_locator(_z_session_rc_t *zn, _z_pending_peers_
 
             _z_string_t *locator = &peer->_locator;
 
-            ret = _z_open_inner(zn, locator, zid, _Z_PEER_OP_OPEN, config);
+            ret = _z_open_connect_single_locator(zn, locator, zid, config, opts);
             if (ret == _Z_RES_OK) {
                 out->transport_opened = true;
                 peer->_state = _Z_PENDING_PEER_STATE_DONE;
@@ -266,19 +374,24 @@ static z_result_t _z_open_connect_locator(_z_session_rc_t *zn, _z_pending_peers_
 }
 
 z_result_t _z_open_locators_client(_z_session_rc_t *zn, const _z_string_svec_t *connect_locators, const _z_id_t *zid,
-                                   _z_config_t *config, int32_t timeout_ms) {
-    size_t connect_len = _z_string_svec_len(connect_locators);
+                                   _z_config_t *config, int32_t timeout_ms, const _z_open_options_t *opts) {
+    _z_string_svec_t ordered_locators = _z_string_svec_null();
+    _Z_RETURN_IF_ERR(_z_open_order_connect_locators(&ordered_locators, connect_locators, opts));
+    size_t connect_len = _z_string_svec_len(&ordered_locators);
 
     if (connect_len == 0) {
         _Z_ERROR("No connect locators configured in client mode");
+        _z_string_svec_clear(&ordered_locators);
         return _Z_ERR_CONFIG_LOCATOR_INVALID;
     }
 
     _z_pending_peers_t pending_peers = _z_pending_peers_null();
-    _Z_RETURN_IF_ERR(_z_pending_peers_copy_from_locators(&pending_peers, connect_locators));
+    _Z_CLEAN_RETURN_IF_ERR(_z_pending_peers_copy_from_locators(&pending_peers, &ordered_locators),
+                           _z_string_svec_clear(&ordered_locators));
     _z_open_connect_result_t connect_result;
-    z_result_t ret = _z_open_connect_locator(zn, &pending_peers, zid, config, timeout_ms, false, &connect_result);
+    z_result_t ret = _z_open_connect_locator(zn, &pending_peers, zid, config, timeout_ms, false, opts, &connect_result);
     _z_pending_peers_clear(&pending_peers);
+    _z_string_svec_clear(&ordered_locators);
     return ret;
 }
 
@@ -346,8 +459,10 @@ z_result_t _z_open_locators_peer(_z_session_rc_t *zn, _z_string_t *listen_locato
     int32_t remaining_timeout_ms = connect_timeout_ms;
     if (!transport_opened && (connect_len > 0)) {
         _z_open_connect_result_t connect_result;
+        _z_open_options_t default_opts;
+        _z_open_options_default(&default_opts);
         _Z_CLEAN_RETURN_IF_ERR(_z_open_connect_locator(zn, &pending_peers, zid, config, connect_timeout_ms,
-                                                       connect_exit_on_failure, &connect_result),
+                                                       connect_exit_on_failure, &default_opts, &connect_result),
                                _z_pending_peers_clear(&pending_peers));
         transport_opened = connect_result.transport_opened;
         remaining_timeout_ms = connect_result.remaining_timeout_ms;
@@ -392,7 +507,7 @@ static inline const char *_z_open_connect_exit_on_failure_default(z_whatami_t mo
 
 z_result_t _z_open_locators(_z_session_rc_t *zn, const _z_string_svec_t *listen_locators,
                             const _z_string_svec_t *connect_locators, const _z_id_t *zid, _z_config_t *config,
-                            z_whatami_t mode) {
+                            z_whatami_t mode, const _z_open_options_t *opts) {
     size_t listen_len = _z_string_svec_len(listen_locators);
     size_t connect_len = _z_string_svec_len(connect_locators);
 
@@ -453,7 +568,7 @@ z_result_t _z_open_locators(_z_session_rc_t *zn, const _z_string_svec_t *listen_
 
     switch (mode) {
         case Z_WHATAMI_CLIENT:
-            return _z_open_locators_client(zn, connect_locators, zid, config, connect_timeout_ms);
+            return _z_open_locators_client(zn, connect_locators, zid, config, connect_timeout_ms, opts);
 
         case Z_WHATAMI_PEER: {
             _z_string_t *listen_locator = (listen_len == 1) ? _z_string_svec_get(listen_locators, 0) : NULL;
@@ -464,6 +579,71 @@ z_result_t _z_open_locators(_z_session_rc_t *zn, const _z_string_svec_t *listen_
         default:
             return _Z_ERR_CONFIG_INVALID_MODE;
     }
+}
+
+static z_result_t _z_open_common(_z_session_rc_t *zn, _z_config_t *config, const _z_id_t *zid,
+                                 const _z_open_options_t *opts) {
+    z_result_t ret = _Z_RES_OK;
+    _z_open_options_t default_opts;
+    if (opts == NULL) {
+        _z_open_options_default(&default_opts);
+        opts = &default_opts;
+    }
+
+    _z_string_svec_t listen_locators = _z_string_svec_null();
+    _z_string_svec_t connect_locators = _z_string_svec_null();
+
+    ret = _z_locators_by_config(config, &listen_locators, &connect_locators);
+    if (ret != _Z_RES_OK) {
+        goto exit;
+    }
+
+    z_whatami_t mode;
+    ret = _z_config_get_mode(config, &mode);
+    if (ret != _Z_RES_OK) {
+        goto exit;
+    }
+    _Z_RC_IN_VAL(zn)->_mode = mode;
+
+    if ((_z_string_svec_len(&listen_locators) > 0) || (_z_string_svec_len(&connect_locators) > 0)) {
+        ret = _z_open_locators(zn, &listen_locators, &connect_locators, zid, config, mode, opts);
+        goto exit;
+    }
+
+    if ((mode == Z_WHATAMI_CLIENT) && _z_open_has_preferred_locator(opts)) {
+        // Reconnect may have no configured connect locators when the previous open used scouting.
+        // Try the last successful locator before scouting again.
+        ret = _z_open_append_locator_copy(&connect_locators, opts->_preferred_locator);
+        if (ret != _Z_RES_OK) {
+            goto exit;
+        }
+
+        _z_open_options_t preferred_opts = *opts;
+        preferred_opts._preferred_locator = NULL;
+        ret = _z_open_locators(zn, &listen_locators, &connect_locators, zid, config, mode, &preferred_opts);
+        _z_string_svec_clear(&connect_locators);
+        if (ret == _Z_RES_OK) {
+            goto exit;
+        }
+    }
+
+    _z_open_options_t fallback_opts = *opts;
+    fallback_opts._preferred_locator = NULL;
+
+    ret = _z_locators_by_scout(config, zid, &connect_locators);
+    if (ret != _Z_RES_OK) {
+        goto exit;
+    }
+    if (_z_string_svec_len(&connect_locators) == 0) {
+        ret = _Z_ERR_SCOUT_NO_RESULTS;
+        goto exit;
+    }
+    ret = _z_open_locators(zn, &listen_locators, &connect_locators, zid, config, mode, &fallback_opts);
+
+exit:
+    _z_string_svec_clear(&listen_locators);
+    _z_string_svec_clear(&connect_locators);
+    return ret;
 }
 
 /**
@@ -508,40 +688,24 @@ z_result_t _z_open_locators(_z_session_rc_t *zn, const _z_string_svec_t *listen_
  *   failure (e.g. exit-on-failure with incomplete connectivity).
  */
 z_result_t _z_open(_z_session_rc_t *zn, _z_config_t *config, const _z_id_t *zid) {
-    z_result_t ret = _Z_RES_OK;
     _Z_RC_IN_VAL(zn)->_tp._type = _Z_TRANSPORT_NONE;
+    _z_open_options_t opts;
+    _z_open_options_default(&opts);
 
-    _z_string_svec_t listen_locators = _z_string_svec_null();
-    _z_string_svec_t connect_locators = _z_string_svec_null();
-
-    ret = _z_locators_by_config(config, &listen_locators, &connect_locators);
-    if (ret == _Z_RES_OK) {
-        z_whatami_t mode;
-        ret = _z_config_get_mode(config, &mode);
-        if (ret == _Z_RES_OK) {
-            _Z_RC_IN_VAL(zn)->_mode = mode;
-
-            if ((_z_string_svec_len(&listen_locators) > 0) || (_z_string_svec_len(&connect_locators) > 0)) {
-                ret = _z_open_locators(zn, &listen_locators, &connect_locators, zid, config, mode);
-            } else {
-                ret = _z_locators_by_scout(config, zid, &connect_locators);
-                if (ret == _Z_RES_OK) {
-                    if (_z_string_svec_len(&connect_locators) == 0) {
-                        ret = _Z_ERR_SCOUT_NO_RESULTS;
-                    } else {
-                        ret = _z_open_locators(zn, &listen_locators, &connect_locators, zid, config, mode);
-                    }
-                }
-            }
-        }
-    }
-
-    _z_string_svec_clear(&listen_locators);
-    _z_string_svec_clear(&connect_locators);
-    return ret;
+    return _z_open_common(zn, config, zid, &opts);
 }
 
 #if Z_FEATURE_AUTO_RECONNECT == 1
+static z_result_t _z_client_reopen_unicast(_z_session_rc_t *zs) {
+    _z_session_t *s = _Z_RC_IN_VAL(zs);
+    _z_open_options_t opts;
+    _z_open_options_default(&opts);
+    opts._preferred_locator = &s->_last_connect_locator;
+    opts._connect_mode = _Z_OPEN_CONNECT_CLIENT_UNICAST_RECONNECT;
+    opts._reconnect_unicast = &s->_tp._transport._unicast;
+    return _z_open_common(zs, &s->_config, &s->_local_zid, &opts);
+}
+
 void _z_client_reopen_task_drop(void *ztc_arg) {
     _z_transport_common_t *tc = (_z_transport_common_t *)ztc_arg;
     if (tc->_state == _Z_TRANSPORT_STATE_RECONNECTING) {
@@ -555,35 +719,46 @@ _z_fut_fn_result_t _z_client_reopen_task_fn(void *ztc_arg, _z_executor_t *execut
     _z_transport_common_t *tc = (_z_transport_common_t *)ztc_arg;
     _z_transport_tasks_t tasks_handles = tc->_tasks;
     _z_session_rc_t zs = _z_session_weak_upgrade(&tc->_session);  // should not fail
+    if (_Z_RC_IS_NULL(&zs)) {
+        return _z_fut_fn_result_ready();
+    }
     _z_session_t *s = _Z_RC_IN_VAL(&zs);
-    _z_session_weak_drop(&tc->_session);
 
+    _z_session_transport_mutex_lock(s);
+    bool in_place_reconnect = _z_transport_in_place_reconnect_supported(&s->_tp, s->_mode);
+    if (!in_place_reconnect) {
+        _z_session_weak_drop(&tc->_session);
+    }
     if (_z_config_is_empty(&s->_config)) {
+        _z_session_transport_mutex_unlock(s);
         _z_session_rc_drop(&zs);
         return _z_fut_fn_result_ready();
     }
-    _z_session_transport_mutex_lock(s);
-    z_result_t ret = _z_open(&zs, &s->_config, &s->_local_zid);
-    _z_session_transport_mutex_unlock(s);
+
+    z_result_t ret = in_place_reconnect ? _z_client_reopen_unicast(&zs) : _z_open(&zs, &s->_config, &s->_local_zid);
     if (ret != _Z_RES_OK) {
-        if (ret == _Z_ERR_TRANSPORT_OPEN_FAILED || ret == _Z_ERR_SCOUT_NO_RESULTS ||
-            ret == _Z_ERR_TRANSPORT_TX_FAILED || ret == _Z_ERR_TRANSPORT_RX_FAILED ||
-            ret == _Z_ERR_TRANSPORT_RX_DURATION_EXPIRED || ret == _Z_ERR_TRANSPORT_OPEN_PARTIAL_CONNECTIVITY) {
+        _z_session_transport_mutex_unlock(s);
+        if ((ret == _Z_ERR_TRANSPORT_OPEN_FAILED) || (ret == _Z_ERR_SCOUT_NO_RESULTS) ||
+            (ret == _Z_ERR_TRANSPORT_TX_FAILED) || (ret == _Z_ERR_TRANSPORT_RX_FAILED) ||
+            (ret == _Z_ERR_TRANSPORT_RX_DURATION_EXPIRED) || (ret == _Z_ERR_TRANSPORT_OPEN_PARTIAL_CONNECTIVITY)) {
             _Z_DEBUG("Reopen failed, next try in 1s");
-            tc->_session = _z_session_rc_clone_as_weak(&zs);
+            if (!in_place_reconnect) {
+                tc->_session = _z_session_rc_clone_as_weak(&zs);
+            }
             tc->_state = _Z_TRANSPORT_STATE_RECONNECTING;
             tc->_tasks = tasks_handles;
             _z_session_rc_drop(&zs);
             return _z_fut_fn_result_wake_up_after(1000);
-        } else {
-            _Z_ERROR("Reopen failed, will not retry");
-            tc->_state = _Z_TRANSPORT_STATE_CLOSED;
-            _z_session_rc_drop(&zs);
-            return _z_fut_fn_result_ready();
         }
+        _Z_ERROR("Reopen failed, will not retry");
+        tc->_state = _Z_TRANSPORT_STATE_CLOSED;
+        _z_session_rc_drop(&zs);
+        return _z_fut_fn_result_ready();
     }
-
+    tc = _z_transport_get_common(&s->_tp);
     tc->_tasks = tasks_handles;
+    _z_session_transport_mutex_unlock(s);
+
     if (!_z_network_message_slist_is_empty(s->_declaration_cache)) {
         _z_network_message_slist_t *iter = s->_declaration_cache;
         while (iter != NULL) {
@@ -591,9 +766,17 @@ _z_fut_fn_result_t _z_client_reopen_task_fn(void *ztc_arg, _z_executor_t *execut
             ret = _z_send_n_msg(s, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
             if (ret != _Z_RES_OK) {
                 _Z_DEBUG("Send message during reopen failed: %i", ret);
-                _z_transport_clear(&s->_tp);
-                tc->_session = _z_session_rc_clone_as_weak(&zs);
-                tc->_state = _Z_TRANSPORT_STATE_RECONNECTING;
+                _z_session_transport_mutex_lock(s);
+                if (_z_transport_in_place_reconnect_supported(&s->_tp, s->_mode)) {
+                    tc = &s->_tp._transport._unicast._common;
+                    _z_unicast_transport_clear_connection(&s->_tp._transport._unicast);
+                } else {
+                    _z_transport_clear(&s->_tp);
+                    tc->_session = _z_session_rc_clone_as_weak(&zs);
+                    tc->_state = _Z_TRANSPORT_STATE_RECONNECTING;
+                }
+                tc->_tasks = tasks_handles;
+                _z_session_transport_mutex_unlock(s);
                 _z_session_rc_drop(&zs);
                 return _z_fut_fn_result_continue();
             }

--- a/src/session/utils.c
+++ b/src/session/utils.c
@@ -92,6 +92,7 @@ z_result_t _z_session_init(_z_session_t *zn, const _z_id_t *zid) {
     _z_config_init(&zn->_config);
 #if Z_FEATURE_AUTO_RECONNECT == 1
     zn->_declaration_cache = NULL;
+    zn->_last_connect_locator = _z_string_null();
 #endif
 
     // Initialize the data structs
@@ -189,6 +190,7 @@ z_result_t _z_session_close(_z_session_t *zn) {
     _Z_RETURN_IF_ERR(_z_session_mutex_lock(zn));
 #if Z_FEATURE_AUTO_RECONNECT == 1
     _z_network_message_slist_free(&zn->_declaration_cache);
+    _z_string_clear(&zn->_last_connect_locator);
 #endif
     _z_session_mutex_unlock(zn);
     _z_flush_local_resources(zn);

--- a/src/transport/common/tx.c
+++ b/src/transport/common/tx.c
@@ -273,8 +273,12 @@ z_result_t _z_transport_tx_send_t_msg(_z_transport_common_t *ztc, const _z_trans
     // If sending to a peer list, make sure the peer mutex is locked
     _z_transport_tx_mutex_lock(ztc, true);
 
-    ret = _z_transport_tx_send_t_msg_inner(ztc, t_msg, peers);
+    if (ztc->_state != _Z_TRANSPORT_STATE_OPEN) {
+        _z_transport_tx_mutex_unlock(ztc);
+        return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+    }
 
+    ret = _z_transport_tx_send_t_msg_inner(ztc, t_msg, peers);
     _z_transport_tx_mutex_unlock(ztc);
     return ret;
 }
@@ -298,6 +302,13 @@ static z_result_t _z_transport_tx_send_n_msg(_z_transport_common_t *ztc, const _
         return ret;
     }
     // Process message
+    if (ztc->_state != _Z_TRANSPORT_STATE_OPEN) {
+        if (!_z_transport_batch_hold_tx_mutex()) {
+            _z_transport_tx_mutex_unlock(ztc);
+        }
+        return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+    }
+
     ret = _z_transport_tx_send_n_msg_inner(ztc, n_msg, reliability, peers);
     if (!_z_transport_batch_hold_tx_mutex()) {
         _z_transport_tx_mutex_unlock(ztc);
@@ -309,6 +320,9 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
                                                _z_transport_peer_unicast_slist_t *peers) {
 #if Z_FEATURE_BATCHING == 1
     z_result_t ret = _Z_RES_OK;
+    if (ztc->_state != _Z_TRANSPORT_STATE_OPEN) {
+        return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+    }
     // Check batch size
     if (ztc->_batch_count > 0) {
         // Acquire the lock and drop the message if needed
@@ -320,6 +334,13 @@ static z_result_t _z_transport_tx_send_n_batch(_z_transport_common_t *ztc, z_con
             return ret;
         }
         // Send batch
+        if (ztc->_state != _Z_TRANSPORT_STATE_OPEN) {
+            if (!_z_transport_batch_hold_tx_mutex()) {
+                _z_transport_tx_mutex_unlock(ztc);
+            }
+            return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+        }
+
         _Z_DEBUG("Send network batch");
         ret = _z_transport_tx_flush_buffer(ztc, peers);
         if (!_z_transport_batch_hold_tx_mutex()) {
@@ -391,6 +412,10 @@ z_result_t _z_send_t_msg(_z_transport_t *zt, const _z_transport_message_t *t_msg
             ret = _z_transport_tx_send_t_msg(&zt->_transport._multicast._common, t_msg, NULL);
             break;
         case _Z_TRANSPORT_RAWETH_TYPE:
+            if (zt->_transport._raweth._common._state != _Z_TRANSPORT_STATE_OPEN) {
+                ret = _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+                break;
+            }
             ret = _z_raweth_send_t_msg(&zt->_transport._raweth._common, t_msg);
             break;
         default:
@@ -530,6 +555,10 @@ z_result_t _z_send_n_msg(_z_session_t *zn, const _z_network_message_t *z_msg, z_
                 _z_transport_tx_send_n_msg(&zn->_tp._transport._multicast._common, z_msg, reliability, cong_ctrl, NULL);
             break;
         case _Z_TRANSPORT_RAWETH_TYPE:
+            if (zn->_tp._transport._raweth._common._state != _Z_TRANSPORT_STATE_OPEN) {
+                ret = _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+                break;
+            }
             ret = _z_raweth_send_n_msg(zn, z_msg, reliability, cong_ctrl);
             break;
         default:

--- a/src/transport/manager.c
+++ b/src/transport/manager.c
@@ -16,6 +16,7 @@
 
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "zenoh-pico/link/transport/socket.h"
 #if Z_FEATURE_LINK_TLS == 1
@@ -64,6 +65,62 @@ static void _z_new_peer_dispatch_connected_event(_z_transport_unicast_t *ztu, co
 }
 #endif
 
+bool _z_transport_in_place_reconnect_supported(const _z_transport_t *zt, z_whatami_t mode) {
+    return (mode == Z_WHATAMI_CLIENT) && (zt->_type == _Z_TRANSPORT_UNICAST_TYPE);
+}
+
+static z_result_t _z_new_transport_client_unicast_from_link(_z_transport_t *zt, _z_link_t *zl,
+                                                            const _z_id_t *local_zid) {
+    _z_transport_unicast_establish_param_t tp_param = {0};
+    z_result_t ret = _z_unicast_open_client(&tp_param, zl, local_zid);
+    if (ret != _Z_RES_OK) {
+        _z_link_free(&zl);
+        return ret;
+    }
+    ret = _z_unicast_transport_create(zt, zl, &tp_param);
+    if (ret != _Z_RES_OK) {
+        return ret;
+    }
+
+    // Fill peer list
+    return _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(zl), false, NULL);
+}
+
+static z_result_t _z_new_transport_client_unicast(_z_transport_t *zt, const _z_id_t *local_zid,
+                                                  const _z_string_t *locator, const _z_config_t *session_cfg) {
+    _z_link_t *zl = (_z_link_t *)z_malloc(sizeof(_z_link_t));
+    if (zl == NULL) {
+        return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    memset(zl, 0, sizeof(_z_link_t));
+    z_result_t ret = _z_open_link(zl, locator, session_cfg);
+    if (ret != _Z_RES_OK) {
+        z_free(zl);
+        return ret;
+    }
+    if (zl->_cap._transport != Z_LINK_CAP_TRANSPORT_UNICAST) {
+        _z_link_free(&zl);
+        return _Z_ERR_TRANSPORT_NOT_AVAILABLE;
+    }
+
+    return _z_new_transport_client_unicast_from_link(zt, zl, local_zid);
+}
+
+z_result_t _z_reopen_client_unicast_transport(_z_transport_unicast_t *ztu, const _z_id_t *local_zid,
+                                              const _z_string_t *locator, const _z_config_t *session_cfg) {
+    _z_transport_t next = {0};
+    next._type = _Z_TRANSPORT_NONE;
+
+    z_result_t ret = _z_new_transport_client_unicast(&next, local_zid, locator, session_cfg);
+    if (ret != _Z_RES_OK) {
+        _z_transport_clear(&next);
+        return ret;
+    }
+
+    _z_unicast_transport_replace_connection(ztu, &next._transport._unicast);
+    return _Z_RES_OK;
+}
+
 static z_result_t _z_new_transport_client(_z_transport_t *zt, const _z_string_t *locator, const _z_id_t *local_zid,
                                           const _z_config_t *session_cfg) {
     z_result_t ret = _Z_RES_OK;
@@ -83,18 +140,7 @@ static z_result_t _z_new_transport_client(_z_transport_t *zt, const _z_string_t 
     switch (zl->_cap._transport) {
         // Unicast transport
         case Z_LINK_CAP_TRANSPORT_UNICAST: {
-            _z_transport_unicast_establish_param_t tp_param;
-            ret = _z_unicast_open_client(&tp_param, zl, local_zid);
-            if (ret != _Z_RES_OK) {
-                _z_link_free(&zl);
-                return ret;
-            }
-            ret = _z_unicast_transport_create(zt, zl, &tp_param);
-            // Fill peer list
-            if (ret == _Z_RES_OK) {
-                ret = _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(zl), false,
-                                                    NULL);
-            }
+            ret = _z_new_transport_client_unicast_from_link(zt, zl, local_zid);
             break;
         }
         // Multicast transport

--- a/src/transport/transport.c
+++ b/src/transport/transport.c
@@ -109,7 +109,7 @@ void _z_transport_free(_z_transport_t **zt) {
 #if Z_FEATURE_BATCHING == 1
 z_result_t _z_transport_start_batching(_z_transport_t *zt) {
     _z_transport_common_t *ztc = _z_transport_get_common(zt);
-    if (ztc == NULL) {
+    if ((ztc == NULL) || (ztc->_state != _Z_TRANSPORT_STATE_OPEN)) {
         _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_NOT_AVAILABLE);
     }
     if (ztc->_batch_state == _Z_BATCHING_ACTIVE) {
@@ -131,6 +131,10 @@ z_result_t _z_transport_stop_batching(_z_transport_t *zt) {
     _z_transport_common_t *ztc = _z_transport_get_common(zt);
     if (ztc == NULL) {
         _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_NOT_AVAILABLE);
+    }
+
+    if (ztc->_batch_state != _Z_BATCHING_ACTIVE) {
+        return _Z_RES_OK;
     }
 
 #if Z_FEATURE_BATCH_TX_MUTEX == 1

--- a/src/transport/unicast/lease.c
+++ b/src/transport/unicast/lease.c
@@ -73,6 +73,13 @@ z_result_t _zp_unicast_send_keep_alive(_z_transport_unicast_t *ztu) {
 }
 
 _z_fut_fn_result_t _zp_unicast_failed_result(_z_transport_unicast_t *ztu, _z_executor_t *executor) {
+    if (ztu->_common._state == _Z_TRANSPORT_STATE_CLOSED) {
+        return _z_fut_fn_result_ready();
+    }
+    if (ztu->_common._state == _Z_TRANSPORT_STATE_RECONNECTING) {
+        return _z_fut_fn_result_suspend();
+    }
+
     _z_session_t *zs = _z_transport_common_get_session(&ztu->_common);
 #if Z_FEATURE_LIVELINESS == 1 && Z_FEATURE_SUBSCRIPTION == 1
     _z_liveliness_subscription_undeclare_all(zs);
@@ -97,17 +104,28 @@ _z_fut_fn_result_t _zp_unicast_failed_result(_z_transport_unicast_t *ztu, _z_exe
     }
 #endif
     _z_unicast_transport_close(ztu, _Z_CLOSE_EXPIRED);
+#if Z_FEATURE_AUTO_RECONNECT == 1
+    _z_session_weak_t weak_session_clone = _z_session_weak_null();
+#endif
     _z_session_transport_mutex_lock(zs);
 #if Z_FEATURE_AUTO_RECONNECT == 1
-    // Store weak session to reuse for reconnection.
-    _z_session_weak_t weak_session_clone = _z_session_weak_clone(&ztu->_common._session);
-#endif
+    if (zs->_mode == Z_WHATAMI_CLIENT) {
+        _z_unicast_transport_clear_connection(ztu);
+    } else {
+        // Keep the legacy peer-mode reopen path: clear the transport storage and let _z_open() rebuild it.
+        weak_session_clone = _z_session_weak_clone(&ztu->_common._session);
+        _z_transport_clear(&zs->_tp);
+    }
+#else
     _z_transport_clear(&zs->_tp);
+#endif
     _z_session_transport_mutex_unlock(zs);
 
 #if Z_FEATURE_AUTO_RECONNECT == 1
-    ztu->_common._state = _Z_TRANSPORT_STATE_RECONNECTING;
-    ztu->_common._session = weak_session_clone;
+    if (zs->_mode != Z_WHATAMI_CLIENT) {
+        ztu->_common._state = _Z_TRANSPORT_STATE_RECONNECTING;
+        ztu->_common._session = weak_session_clone;
+    }
     _z_fut_t f = _z_fut_null();
     f._fut_arg = &ztu->_common;
     f._fut_fn = _z_client_reopen_task_fn;
@@ -115,11 +133,12 @@ _z_fut_fn_result_t _zp_unicast_failed_result(_z_transport_unicast_t *ztu, _z_exe
     if (_z_fut_handle_is_null(_z_executor_spawn(executor, &f))) {
         _Z_ERROR("Failed to spawn client reopen task after transport failure.");
         ztu->_common._state = _Z_TRANSPORT_STATE_CLOSED;
-        _z_session_weak_drop(&ztu->_common._session);
+        if (zs->_mode != Z_WHATAMI_CLIENT) {
+            _z_session_weak_drop(&ztu->_common._session);
+        }
         return _z_fut_fn_result_ready();
-    } else {
-        return _z_fut_fn_result_suspend();
     }
+    return _z_fut_fn_result_suspend();
 #else
     return _z_fut_fn_result_ready();
 #endif

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -324,6 +324,68 @@ z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reaso
     return _z_unicast_send_close(ztu, reason, false);
 }
 
+static void __unsafe_z_unicast_transport_clear_connection(_z_transport_unicast_t *ztu) {
+    _z_transport_peer_unicast_slist_free(&ztu->_peers);
+    _z_wbuf_clear(&ztu->_common._wbuf);
+    _z_zbuf_clear(&ztu->_common._zbuf);
+    _z_link_free(&ztu->_common._link);
+
+    ztu->_common._sn_res = 0;
+    ztu->_common._sn_tx_reliable = 0;
+    ztu->_common._sn_tx_best_effort = 0;
+    ztu->_common._lease = 0;
+    ztu->_common._transmitted = false;
+#if Z_FEATURE_BATCHING == 1
+    ztu->_common._batch_state = _Z_BATCHING_IDLE;
+    ztu->_common._batch_count = 0;
+#endif
+}
+
+void _z_unicast_transport_clear_connection(_z_transport_unicast_t *ztu) {
+    _z_transport_tx_mutex_lock(&ztu->_common, true);
+    ztu->_common._state = _Z_TRANSPORT_STATE_RECONNECTING;
+    _z_transport_peer_mutex_lock(&ztu->_common);
+    __unsafe_z_unicast_transport_clear_connection(ztu);
+    _z_transport_peer_mutex_unlock(&ztu->_common);
+    _z_transport_tx_mutex_unlock(&ztu->_common);
+}
+
+void _z_unicast_transport_replace_connection(_z_transport_unicast_t *dst, _z_transport_unicast_t *src) {
+    _z_transport_tx_mutex_lock(&dst->_common, true);
+    _z_transport_peer_mutex_lock(&dst->_common);
+
+    __unsafe_z_unicast_transport_clear_connection(dst);
+
+    dst->_common._link = src->_common._link;
+    dst->_common._wbuf = src->_common._wbuf;
+    dst->_common._zbuf = src->_common._zbuf;
+    dst->_common._sn_res = src->_common._sn_res;
+    dst->_common._sn_tx_reliable = src->_common._sn_tx_reliable;
+    dst->_common._sn_tx_best_effort = src->_common._sn_tx_best_effort;
+    dst->_common._lease = src->_common._lease;
+    dst->_common._transmitted = src->_common._transmitted;
+#if Z_FEATURE_BATCHING == 1
+    dst->_common._batch_state = src->_common._batch_state;
+    dst->_common._batch_count = src->_common._batch_count;
+#endif
+    dst->_peers = src->_peers;
+    dst->_common._state = _Z_TRANSPORT_STATE_OPEN;
+
+    src->_common._link = NULL;
+    src->_common._wbuf = _z_wbuf_null();
+    src->_common._zbuf = _z_zbuf_null();
+    src->_peers = NULL;
+
+    _z_transport_peer_mutex_unlock(&dst->_common);
+    _z_transport_tx_mutex_unlock(&dst->_common);
+
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_drop(&src->_common._mutex_tx);
+    _z_mutex_rec_drop(&src->_common._mutex_peer);
+#endif
+    _z_session_weak_drop(&src->_common._session);
+}
+
 void _z_unicast_transport_clear(_z_transport_unicast_t *ztu) {
     _z_transport_peer_unicast_slist_free(&ztu->_peers);
     _z_pending_peers_clear(&ztu->_pending_peers);
@@ -372,6 +434,11 @@ z_result_t _z_unicast_transport_close(_z_transport_unicast_t *ztu, uint8_t reaso
     _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_NOT_AVAILABLE);
 }
 
+void _z_unicast_transport_clear_connection(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
+void _z_unicast_transport_replace_connection(_z_transport_unicast_t *dst, _z_transport_unicast_t *src) {
+    _ZP_UNUSED(dst);
+    _ZP_UNUSED(src);
+}
 void _z_unicast_transport_clear(_z_transport_unicast_t *ztu) { _ZP_UNUSED(ztu); }
 
 #endif  // Z_FEATURE_UNICAST_TRANSPORT == 1

--- a/tests/connection_restore.py
+++ b/tests/connection_restore.py
@@ -26,6 +26,19 @@ PASSIVE_CLIENT_COMMAND = STDBUF_CMD + [f'{DIR_EXAMPLES}/z_sub', '-e', f'tcp/127.
 LIVELINESS_CLIENT_COMMAND = STDBUF_CMD + [f'{DIR_EXAMPLES}/z_liveliness', '-e', f'tcp/127.0.0.1:{ZENOH_PORT}']
 LIVELINESS_SUB_CLIENT_COMMAND = STDBUF_CMD + [f'{DIR_EXAMPLES}/z_sub_liveliness', '-h', '-e', f'tcp/127.0.0.1:{ZENOH_PORT}']
 
+SINGLE_THREAD_ZENOH_PORT = "7448"
+SINGLE_THREAD_ROUTER_ARGS = ['-l', f'tcp/0.0.0.0:{SINGLE_THREAD_ZENOH_PORT}', '--no-multicast-scouting']
+SINGLE_THREAD_ACTIVE_CLIENT_COMMAND = STDBUF_CMD + [
+    f'{DIR_EXAMPLES}/z_pub_st',
+    '-e',
+    f'tcp/127.0.0.1:{SINGLE_THREAD_ZENOH_PORT}',
+]
+SINGLE_THREAD_PASSIVE_CLIENT_COMMAND = STDBUF_CMD + [
+    f'{DIR_EXAMPLES}/z_sub_st',
+    '-e',
+    f'tcp/127.0.0.1:{SINGLE_THREAD_ZENOH_PORT}',
+]
+
 LIBASAN_PATH = subprocess.run(["gcc", "-print-file-name=libasan.so"], stdout=subprocess.PIPE, text=True, check=True).stdout.strip()
 
 
@@ -383,8 +396,20 @@ def test_pub_before_restart_then_new_sub(router_command, pub_command, sub_comman
 
 
 def main():
+    if len(sys.argv) == 3 and sys.argv[2] == "--single-thread":
+        router_command = STDBUF_CMD + [sys.argv[1]] + SINGLE_THREAD_ROUTER_ARGS
+        test_pub_sub_survive_router_restart(router_command,
+                                            SINGLE_THREAD_ACTIVE_CLIENT_COMMAND,
+                                            SINGLE_THREAD_PASSIVE_CLIENT_COMMAND,
+                                            8)
+        test_pub_before_restart_then_new_sub(router_command,
+                                             SINGLE_THREAD_ACTIVE_CLIENT_COMMAND,
+                                             SINGLE_THREAD_PASSIVE_CLIENT_COMMAND,
+                                             8)
+        return
+
     if len(sys.argv) != 2:
-        print("Usage: sudo python3 ./connection_restore.py /path/to/zenohd")
+        print("Usage: sudo python3 ./connection_restore.py /path/to/zenohd [--single-thread]")
         sys.exit(1)
 
     router_command = STDBUF_CMD + [sys.argv[1]] + ROUTER_ARGS


### PR DESCRIPTION
Avoid restarting transport tasks during client reconnect.
Reuse the existing client transport and try the last successful endpoint first.
If that fails, continue with the configured connect locators or scouted locators. Restore the connection without replacing the transport object.

Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/1005
Closes: https://github.com/eclipse-zenoh/zenoh-pico/issues/1053


<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->