### PR TITLE
test(fuzz): add endpoint string fuzz target and CI build coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,40 @@ jobs:
             exit 1
           fi
 
+  fuzz_build_and_run:
+    name: Build and run fuzz targets on ubuntu-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure fuzz build
+        run: |
+          sudo apt update
+          sudo apt install -y clang ninja-build
+          CC=clang cmake -B build-fuzz -G Ninja \
+            -DBUILD_FUZZERS=ON \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_EXAMPLES=OFF
+
+      - name: Build fuzz targets
+        run: |
+          cmake --build build-fuzz --target z_fuzz_scouting_message_decode z_fuzz_endpoint_str
+
+      # TODO: Need to wait for the bugfix merged before enabling the smoke test
+      #- name: Run fuzz target smoke tests
+      #  run: |
+      #    mkdir -p fuzz/corpus/scouting_message_decode fuzz/corpus/endpoint_str
+      #    ./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+      #      -timeout=5 \
+      #      -runs=10000 \
+      #      fuzz/corpus/scouting_message_decode
+      #    ./build-fuzz/fuzz/z_fuzz_endpoint_str \
+      #      -timeout=5 \
+      #      -runs=10000 \
+      #      fuzz/corpus/endpoint_str
+
   run_windows_test:
     name: Run peer unicast test on windows-latest
     runs-on: windows-latest

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -6,3 +6,8 @@ target_link_libraries(z_fuzz_scouting_message_decode zenohpico::lib)
 target_compile_options(z_fuzz_scouting_message_decode PRIVATE -fsanitize=fuzzer,address,undefined
                                                               -fno-omit-frame-pointer)
 target_link_options(z_fuzz_scouting_message_decode PRIVATE -fsanitize=fuzzer,address,undefined)
+
+add_executable(z_fuzz_endpoint_str ${PROJECT_SOURCE_DIR}/fuzz/fuzz_endpoint_str.c)
+target_link_libraries(z_fuzz_endpoint_str zenohpico::lib)
+target_compile_options(z_fuzz_endpoint_str PRIVATE -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer)
+target_link_options(z_fuzz_endpoint_str PRIVATE -fsanitize=fuzzer,address,undefined)

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -3,6 +3,8 @@
 This folder contains `libFuzzer` targets for `zenoh-pico`.
 The following targets will be tested:
 
+- `z_fuzz_endpoint_str`: feeds arbitrary bytes into `_z_endpoint_from_string()`
+  and, on successful parses, round-trips them through `_z_endpoint_to_string()`
 - `z_fuzz_scouting_message_decode`: feeds arbitrary bytes into `_z_scouting_message_decode()`
 
 ## Requirements
@@ -28,16 +30,18 @@ This keeps the normal build separate from the fuzzing build.
 
 ## Build
 
-Build the first fuzz target:
+Build the fuzz targets:
 
 ```bash
 cmake --build build-fuzz --target z_fuzz_scouting_message_decode
+cmake --build build-fuzz --target z_fuzz_endpoint_str
 ```
 
-The executable will be generated at:
+The executables will be generated at:
 
 ```bash
 build-fuzz/fuzz/z_fuzz_scouting_message_decode
+build-fuzz/fuzz/z_fuzz_endpoint_str
 ```
 
 ## Run continuous fuzzing
@@ -46,9 +50,13 @@ You can let `libFuzzer` keep mutating inputs:
 
 ```bash
 mkdir -p fuzz/corpus/scouting_message_decode
+mkdir -p fuzz/corpus/endpoint_str
 ./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
   -timeout=5 \
   fuzz/corpus/scouting_message_decode
+./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -timeout=5 \
+  fuzz/corpus/endpoint_str
 ```
 
 ## Useful options
@@ -60,6 +68,10 @@ Run for a fixed number of executions:
   -timeout=5 \
   -runs=10000 \
   fuzz/corpus/scouting_message_decode
+./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -timeout=5 \
+  -runs=10000 \
+  fuzz/corpus/endpoint_str
 ```
 
 Limit generated input size:
@@ -69,12 +81,17 @@ Limit generated input size:
   -timeout=5 \
   -max_len=256 \
   fuzz/corpus/scouting_message_decode
+./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -timeout=5 \
+  -max_len=256 \
+  fuzz/corpus/endpoint_str
 ```
 
 Replay a saved crashing input:
 
 ```bash
 ./build-fuzz/fuzz/z_fuzz_scouting_message_decode path/to/crash-input
+./build-fuzz/fuzz/z_fuzz_endpoint_str path/to/crash-input
 ```
 
 ## Clean up

--- a/fuzz/fuzz_endpoint_str.c
+++ b/fuzz/fuzz_endpoint_str.c
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "zenoh-pico/collections/string.h"
+#include "zenoh-pico/link/endpoint.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    _z_string_t input = _z_string_alias_substr((const char *)data, size);
+    _z_endpoint_t endpoint = {0};
+
+    if (_z_endpoint_from_string(&endpoint, &input) != _Z_RES_OK) {
+        _z_endpoint_clear(&endpoint);
+        return 0;
+    }
+
+    _z_string_t endpoint_str = _z_endpoint_to_string(&endpoint);
+    if (_z_string_check(&endpoint_str)) {
+        _z_endpoint_t reparsed = {0};
+
+        (void)_z_endpoint_from_string(&reparsed, &endpoint_str);
+        _z_endpoint_clear(&reparsed);
+        _z_string_clear(&endpoint_str);
+    }
+
+    _z_endpoint_clear(&endpoint);
+    return 0;
+}


### PR DESCRIPTION
## Description

This PR adds fuzz coverage for endpoint string parsing and wires the fuzz targets into CI.

### What does this PR do?

- Adds a new `z_fuzz_endpoint_str` libFuzzer target that feeds arbitrary bytes into `_z_endpoint_from_string()` and round-trips successful parses through `_z_endpoint_to_string()`.
- Adds a CI job on Ubuntu that configures and builds the fuzz targets with Clang/libFuzzer.

### Why is this change needed?

Endpoint string parsing is a good fuzzing target because malformed inputs can exercise tricky parser paths that normal unit tests may miss. This PR adds direct fuzz coverage for that area and ensures CI keeps the fuzz targets building so regressions in the fuzz setup are caught early.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->