### PR TITLE
fix: bound keyexpr canonizer slash scan

### DIFF
--- a/src/session/keyexpr.c
+++ b/src/session/keyexpr.c
@@ -323,7 +323,7 @@ zp_keyexpr_canon_status_t _z_keyexpr_canonize(char *start, size_t *len) {
         char *reader = _z_ptr_char_offset(start, (ptrdiff_t)canon_len);
         const char *write_start = reader;
         char *writer = reader;
-        char *next_slash = strchr(reader, '/');
+        char *next_slash = memchr(reader, '/', _z_ptr_char_diff(end, reader));
         char const *chunk_end = (next_slash != NULL) ? next_slash : end;
 
         bool in_big_wild = false;

--- a/tests/z_keyexpr_test.c
+++ b/tests/z_keyexpr_test.c
@@ -374,6 +374,10 @@ void test_keyexpr_constructor(void) {
     assert(keyexpr_equals_string(z_keyexpr_loan(&ke), "a/**"));
     z_keyexpr_drop(z_keyexpr_move(&ke));
 
+    assert(0 == z_keyexpr_from_str_autocanonize(&ke, "$*"));
+    assert(keyexpr_equals_string(z_keyexpr_loan(&ke), "*"));
+    z_keyexpr_drop(z_keyexpr_move(&ke));
+
     size_t len = 9;
     assert(0 == z_keyexpr_from_substr_autocanonize(&ke, "a/**/**/m/b/c", &len));
     assert(keyexpr_equals_string(z_keyexpr_loan(&ke), "a/**/m"));


### PR DESCRIPTION
## Description

Fixes an AddressSanitizer heap-buffer-overflow in keyexpr autocanonization by ensuring the canonizer only scans within the caller-provided length-bounded buffer.

### What does this PR do?

Adds regression coverage for autocanonizing a lone `$*` key expression through `z_keyexpr_from_str_autocanonize()`, asserting that it canonicalizes to `*`.

The fix updates `_z_keyexpr_canonize()` to use a bounded slash search when operating on owned keyexpr buffers that are not NUL-terminated.

### Why is this change needed?

`_z_keyexpr_canonize()` accepts a buffer and explicit length, but one path searched for `/` with `strchr()`. Owned keyexpr strings are copied without a trailing NUL byte, so `strchr()` can read past the allocation while looking for either `/` or `\0`.

Using a bounded search keeps canonicalization within `[start, start + len)` and prevents ASAN failures for valid keyexpr inputs such as `$*`.

Validation:
- Plain `z_keyexpr_test` passes.
- ASAN `z_keyexpr_test` passes.

### Related Issues

None.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->