### PR TITLE
fuzz(codec): Add fuzz tests for scouting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,11 @@ Module.symvers
 Mkfile.old
 dkms.conf
 .cache
+
+# Fuzz test related
+fuzz/corpus
+build-fuzz
+crash-*
+leak-*
+oom-*
+timeout-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,7 @@ option(BUILD_EXAMPLES "Use this to also build the examples." ON)
 option(BUILD_TOOLS "Use this to also build the tools." OFF)
 option(BUILD_TESTING "Use this to also build tests." ON)
 option(BUILD_INTEGRATION "Use this to also build integration tests." OFF)
+option(BUILD_FUZZERS "Use this to also build libFuzzer targets." OFF)
 option(ASAN "Enable AddressSanitizer." OFF)
 
 message(STATUS "Produce Debian and RPM packages: ${PACKAGING}")
@@ -627,6 +628,7 @@ message(STATUS "Build examples: ${BUILD_EXAMPLES}")
 message(STATUS "Build tools: ${BUILD_TOOLS}")
 message(STATUS "Build tests: ${BUILD_TESTING}")
 message(STATUS "Build integration: ${BUILD_INTEGRATION}")
+message(STATUS "Build fuzzers: ${BUILD_FUZZERS}")
 message(STATUS "AddressSanitizer: ${ASAN}")
 
 set(PICO_LIBS "")
@@ -708,6 +710,22 @@ endif()
 if(ASAN AND NOT MSVC)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+endif()
+
+if(BUILD_FUZZERS)
+  if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "BUILD_FUZZERS requires Clang/libFuzzer. Configure with CC=clang.")
+  endif()
+
+  foreach(_zp_fuzz_target IN ITEMS ${Libname}_static ${Libname}_shared)
+    if(TARGET ${_zp_fuzz_target})
+      target_compile_options(${_zp_fuzz_target} PRIVATE -fsanitize=fuzzer-no-link,address,undefined
+                                                     -fno-omit-frame-pointer)
+      target_link_options(${_zp_fuzz_target} PRIVATE -fsanitize=address,undefined)
+    endif()
+  endforeach()
+
+  add_subdirectory(fuzz)
 endif()
 
 if(BUILD_EXAMPLES)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/fuzz")
+
+add_executable(z_fuzz_scouting_message_decode
+               ${PROJECT_SOURCE_DIR}/fuzz/fuzz_scouting_message_decode.c)
+target_link_libraries(z_fuzz_scouting_message_decode zenohpico::lib)
+target_compile_options(z_fuzz_scouting_message_decode PRIVATE -fsanitize=fuzzer,address,undefined
+                                                              -fno-omit-frame-pointer)
+target_link_options(z_fuzz_scouting_message_decode PRIVATE -fsanitize=fuzzer,address,undefined)

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,86 @@
+# Fuzzing
+
+This folder contains `libFuzzer` targets for `zenoh-pico`.
+The following targets will be tested:
+
+- `z_fuzz_scouting_message_decode`: feeds arbitrary bytes into `_z_scouting_message_decode()`
+
+## Requirements
+
+- `clang`
+- CMake
+
+`BUILD_FUZZERS=ON` currently requires `clang` because the fuzz targets use
+LLVM `libFuzzer`.
+
+## Configure
+
+Create a dedicated build directory for fuzzing:
+
+```bash
+CC=clang cmake -B build-fuzz \
+  -DBUILD_FUZZERS=ON \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_EXAMPLES=OFF
+```
+
+This keeps the normal build separate from the fuzzing build.
+
+## Build
+
+Build the first fuzz target:
+
+```bash
+cmake --build build-fuzz --target z_fuzz_scouting_message_decode
+```
+
+The executable will be generated at:
+
+```bash
+build-fuzz/fuzz/z_fuzz_scouting_message_decode
+```
+
+## Run continuous fuzzing
+
+You can let `libFuzzer` keep mutating inputs:
+
+```bash
+mkdir -p fuzz/corpus/scouting_message_decode
+./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -timeout=5 \
+  fuzz/corpus/scouting_message_decode
+```
+
+## Useful options
+
+Run for a fixed number of executions:
+
+```bash
+./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -timeout=5 \
+  -runs=10000 \
+  fuzz/corpus/scouting_message_decode
+```
+
+Limit generated input size:
+
+```bash
+./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -timeout=5 \
+  -max_len=256 \
+  fuzz/corpus/scouting_message_decode
+```
+
+Replay a saved crashing input:
+
+```bash
+./build-fuzz/fuzz/z_fuzz_scouting_message_decode path/to/crash-input
+```
+
+## Clean up
+
+Remove the fuzzing build directory when you want a clean rebuild:
+
+```bash
+rm -rf build-fuzz
+```

--- a/fuzz/fuzz_scouting_message_decode.c
+++ b/fuzz/fuzz_scouting_message_decode.c
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "zenoh-pico/collections/slice.h"
+#include "zenoh-pico/protocol/codec/transport.h"
+#include "zenoh-pico/protocol/definitions/transport.h"
+#include "zenoh-pico/protocol/iobuf.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    _z_slice_t slice = _z_slice_alias_buf(data, size);
+    _z_zbuf_t zbf = _z_slice_as_zbuf(slice);
+    _z_scouting_message_t msg = {0};
+
+    (void)_z_scouting_message_decode(&msg, &zbf);
+    _z_s_msg_clear(&msg);
+
+    return 0;
+}


### PR DESCRIPTION
## Description

This PR adds the first libFuzzer target for `zenoh-pico` and wires it into the build as an optional fuzzing configuration. It gives the project a small, focused entry point for fuzzing scouting message decoding and documenting how to run it.

### What does this PR do?

- Adds a `BUILD_FUZZERS` CMake option and a dedicated `fuzz/` build directory.
- Adds a `libFuzzer` target for `_z_scouting_message_decode()`.
- Documents how to configure, build, and run the scouting message fuzzer.
- Adds ignore rules for fuzzing artifacts such as `build-fuzz`, `crash-*`, `leak-*`, `oom-*`, and `timeout-*`.

### Why is this change needed?

This creates the initial fuzzing infrastructure for `zenoh-pico` without affecting normal builds. It makes it easier to exercise the scouting decoder with malformed inputs and catch memory-safety or parsing issues early.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->