### PR TITLE
fix: clear LRU cache values on eviction

### DIFF
--- a/include/zenoh-pico/collections/lru_cache.h
+++ b/include/zenoh-pico/collections/lru_cache.h
@@ -45,7 +45,8 @@ typedef struct _z_lru_cache_t {
 
 _z_lru_cache_t _z_lru_cache_init(size_t capacity);
 void *_z_lru_cache_get(_z_lru_cache_t *cache, void *value, _z_lru_val_cmp_f compare);
-z_result_t _z_lru_cache_insert(_z_lru_cache_t *cache, void *value, size_t value_size, _z_lru_val_cmp_f compare);
+z_result_t _z_lru_cache_insert(_z_lru_cache_t *cache, void *value, size_t value_size, _z_lru_val_cmp_f compare,
+                               z_element_clear_f clear);
 void _z_lru_cache_clear(_z_lru_cache_t *cache, z_element_clear_f clear);
 void _z_lru_cache_delete(_z_lru_cache_t *cache, z_element_clear_f clear);
 
@@ -56,7 +57,7 @@ void _z_lru_cache_delete(_z_lru_cache_t *cache, z_element_clear_f clear);
         return (type *)_z_lru_cache_get(cache, (void *)val, compare_f);                                             \
     }                                                                                                               \
     static inline z_result_t name##_lru_cache_insert(name##_lru_cache_t *cache, type *val) {                        \
