### PR TITLE
fix(ci): make embedded workflows use checkout-relative paths

### DIFF
--- a/.github/workflows/arduino_esp32.yaml
+++ b/.github/workflows/arduino_esp32.yaml
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      ARDUINO_BASE: ${{ runner.temp }}/arduino_esp32project
+      ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,93 +44,65 @@ jobs:
 
       - name: Set up project
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          mkdir -p $ARDUINO_BASE
-          cd $ARDUINO_BASE
+          mkdir -p "$ARDUINO_BASE"
+          cd "$ARDUINO_BASE"
           pio init -b esp32thing_plus -O "-DZ_FEATURE_LINK_BLUETOOTH=1 -DZ_FEATURE_LINK_SERIAL=1" -O "build_flags=-DZENOH_COMPILER_GCC -DZENOH_LOG_DEBUG" -O "lib_ldf_mode=deep+"
 
-          cd $ARDUINO_BASE/lib
-          ln -s $ZENOH_PICO_BASE
+          cd "$ARDUINO_BASE/lib"
+          ln -sfn "$ZENOH_PICO_BASE" "$ARDUINO_BASE/lib/zenoh-pico"
 
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
 
       - name: Build z_pub example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_pub.ino" "$ARDUINO_BASE/src/z_pub.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_pub.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run
 
       - name: Build z_sub example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_sub.ino" "$ARDUINO_BASE/src/z_sub.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_sub.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run
 
       - name: Build z_pull example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_pull.ino" "$ARDUINO_BASE/src/z_pull.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_pull.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run
 
       - name: Build z_get example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_get.ino" "$ARDUINO_BASE/src/z_get.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_get.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run
 
       - name: Build z_queryable example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_queryable.ino" "$ARDUINO_BASE/src/z_queryable.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_queryable.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run
 
       - name: Build z_scout example
         run: |
-          cd $HOME
-          export ARDUINO_BASE=$HOME/work/arduino_esp32project/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ARDUINO_BASE"/src/*
+          cd "$ARDUINO_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/arduino/z_scout.ino" "$ARDUINO_BASE/src/z_scout.ino"
 
