### PR TITLE
Executor fix

### DIFF
--- a/include/zenoh-pico/runtime/executor.h
+++ b/include/zenoh-pico/runtime/executor.h
@@ -20,6 +20,7 @@
 
 #include "zenoh-pico/collections/atomic.h"
 #include "zenoh-pico/collections/refcount.h"
+#include "zenoh-pico/config.h"
 #include "zenoh-pico/system/platform.h"
 
 #ifdef __cplusplus
@@ -158,25 +159,19 @@ static inline void _z_fut_data_move(_z_fut_data_t *dst, _z_fut_data_t *src) {
 
 static inline size_t _z_size_fut_data_hmap_hash(const size_t *key) { return *key; }
 
-#ifndef _ZP_EXECUTOR_MAX_NUM_FUTURES
-#define _ZP_EXECUTOR_MAX_NUM_FUTURES 64
-#endif
-
-#define _ZP_EXECUTOR_MAX_FUT_BUCKET_COUNT (_ZP_EXECUTOR_MAX_NUM_FUTURES * 3 / 2)  // 0.66 load factor
-
 #define _ZP_STATIC_HASHMAP_TEMPLATE_KEY_TYPE size_t
 #define _ZP_STATIC_HASHMAP_TEMPLATE_VAL_TYPE _z_fut_data_t
 #define _ZP_STATIC_HASHMAP_TEMPLATE_NAME _z_fut_data_hmap
 #define _ZP_STATIC_HASHMAP_TEMPLATE_KEY_HASH_FN_NAME _z_size_fut_data_hmap_hash
-#define _ZP_STATIC_HASHMAP_TEMPLATE_BUCKET_COUNT _ZP_EXECUTOR_MAX_FUT_BUCKET_COUNT
-#define _ZP_STATIC_HASHMAP_TEMPLATE_CAPACITY _ZP_EXECUTOR_MAX_NUM_FUTURES
+#define _ZP_STATIC_HASHMAP_TEMPLATE_BUCKET_COUNT Z_RUNTIME_MAX_TASKS
+#define _ZP_STATIC_HASHMAP_TEMPLATE_CAPACITY Z_RUNTIME_MAX_TASKS
 #define _ZP_STATIC_HASHMAP_TEMPLATE_VAL_DESTROY_FN_NAME _z_fut_data_destroy
 #define _ZP_STATIC_HASHMAP_TEMPLATE_VAL_MOVE_FN_NAME _z_fut_data_move
 #include "zenoh-pico/collections/static_hashmap_template.h"
 
 #define _ZP_STATIC_DEQUE_TEMPLATE_ELEM_TYPE _z_fut_data_hmap_index_t
 #define _ZP_STATIC_DEQUE_TEMPLATE_NAME _z_fut_data_hmap_index_deque
-#define _ZP_STATIC_DEQUE_TEMPLATE_SIZE _ZP_EXECUTOR_MAX_NUM_FUTURES
+#define _ZP_STATIC_DEQUE_TEMPLATE_SIZE Z_RUNTIME_MAX_TASKS
 #include "zenoh-pico/collections/static_deque_template.h"
 
 // Compare two sleeping-task indices by their wake-up time stored in the hashmap.
@@ -196,7 +191,7 @@ static inline int _z_sleeping_fut_idx_cmp(const _z_fut_data_hmap_index_t *a, con
 #define _ZP_STATIC_PQUEUE_TEMPLATE_NAME _z_sleeping_fut_pqueue
 #define _ZP_STATIC_PQUEUE_TEMPLATE_CMP_CTX_TYPE _z_fut_data_hmap_t
 #define _ZP_STATIC_PQUEUE_TEMPLATE_ELEM_CMP_FN_NAME _z_sleeping_fut_idx_cmp
-#define _ZP_STATIC_PQUEUE_TEMPLATE_SIZE _ZP_EXECUTOR_MAX_NUM_FUTURES
+#define _ZP_STATIC_PQUEUE_TEMPLATE_SIZE Z_RUNTIME_MAX_TASKS
 #include "zenoh-pico/collections/static_pqueue_template.h"
 
 typedef struct _z_executor_t {

--- a/include/zenoh-pico/runtime/runtime.h
+++ b/include/zenoh-pico/runtime/runtime.h
@@ -17,7 +17,6 @@
 
 #include "zenoh-pico/config.h"
 
-#define _ZP_EXECUTOR_MAX_NUM_FUTURES Z_RUNTIME_MAX_TASKS
 #if Z_FEATURE_MULTI_THREAD == 1
 #include "zenoh-pico/runtime/background_executor.h"
 #else

--- a/src/runtime/executor.c
+++ b/src/runtime/executor.c
@@ -24,6 +24,7 @@ _z_fut_handle_t _z_executor_spawn(_z_executor_t *executor, _z_fut_t *fut) {
     _z_fut_data_hmap_index_t idx = _z_fut_data_hmap_insert(&executor->_tasks, &executor->_next_fut_id, &fut_data);
     _z_fut_handle_t handle = _z_fut_handle_null();
     if (!_z_fut_data_hmap_index_valid(idx)) {
+        _z_fut_data_destroy(&fut_data);
         return handle;
     }
     handle._id = executor->_next_fut_id;

--- a/tests/z_executor_test.c
+++ b/tests/z_executor_test.c
@@ -441,6 +441,34 @@ static void test_destroy_cleans_up_suspended(void) {
     assert(arg.destroyed == true);
 }
 
+// When the task pool is at capacity, spawn fails: the null handle is returned and
+// the future's destroy_fn is still invoked so no resources leak.
+static void test_spawn_fail_destroys_future(void) {
+    printf("Test: spawn failure properly destroys the future\n");
+    _z_executor_t ex = _z_executor_new();
+
+    // Fill every slot in the hashmap without spinning so all remain occupied.
+    // Keys 1..Z_RUNTIME_MAX_TASKS hash to distinct buckets (identity hash, no collisions).
+    test_arg_t fill_args[Z_RUNTIME_MAX_TASKS];
+    for (size_t i = 0; i < Z_RUNTIME_MAX_TASKS; i++) {
+        fill_args[i] = (test_arg_t){0};
+        _z_fut_t fut = _z_fut_new(&fill_args[i], fn_finish, NULL);
+        _z_fut_handle_t h = _z_executor_spawn(&ex, &fut);
+        assert(!_z_fut_handle_is_null(h));
+    }
+
+    // One more spawn must fail: the hashmap is at capacity.
+    test_arg_t overflow_arg = {0};
+    _z_fut_t overflow_fut = _z_fut_new(&overflow_arg, fn_finish, destroy_fn);
+    _z_fut_handle_t h = _z_executor_spawn(&ex, &overflow_fut);
+
+    assert(_z_fut_handle_is_null(h));        // spawn must signal failure via null handle
+    assert(overflow_arg.destroyed == true);  // destroy_fn must be called — no leak
+    assert(overflow_arg.call_count == 0);    // future body must never have run
+
+    _z_executor_destroy(&ex);
+}
+
 // ─── main ────────────────────────────────────────────────────────────────────
 
 int main(void) {
@@ -458,6 +486,7 @@ int main(void) {
     test_cancel_suspended();
     test_other_tasks_run_while_suspended();
     test_destroy_cleans_up_suspended();
+    test_spawn_fail_destroys_future();
     printf("All executor tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
remove _ZP_EXECUTOR_NUM_FUTURES setter - executor capacity is now taken directly from the configured Z_RUNTIME_MAX_TASKS;
increase load factor in executors's hashmap to 1 (it is ok for separate chaining);
Fix memory leak in _z_executor_spawn in case of failure to register the task;

### What does this PR do?
<!-- Describe the changes and their purpose -->
remove _ZP_EXECUTOR_NUM_FUTURES setter - executor capacity is now taken directly from the configured Z_RUNTIME_MAX_TASKS;
increase load factor in executors's hashmap to 1 (it is ok for separate chaining);
Fix memory leak in _z_executor_spawn in case of failure to register the task;

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
It fixes bugs: not correctly taken into account Z_RUNTIME_MAX_TASKS and a memory leak in _z_executor_spawn in case of failure.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->