### PR TITLE
collections: fix variant_template move leak, macro cleanup

### DIFF
--- a/include/zenoh-pico/collections/README.md
+++ b/include/zenoh-pico/collections/README.md
@@ -579,7 +579,8 @@ typedef <N>_TYPE NAME_XN_t;          // alias per enabled alternative
 | `NAME_t NAME_none(void)`                   | Construct the empty (`NONE`) variant.                                                                                    |
 | `NAME_t NAME_from_XN(<N>_TYPE *val)`       | Construct holding alternative `XN`, moving `*val` in.                                                                    |
 | `void NAME_destroy(NAME_t *v)`             | Destroy the active alternative and reset to `NONE`.                                                                      |
-| `void NAME_move(NAME_t *dst, NAME_t *src)` | Move `*src` into `*dst` (destroying the previous `*dst`); `*src` becomes `NONE`. Omitted if `..._NO_MOVE_FN` is defined. |
+| `void NAME_move(NAME_t *dst, NAME_t *src)` | Move `*src` into `*dst`; `*dst` must be uninitialized or safe to overwrite.                                              |
+|                                            | Previous `*dst` contents are not destroyed; `*src` becomes `NONE`. Omitted if `..._NO_MOVE_FN` is defined.               |
 
 #### Inspection
 

--- a/include/zenoh-pico/collections/algorithms_template.h
+++ b/include/zenoh-pico/collections/algorithms_template.h
@@ -44,59 +44,67 @@
 
 // Find first element matching predicate.  var_name is a pointer to the element type which should be declared by
 // user before the loop.  It is set to NULL if no matching element is found
-#define _ZP_FIND(collection_name, collection_ptr, var_name, predicate)                 \
-    var_name = NULL;                                                                   \
-    for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr); \
-         _a_t_iter != collection_name##_end(collection_ptr);                           \
-         _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {         \
-        collection_name##_elem_t *_ = collection_name##_at(collection_ptr, _a_t_iter); \
-        if (predicate) {                                                               \
-            var_name = _;                                                              \
-            break;                                                                     \
-        }                                                                              \
-    }
+#define _ZP_FIND(collection_name, collection_ptr, var_name, predicate)                     \
+    do {                                                                                   \
+        var_name = NULL;                                                                   \
+        for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr); \
+             _a_t_iter != collection_name##_end(collection_ptr);                           \
+             _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {         \
+            collection_name##_elem_t *_ = collection_name##_at(collection_ptr, _a_t_iter); \
+            if (predicate) {                                                               \
+                var_name = _;                                                              \
+                break;                                                                     \
+            }                                                                              \
+        }                                                                                  \
+    } while (0)
 
 // Find first const element matching predicate.  var_name is a pointer to the element type which should be declared by
 // user before the loop.  It is set to NULL if no matching element is found
-#define _ZP_CONST_FIND(collection_name, collection_ptr, var_name, predicate)                       \
-    var_name = NULL;                                                                               \
-    for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);             \
-         _a_t_iter != collection_name##_end(collection_ptr);                                       \
-         _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {                     \
-        const collection_name##_elem_t *_ = collection_name##_const_at(collection_ptr, _a_t_iter); \
-        if (predicate) {                                                                           \
-            var_name = _;                                                                          \
-            break;                                                                                 \
-        }                                                                                          \
-    }
+#define _ZP_CONST_FIND(collection_name, collection_ptr, var_name, predicate)                           \
+    do {                                                                                               \
+        var_name = NULL;                                                                               \
+        for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);             \
+             _a_t_iter != collection_name##_end(collection_ptr);                                       \
+             _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {                     \
+            const collection_name##_elem_t *_ = collection_name##_const_at(collection_ptr, _a_t_iter); \
+            if (predicate) {                                                                           \
+                var_name = _;                                                                          \
+                break;                                                                                 \
+            }                                                                                          \
+        }                                                                                              \
+    } while (0)
 
 // Find first value matching predicate.  var_name is a pointer to the value type which should be declared by
 // user before the loop.  It is set to NULL if no matching element is found
-#define _ZP_FIND_VAL(collection_name, collection_ptr, var_name, predicate)                  \
-    var_name = NULL;                                                                        \
-    for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);      \
-         _a_t_iter != collection_name##_end(collection_ptr);                                \
-         _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {              \
-        collection_name##_val_t *_ = &collection_name##_at(collection_ptr, _a_t_iter)->val; \
-        if (predicate) {                                                                    \
-            var_name = _;                                                                   \
-            break;                                                                          \
-        }                                                                                   \
-    }
+#define _ZP_FIND_VAL(collection_name, collection_ptr, var_name, predicate)                      \
+    do {                                                                                        \
+        var_name = NULL;                                                                        \
+        for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);      \
+             _a_t_iter != collection_name##_end(collection_ptr);                                \
+             _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {              \
+            collection_name##_val_t *_ = &collection_name##_at(collection_ptr, _a_t_iter)->val; \
+            if (predicate) {                                                                    \
+                var_name = _;                                                                   \
+                break;                                                                          \
+            }                                                                                   \
+        }                                                                                       \
+    } while (0)
 
 // Find first value matching predicate.  var_name is a pointer to the value type which should be declared by
 // user before the loop.  It is set to NULL if no matching element is found