-        return _z_lru_cache_insert(cache, (void *)val, sizeof(type), compare_f);                                    \
+        return _z_lru_cache_insert(cache, (void *)val, sizeof(type), compare_f, name##_elem_clear);                 \
     }                                                                                                               \
     static inline void name##_lru_cache_clear(name##_lru_cache_t *cache) {                                          \
         _z_lru_cache_clear(cache, name##_elem_clear);                                                               \

--- a/src/collections/lru_cache.c
+++ b/src/collections/lru_cache.c
@@ -193,14 +193,13 @@ static size_t _z_lru_cache_delete_slist(_z_lru_cache_t *cache, _z_lru_cache_node
 }
 
 // Main static functions
-static size_t _z_lru_cache_delete_last(_z_lru_cache_t *cache, _z_lru_val_cmp_f compare) {
+static _z_lru_cache_node_t *_z_lru_cache_detach_last(_z_lru_cache_t *cache, _z_lru_val_cmp_f compare, size_t *del_idx) {
     _z_lru_cache_node_t *last = cache->tail;
     assert(last != NULL);
     _z_lru_cache_remove_list_node(cache, last);
-    size_t del_idx = _z_lru_cache_delete_slist(cache, last, compare);
-    z_free(last);
+    *del_idx = _z_lru_cache_delete_slist(cache, last, compare);
     cache->len--;
-    return del_idx;
+    return last;
 }
 
 static void _z_lru_cache_insert_node(_z_lru_cache_t *cache, _z_lru_cache_node_t *node, _z_lru_val_cmp_f compare,
@@ -233,7 +232,8 @@ void *_z_lru_cache_get(_z_lru_cache_t *cache, void *value, _z_lru_val_cmp_f comp
     return _z_lru_cache_node_value(node);
 }
 
-z_result_t _z_lru_cache_insert(_z_lru_cache_t *cache, void *value, size_t value_size, _z_lru_val_cmp_f compare) {
+z_result_t _z_lru_cache_insert(_z_lru_cache_t *cache, void *value, size_t value_size, _z_lru_val_cmp_f compare,
+                               z_element_clear_f clear) {
     assert(cache->capacity > 0);
     // Init slist
     if (cache->slist == NULL) {
@@ -247,17 +247,22 @@ z_result_t _z_lru_cache_insert(_z_lru_cache_t *cache, void *value, size_t value_
     _z_lru_cache_node_t *node = _z_lru_cache_node_create(value, value_size);
     size_t *del_idx_addr = NULL;
     size_t del_idx = 0;
+    _z_lru_cache_node_t *deleted = NULL;
     if (node == NULL) {
         _Z_ERROR_RETURN(_Z_ERR_SYSTEM_OUT_OF_MEMORY);
     }
     // Check capacity
     if (cache->len == cache->capacity) {
-        // Delete lru entry
-        del_idx = _z_lru_cache_delete_last(cache, compare);
+        // Detach the LRU entry, but keep its value valid until the sorted list has been updated.
+        deleted = _z_lru_cache_detach_last(cache, compare, &del_idx);
         del_idx_addr = &del_idx;
     }
     // Update the cache
     _z_lru_cache_insert_node(cache, node, compare, del_idx_addr);
+    if (deleted != NULL) {
+        clear(_z_lru_cache_node_value(deleted));
+        z_free(deleted);
+    }
     return _Z_RES_OK;
 }
 

--- a/tests/z_lru_cache_test.c
+++ b/tests/z_lru_cache_test.c
@@ -29,6 +29,11 @@ typedef struct _dummy_t {
     int foo;
 } _dummy_t;
 
+typedef struct _owned_dummy_t {
+    int foo;
+    int *clear_count;
+} _owned_dummy_t;
+
 int _dummy_compare(const void *first, const void *second) {
     _dummy_t *d_first = (_dummy_t *)first;
     _dummy_t *d_second = (_dummy_t *)second;
@@ -44,6 +49,27 @@ int _dummy_compare(const void *first, const void *second) {
 static inline void _dummy_elem_clear(void *e) { _z_noop_clear((_dummy_t *)e); }
 
 _Z_LRU_CACHE_DEFINE(_dummy, _dummy_t, _dummy_compare)
+
+int _owned_dummy_compare(const void *first, const void *second) {
+    const _owned_dummy_t *d_first = (const _owned_dummy_t *)first;
+    const _owned_dummy_t *d_second = (const _owned_dummy_t *)second;
+
+    if (d_first->foo == d_second->foo) {
+        return 0;
+    } else if (d_first->foo > d_second->foo) {
+        return 1;
+    }
+    return -1;
+}
+
+static inline void _owned_dummy_elem_clear(void *e) {
+    _owned_dummy_t *d = (_owned_dummy_t *)e;
+    if (d->clear_count != NULL) {
+        (*d->clear_count)++;
+    }
+}
+
+_Z_LRU_CACHE_DEFINE(_owned_dummy, _owned_dummy_t, _owned_dummy_compare)
 
 void test_lru_init(void) {
     _dummy_lru_cache_t dcache = _dummy_lru_cache_init(CACHE_CAPACITY);
@@ -116,6 +142,34 @@ void test_lru_cache_deletion(void) {
         assert(res->foo == data[i].foo);
     }
     _dummy_lru_cache_delete(&dcache);
+}
+
+void test_lru_cache_deletion_clear(void) {
+    _owned_dummy_lru_cache_t dcache = _owned_dummy_lru_cache_init(2);
+
+    int clear_count = 0;
+    _owned_dummy_t data[3] = {{0, &clear_count}, {1, &clear_count}, {2, &clear_count}};
+    assert(_owned_dummy_lru_cache_insert(&dcache, &data[0]) == 0);
+    assert(_owned_dummy_lru_cache_insert(&dcache, &data[1]) == 0);
+    assert(clear_count == 0);
+
+    assert(_owned_dummy_lru_cache_insert(&dcache, &data[2]) == 0);
+    assert(clear_count == 1);
+    assert(_owned_dummy_lru_cache_get(&dcache, &data[0]) == NULL);
+
+    _owned_dummy_t *res = _owned_dummy_lru_cache_get(&dcache, &data[1]);
+    assert(res != NULL);
+    assert(res->foo == data[1].foo);
+    res = _owned_dummy_lru_cache_get(&dcache, &data[2]);
+    assert(res != NULL);
+    assert(res->foo == data[2].foo);
+
+    _owned_dummy_lru_cache_clear(&dcache);
+    assert(clear_count == 3);
+    assert(dcache.len == 0);
+    assert(dcache.head == NULL);
+    assert(dcache.tail == NULL);
+    _owned_dummy_lru_cache_delete(&dcache);
 }
 
 void test_lru_cache_update(void) {
@@ -259,6 +313,7 @@ int main(void) {
     test_lru_cache_insert();
     test_lru_cache_clear();
     test_lru_cache_deletion();
+    test_lru_cache_deletion_clear();
     test_lru_cache_update();
     test_lru_cache_random_val();
 #if 0


### PR DESCRIPTION
## Description

Fixes a memory leak in the generic LRU cache eviction path used by the RX cache.

### What does this PR do?

When the LRU cache reaches capacity, it evicts the least-recently-used node before inserting the new entry. The eviction path previously removed and freed the cache node, but did not clear the value stored inside it.

This PR updates the LRU insertion/eviction path so evicted values are cleared with the cache element clear callback before the node is freed. This matches the existing full-cache clear/delete behavior.

A regression test was added to verify that evicting an entry invokes the value clear callback.

### Why is this change needed?

With `Z_FEATURE_RX_CACHE` enabled, subscription/queryable cache entries own copied key expressions and cloned ref-counted vectors. If traffic uses more distinct key expressions than `Z_RX_CACHE_SIZE`, the RX cache churns and evicts old entries.

Before this fix, those evicted entries leaked their owned contents. In a scenario with 23 topics total, 12 received topics, and the default cache size of 10, memory usage grew significantly during RX cache churn.

After this fix, RX cache memory remains bounded by the configured cache capacity instead of growing with the number of evictions.

### Related Issues

N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->