### PR TITLE
fix(config): avoid malformed locator metadata crashes

### DIFF
--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -155,9 +155,9 @@ z_result_t _z_locator_metadata_from_string(_z_str_intmap_t *strint, const _z_str
     }
 
     size_t curr_len = _z_string_len(str) - start_offset;
-    const char *p_end = (char *)memchr(p_start, ENDPOINT_CONFIG_SEPARATOR, curr_len);
+    const char *p_end = memchr(p_start, ENDPOINT_CONFIG_SEPARATOR, curr_len);
     if (p_end == NULL) {
-        p_end = _z_cptr_char_offset(_z_string_data(str), (ptrdiff_t)_z_string_len(str));
+        p_end = _z_cptr_char_offset(p_start, (ptrdiff_t)curr_len);
     }
 
     if (p_start != p_end) {

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -162,7 +162,11 @@ z_result_t _z_locator_metadata_from_string(_z_str_intmap_t *strint, const _z_str
 
     if (p_start != p_end) {
         size_t p_len = _z_ptr_char_diff(p_end, p_start);
-        return _z_str_intmap_from_strn(strint, p_start, 0, NULL, p_len);
+        z_result_t ret = _z_str_intmap_from_strn(strint, p_start, 0, NULL, p_len);
+        if (ret == _Z_ERR_CONFIG_INVALID_VALUE) {
+            return _Z_ERR_CONFIG_LOCATOR_INVALID;
+        }
+        return ret;
     }
     return _Z_RES_OK;
 }

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -154,9 +154,10 @@ z_result_t _z_locator_metadata_from_string(_z_str_intmap_t *strint, const _z_str
         return _Z_RES_OK;
     }
 
-    const char *p_end = (char *)memchr(_z_string_data(str), ENDPOINT_CONFIG_SEPARATOR, _z_string_len(str));
+    size_t curr_len = _z_string_len(str) - start_offset;
+    const char *p_end = (char *)memchr(p_start, ENDPOINT_CONFIG_SEPARATOR, curr_len);
     if (p_end == NULL) {
-        p_end = _z_cptr_char_offset(_z_string_data(str), (ptrdiff_t)_z_string_len(str) + 1);
+        p_end = _z_cptr_char_offset(_z_string_data(str), (ptrdiff_t)_z_string_len(str));
     }
 
     if (p_start != p_end) {

--- a/src/protocol/config.c
+++ b/src/protocol/config.c
@@ -105,7 +105,9 @@ z_result_t _z_str_intmap_from_strn(_z_str_intmap_t *strint, const char *s, uint8
         const char *p_key_start = start;
         const char *p_key_end = memchr(p_key_start, INT_STR_MAP_KEYVALUE_SEPARATOR, curr_len);
 
-        if (p_key_end != NULL) {
+        if (p_key_end == NULL) {
+            break;
+        } else {
             // Verify the key is valid based on the provided mapping
             size_t p_key_len = _z_ptr_char_diff(p_key_end, p_key_start);
             bool found = false;

--- a/src/protocol/config.c
+++ b/src/protocol/config.c
@@ -106,7 +106,8 @@ z_result_t _z_str_intmap_from_strn(_z_str_intmap_t *strint, const char *s, uint8
         const char *p_key_end = memchr(p_key_start, INT_STR_MAP_KEYVALUE_SEPARATOR, curr_len);
 
         if (p_key_end == NULL) {
-            break;
+            _Z_ERROR_LOG(_Z_ERR_CONFIG_INVALID_VALUE);
+            return _Z_ERR_CONFIG_INVALID_VALUE;
         } else {
             // Verify the key is valid based on the provided mapping
             size_t p_key_len = _z_ptr_char_diff(p_key_end, p_key_start);

--- a/tests/z_endpoint_test.c
+++ b/tests/z_endpoint_test.c
@@ -75,6 +75,10 @@ int main(void) {
     assert(_z_locator_from_string(&lc, &str) == _Z_RES_OK);
     _z_locator_clear(&lc);
 
+    str = _z_string_alias_str("tcp/127.0.0.1:7447?invalid");
+    assert(_z_locator_from_string(&lc, &str) == _Z_ERR_CONFIG_INVALID_VALUE);
+    _z_locator_clear(&lc);
+
     // Endpoint
     printf(">>> Testing endpoints...\n");
 
@@ -118,6 +122,10 @@ int main(void) {
     // No metadata defined so far... but this is a valid syntax in principle
     str = _z_string_alias_str("tcp/127.0.0.1:7447?invalid=ctrl");
     assert(_z_endpoint_from_string(&ep, &str) == _Z_RES_OK);
+    _z_endpoint_clear(&ep);
+
+    str = _z_string_alias_str("tcp/127.0.0.1:7447?invalid");
+    assert(_z_endpoint_from_string(&ep, &str) != _Z_RES_OK);
     _z_endpoint_clear(&ep);
 
     str = _z_string_alias_str("udp/127.0.0.1:7447#iface=eth0");

--- a/tests/z_endpoint_test.c
+++ b/tests/z_endpoint_test.c
@@ -76,7 +76,7 @@ int main(void) {
     _z_locator_clear(&lc);
 
     str = _z_string_alias_str("tcp/127.0.0.1:7447?invalid");
-    assert(_z_locator_from_string(&lc, &str) == _Z_ERR_CONFIG_INVALID_VALUE);
+    assert(_z_locator_from_string(&lc, &str) == _Z_ERR_CONFIG_LOCATOR_INVALID);
     _z_locator_clear(&lc);
 
     // Endpoint
@@ -125,7 +125,7 @@ int main(void) {
     _z_endpoint_clear(&ep);
 
     str = _z_string_alias_str("tcp/127.0.0.1:7447?invalid");
-    assert(_z_endpoint_from_string(&ep, &str) != _Z_RES_OK);
+    assert(_z_endpoint_from_string(&ep, &str) == _Z_ERR_CONFIG_LOCATOR_INVALID);
     _z_endpoint_clear(&ep);
 
     str = _z_string_alias_str("udp/127.0.0.1:7447#iface=eth0");


### PR DESCRIPTION
## Description

This PR fixes two parser edge cases in locator metadata handling that could cause crashes or hangs when zenoh-pico receives malformed endpoint strings. It makes the metadata parsing logic stop cleanly at valid buffer boundaries and exit safely when input does not contain a valid key/value pair.

### What does this PR do?

The failure pattern: `tcp/127.0.0.1:7447?invalid`

- Fixes locator metadata parsing so it does not read past the end of the input buffer when no endpoint config separator is present.
- Updates string-to-config map parsing to stop safely when malformed metadata does not include a `=` separator.

### Why is this change needed?

Malformed endpoint metadata should never crash or hang the parser. Before this change, one code path could compute a metadata slice that extended past the input buffer, and another could loop indefinitely when the metadata format was incomplete. This PR tightens those bounds checks and exit conditions so invalid inputs are handled safely.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->