### PR TITLE
[FIX] system: fix ThreadX clock and time math

### DIFF
--- a/src/system/threadx/stm32/system.c
+++ b/src/system/threadx/stm32/system.c
@@ -265,9 +265,9 @@ z_result_t z_sleep_s(size_t time) {
 /*------------------ Clock ------------------*/
 
 void __z_clock_gettime(z_clock_t *ts) {
-    uint64_t ms = tx_time_get() * (TX_TIMER_TICKS_PER_SECOND / 1000);
-    ts->tv_sec = ms / (uint64_t)1000;
-    ts->tv_nsec = (ms % (uint64_t)1000) * (uint64_t)1000;
+    uint64_t ticks = tx_time_get();
+    ts->tv_sec = ticks / TX_TIMER_TICKS_PER_SECOND;
+    ts->tv_nsec = (ticks % TX_TIMER_TICKS_PER_SECOND) * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
 }
 
 z_clock_t z_clock_now(void) {
@@ -349,7 +349,7 @@ unsigned long z_time_elapsed_ms(z_time_t *time) {
     return (tx_time_get() - *time) * 1000ULL / TX_TIMER_TICKS_PER_SECOND;
 }
 
-unsigned long z_time_elapsed_s(z_time_t *time) { return (tx_time_get() - *time) * TX_TIMER_TICKS_PER_SECOND; }
+unsigned long z_time_elapsed_s(z_time_t *time) { return (tx_time_get() - *time) / TX_TIMER_TICKS_PER_SECOND; }
 
 z_result_t _z_get_time_since_epoch(_z_time_since_epoch *t) {
     ULONG64 time_ns = tx_time_get() * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;


### PR DESCRIPTION
Fixes #1233 and Fixes #1230. 
- Fixes \__z_clock_gettime\ math.
- Fixes \z_time_elapsed_s\ math which caused leases to disconnect early.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->