-#define _ZP_CONST_FIND_VAL(collection_name, collection_ptr, var_name, predicate)                        \
-    var_name = NULL;                                                                                    \
-    for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);                  \
-         _a_t_iter != collection_name##_end(collection_ptr);                                            \
-         _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {                          \
-        const collection_name##_val_t *_ = &collection_name##_const_at(collection_ptr, _a_t_iter)->val; \
-        if (predicate) {                                                                                \
-            var_name = _;                                                                               \
-            break;                                                                                      \
-        }                                                                                               \
-    }
+#define _ZP_CONST_FIND_VAL(collection_name, collection_ptr, var_name, predicate)                            \
+    do {                                                                                                    \
+        var_name = NULL;                                                                                    \
+        for (collection_name##_iter_t _a_t_iter = collection_name##_begin(collection_ptr);                  \
+             _a_t_iter != collection_name##_end(collection_ptr);                                            \
+             _a_t_iter = collection_name##_iter_next(collection_ptr, _a_t_iter)) {                          \
+            const collection_name##_val_t *_ = &collection_name##_const_at(collection_ptr, _a_t_iter)->val; \
+            if (predicate) {                                                                                \
+                var_name = _;                                                                               \
+                break;                                                                                      \
+            }                                                                                               \
+        }                                                                                                   \
+    } while (0)
 
 // Set begin iterator to point to the first element satisfying predicate within [begin, end) range.
 // Will be set to end if no matching element is found.

--- a/include/zenoh-pico/collections/variant_template.h
+++ b/include/zenoh-pico/collections/variant_template.h
@@ -107,7 +107,7 @@
 //   void    NAME_destroy(NAME_t *v)
 //
 // Move (variant-to-variant)  — omitted when _ZP_VARIANT_TEMPLATE_NO_MOVE_FN is defined:
-//   void    NAME_move(NAME_t *dst, NAME_t *src)
+//   void    NAME_move(NAME_t *dst, NAME_t *src)  — dst must be uninitialized or safe to overwrite
 //
 // Inspection:
 //   bool       NAME_is_none(const NAME_t *v)
@@ -366,8 +366,6 @@ typedef _ZP_VARIANT_TEMPLATE_8_TYPE _ZP_VARIANT_ALIAS_8;
 #define _ZP_VARIANT_FN_GET_NONE _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, get_none)
 #define _ZP_VARIANT_FN_CONST_GET_NONE _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, const_get_none)
 
-#define _ZP_VARIANT_FN_VISIT _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, visit)
-#define _ZP_VARIANT_FN_VISIT_CTX _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, visit_ctx)
 #ifdef _ZP_VARIANT_TEMPLATE_1_TYPE
 #define _ZP_VARIANT_FN_FROM_1 _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, _ZP_CAT(from, _ZP_VARIANT_TEMPLATE_1_NAME))
 #define _ZP_VARIANT_FN_IS_1 _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, _ZP_CAT(is, _ZP_VARIANT_TEMPLATE_1_NAME))
@@ -665,7 +663,8 @@ static inline void _ZP_CAT(_ZP_VARIANT_TEMPLATE_NAME, destroy)(_ZP_VARIANT_TEMPL
 }
 
 // ── NAME_move ─────────────────────────────────────────────────────────────────
-// Moves *src into *dst.  Previous contents of *dst are destroyed.
+// Moves *src into *dst.  *dst must be uninitialized or otherwise safe to overwrite;
+// previous contents of *dst are not destroyed.
 // *src is left in NONE state.
 // Generated only when _ZP_VARIANT_TEMPLATE_NO_MOVE_FN is NOT defined.
 
@@ -1069,11 +1068,9 @@ static inline bool _ZP_VARIANT_FN_TAKE_8(_ZP_VARIANT_TEMPLATE_TYPE *v, _ZP_VARIA
 #define _ZP_VARIANT_CONST_VISIT(variant_name, v, ...)                                                         \
     _ZP_EXPAND(_ZP_CAT(_ZP_VARIANT_VISIT_IMPL, _ZP_VA_NARGS(__VA_ARGS__))(_ZP_VARIANT_INNER_CONST_VISIT_CASE, \
                                                                           variant_name, v, __VA_ARGS__))
-#undef _ZP_VARIANT_TEMPLATE_DEFINE_VISIT_FN_CHECKER_TYPE
 #endif
 
 // ── Undef all macros ──────────────────────────────────────────────────────────
-#undef _ZP_VARIANT_TEMPLATE_SENTINEL_TYPE
 #undef _ZP_VARIANT_TEMPLATE_NAME
 #undef _ZP_VARIANT_TEMPLATE_NO_MOVE_FN
 #undef _ZP_VARIANT_TEMPLATE_1_TYPE

--- a/tests/z_variant_template_test.c
+++ b/tests/z_variant_template_test.c
@@ -199,9 +199,8 @@ static void test_default_move(void) {
     assert(my_variant_is_2(&dst));
     assert(strcmp(my_variant_get_2(&dst)->ptr, "world") == 0);
 
-    // Move onto a non-empty dst (old A value must be destroyed)
-    int x = 7;
-    my_variant_t dst2 = my_variant_from_1(&x);
+    // Move into another destination with no owned contents to destroy.
+    my_variant_t dst2 = my_variant_none();
     my_variant_move(&dst2, &dst);
 
     assert(my_variant_is_none(&dst));


### PR DESCRIPTION
<variant>_move template did not destroy the previous destination value overwriting, contradicting its documented contract.

- Document that *dst is overwritten and its previous contents are not destroyed.
- Fix variant_template move tests to use a destination that is safe to overwrite.
- Remove the unused _ZP_VARIANT_FN_VISIT / _ZP_VARIANT_FN_VISIT_CTX defines and two #undefs.
- Wrap the _ZP_FIND* helper macros in do { ... } while (0).

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->