-          rm -rf $ARDUINO_BASE/src/*
-          cd $ARDUINO_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/arduino/z_scout.ino
-
-          cd $ARDUINO_BASE
+          cd "$ARDUINO_BASE"
           pio run

--- a/.github/workflows/arduino_esp32.yaml
+++ b/.github/workflows/arduino_esp32.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      ARDUINO_BASE: ${{ runner.temp }}/arduino_esp32project
+      ARDUINO_BASE: ${{ github.workspace }}/.ci/arduino_esp32project
       ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false

--- a/.github/workflows/espidf.yaml
+++ b/.github/workflows/espidf.yaml
@@ -27,6 +27,8 @@ jobs:
 
     env:
       IDF_COMPONENT_MANAGER: "0"   # ← disable pacman to avoid the pydantic crash
+      ESPIDF_BASE: ${{ runner.temp }}/espidfproject
+      ZENOH_PICO_BASE: ${{ github.workspace }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,12 +46,8 @@ jobs:
 
       - name: Set up project
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          mkdir -p $ESPIDF_BASE
-          cd $ESPIDF_BASE
+          mkdir -p "$ESPIDF_BASE"
+          cd "$ESPIDF_BASE"
           # Temporary workaround: espressif32@7.0.0 pulls in ESP-IDF 6.0 and exposes
           # the existing PlatformIO source-selection issue after the platform
           # restructuring from #1188. Remove this pin once PlatformIO integration is
@@ -60,85 +58,61 @@ jobs:
             --project-option="build_flags=-DZENOH_ESPIDF -DZENOH_LOG_DEBUG" \
             -O "board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1"
 
-          cd $ESPIDF_BASE/lib
-          ln -s $ZENOH_PICO_BASE
+          cd "$ESPIDF_BASE/lib"
+          ln -sfn "$ZENOH_PICO_BASE" "$ESPIDF_BASE/lib/zenoh-pico"
 
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
 
       - name: Build z_pub example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_pub.c" "$ESPIDF_BASE/src/z_pub.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_pub.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run
 
       - name: Build z_sub example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_sub.c" "$ESPIDF_BASE/src/z_sub.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_sub.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run
 
       - name: Build z_pull example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_pull.c" "$ESPIDF_BASE/src/z_pull.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_pull.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run
 
       - name: Build z_get example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_get.c" "$ESPIDF_BASE/src/z_get.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_get.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run
 
       - name: Build z_queryable example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_queryable.c" "$ESPIDF_BASE/src/z_queryable.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_queryable.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run
 
       - name: Build z_scout example
         run: |
-          cd $HOME
-          export ESPIDF_BASE=$HOME/work/espidfproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$ESPIDF_BASE"/src/*
+          cd "$ESPIDF_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/espidf/z_scout.c" "$ESPIDF_BASE/src/z_scout.c"
 
-          rm -rf $ESPIDF_BASE/src/*
-          cd $ESPIDF_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/espidf/z_scout.c
-
-          cd $ESPIDF_BASE
+          cd "$ESPIDF_BASE"
           pio run

--- a/.github/workflows/espidf.yaml
+++ b/.github/workflows/espidf.yaml
@@ -27,7 +27,7 @@ jobs:
 
     env:
       IDF_COMPONENT_MANAGER: "0"   # ← disable pacman to avoid the pydantic crash
-      ESPIDF_BASE: ${{ runner.temp }}/espidfproject
+      ESPIDF_BASE: ${{ github.workspace }}/.ci/espidfproject
       ZENOH_PICO_BASE: ${{ github.workspace }}
 
     steps:

--- a/.github/workflows/mbed.yaml
+++ b/.github/workflows/mbed.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      MBED_BASE: ${{ runner.temp }}/mbedproject
+      MBED_BASE: ${{ github.workspace }}/.ci/mbedproject
       ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false

--- a/.github/workflows/mbed.yaml
+++ b/.github/workflows/mbed.yaml
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      MBED_BASE: ${{ runner.temp }}/mbedproject
+      ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,93 +44,65 @@ jobs:
 
       - name: Set up project
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          mkdir -p $MBED_BASE
-          cd $MBED_BASE
+          mkdir -p "$MBED_BASE"
+          cd "$MBED_BASE"
           pio init -b nucleo_f767zi --project-option="framework=mbed" --project-option="board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1" -O "build_flags=-DZENOH_COMPILER_GCC -DZENOH_LOG_DEBUG"
 
-          cd $MBED_BASE/lib
-          ln -s $ZENOH_PICO_BASE
+          cd "$MBED_BASE/lib"
+          ln -sfn "$ZENOH_PICO_BASE" "$MBED_BASE/lib/zenoh-pico"
 
-          cd $MBED_BASE
+          cd "$MBED_BASE"
 
       - name: Build z_pub example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_pub.cpp" "$MBED_BASE/src/z_pub.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_pub.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run
 
       - name: Build z_sub example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_sub.cpp" "$MBED_BASE/src/z_sub.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_sub.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run
 
       - name: Build z_pull example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_pull.cpp" "$MBED_BASE/src/z_pull.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_pull.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run
 
       - name: Build z_get example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_get.cpp" "$MBED_BASE/src/z_get.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_get.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run
 
       - name: Build z_queryable example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_queryable.cpp" "$MBED_BASE/src/z_queryable.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_queryable.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run
 
       - name: Build z_scout example
         run: |
-          cd $HOME
-          export MBED_BASE=$HOME/work/mbedproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
+          rm -rf "$MBED_BASE"/src/*
+          cd "$MBED_BASE/src"
+          ln -sfn "$ZENOH_PICO_BASE/examples/mbed/z_scout.cpp" "$MBED_BASE/src/z_scout.cpp"
 
-          rm -rf $MBED_BASE/src/*
-          cd $MBED_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/mbed/z_scout.cpp
-
-          cd $MBED_BASE
+          cd "$MBED_BASE"
           pio run

--- a/.github/workflows/rpi_pico.yaml
+++ b/.github/workflows/rpi_pico.yaml
@@ -20,6 +20,8 @@ jobs:
   build:
     name: Build on ${{ matrix.os }} for ${{ matrix.pico_board }}
     runs-on: ${{ matrix.os }}
+    env:
+      ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +57,7 @@ jobs:
         run: |
           export PICO_SDK_PATH=$HOME/work/pico-sdk
           export FREERTOS_KERNEL_PATH=$HOME/work/FreeRTOS-Kernel/
-          cd $HOME/work/zenoh-pico/zenoh-pico/examples/rpi_pico
+          cd "$ZENOH_PICO_BASE/examples/rpi_pico"
           cmake -Bbuild -DWIFI_SSID=wifi_network_ssid -DWIFI_PASSWORD=wifi_network_password -DPICO_BOARD="$PICO_BOARD"
           cmake --build ./build
         env:

--- a/.github/workflows/zephyr.yaml
+++ b/.github/workflows/zephyr.yaml
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      ZEPHYR_BASE: ${{ runner.temp }}/zephyrproject
+      ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,96 +44,62 @@ jobs:
 
       - name: Set up project
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          mkdir -p $ZEPHYR_BASE
-          cd $ZEPHYR_BASE
+          mkdir -p "$ZEPHYR_BASE"
+          cd "$ZEPHYR_BASE"
           pio init -b nucleo_f767zi --project-option="framework=zephyr" --project-option="board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1" --project-option="build_flags=-DZENOH_LOG_DEBUG"
 
-          cd $ZEPHYR_BASE/lib
-          ln -s $ZENOH_PICO_BASE
+          cd "$ZEPHYR_BASE/lib"
+          ln -s "$ZENOH_PICO_BASE"
 
-          mkdir -p $ZEPHYR_BASE/zephyr
-          cd $ZEPHYR_BASE/zephyr
-          ln -s $ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/prj.conf prj.conf
-          ln -s $ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/CMakeLists.txt CMakeLists.txt
+          mkdir -p "$ZEPHYR_BASE/zephyr"
+          cd "$ZEPHYR_BASE/zephyr"
+          ln -s "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/prj.conf" prj.conf
+          ln -s "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/CMakeLists.txt" CMakeLists.txt
 
       - name: Build z_pub example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_pub.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_pub.c"
+          cd "$ZEPHYR_BASE"
           pio run
 
       - name: Build z_sub example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_sub.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_sub.c"
+          cd "$ZEPHYR_BASE"
           pio run
 
       - name: Build z_pull example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_pull.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_pull.c"
+          cd "$ZEPHYR_BASE"
           pio run
 
       - name: Build z_get example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_get.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_get.c"
+          cd "$ZEPHYR_BASE"
           pio run
 
       - name: Build z_queryable example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_queryable.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_queryable.c"
+          cd "$ZEPHYR_BASE"
           pio run
 
       - name: Build z_scout example
         run: |
-          cd $HOME
-          export ZEPHYR_BASE=$HOME/work/zephyrproject/
-          export ZENOH_PICO_BASE=$HOME/work/zenoh-pico/zenoh-pico/
-
-          rm -rf $ZEPHYR_BASE/src/*
-          cd $ZEPHYR_BASE/src
-          ln -s $ZENOH_PICO_BASE/examples/zephyr/z_scout.c
-
-          cd $ZEPHYR_BASE
+          rm -rf "$ZEPHYR_BASE"/src/*
+          cd "$ZEPHYR_BASE/src"
+          ln -s "$ZENOH_PICO_BASE/examples/zephyr/z_scout.c"
+          cd "$ZEPHYR_BASE"
           pio run

--- a/.github/workflows/zephyr.yaml
+++ b/.github/workflows/zephyr.yaml
@@ -49,12 +49,12 @@ jobs:
           pio init -b nucleo_f767zi --project-option="framework=zephyr" --project-option="board_build.cmake_extra_args=-DZ_FEATURE_LINK_SERIAL=1" --project-option="build_flags=-DZENOH_LOG_DEBUG"
 
           cd "$ZEPHYR_BASE/lib"
-          ln -s "$ZENOH_PICO_BASE"
+          ln -sfn "$ZENOH_PICO_BASE"
 
           mkdir -p "$ZEPHYR_BASE/zephyr"
           cd "$ZEPHYR_BASE/zephyr"
-          ln -s "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/prj.conf" prj.conf
-          ln -s "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/CMakeLists.txt" CMakeLists.txt
+          ln -sfn "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/prj.conf" prj.conf
+          ln -sfn "$ZENOH_PICO_BASE/docs/zephyr/nucleo_f767zi/CMakeLists.txt" CMakeLists.txt
 
       - name: Build z_pub example
         run: |

--- a/.github/workflows/zephyr.yaml
+++ b/.github/workflows/zephyr.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      ZEPHYR_BASE: ${{ runner.temp }}/zephyrproject
+      ZEPHYR_BASE: ${{ github.workspace }}/.ci/zephyrproject
       ZENOH_PICO_BASE: ${{ github.workspace }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

This PR updates the embedded CI workflows to stop depending on a hardcoded repository checkout path. It makes the same jobs work reliably when the repository name or checkout location differs between environments.

### What does this PR do?

- Updates the Arduino ESP32, ESP-IDF, Mbed, Raspberry Pi Pico, and Zephyr workflows to use `${{ github.workspace }}` instead of assuming the repo is checked out under a fixed `zenoh-pico` path.
- Moves the temporary project directories used by Arduino ESP32, ESP-IDF, Mbed, and Zephyr under workspace-local `.ci/...` paths.

### Why is this change needed?

These workflows were relying on paths like `/home/runner/work/zenoh-pico/zenoh-pico`, which happened to work in one repository layout but broke in others. This PR removes that assumption and makes the workflows use the actual checked-out workspace path, so the embedded CI jobs behave consistently across different repository setups.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
None.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->