### PR TITLE
remove cmake install step for cpp ci

### DIFF
--- a/.github/workflows/cpp-check.yaml
+++ b/.github/workflows/cpp-check.yaml
@@ -42,11 +42,6 @@ jobs:
     - name: checkout zenoh-pico
       uses: actions/checkout@v3
 
-    - name: Install cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.31.x'
-
     - name: build zenoh-pico
       run: |
         mkdir build && cd build


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Remove unneeded cmake install step from cpp-check ci that fails on windows. 
### What does this PR do?
<!-- Describe the changes and their purpose -->
Remove unneeded cmake install step from cpp-check ci that fails on windows. 
### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Remove unneeded cmake install step from cpp-check ci that fails on windows. 

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->