### PR TITLE
Improve fuzz coverage workflow and add transport round-trip encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ crash-*
 leak-*
 oom-*
 timeout-*
+*.profdata
+*.profraw

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -12,6 +12,8 @@ The following targets will be tested:
 
 - `clang`
 - CMake
+- `llvm-profdata`
+- `llvm-cov`
 
 `BUILD_FUZZERS=ON` currently requires `clang` because the fuzz targets use
 LLVM `libFuzzer`.
@@ -24,19 +26,23 @@ Create a dedicated build directory for fuzzing:
 CC=clang cmake -B build-fuzz \
   -DBUILD_FUZZERS=ON \
   -DBUILD_TESTING=OFF \
-  -DBUILD_EXAMPLES=OFF
+  -DBUILD_EXAMPLES=OFF \
+  -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fprofile-instr-generate"
 ```
 
-This keeps the normal build separate from the fuzzing build.
+This keeps the normal build separate from the fuzzing build while enabling
+LLVM coverage data collection.
 
 ## Build
 
 Build the fuzz targets:
 
 ```bash
-cmake --build build-fuzz --target z_fuzz_scouting_message_decode
-cmake --build build-fuzz --target z_fuzz_transport_message_decode
-cmake --build build-fuzz --target z_fuzz_endpoint_str
+cmake --build build-fuzz --target \
+  z_fuzz_scouting_message_decode \
+  z_fuzz_transport_message_decode \
+  z_fuzz_endpoint_str
 ```
 
 The executables will be generated at:
@@ -64,7 +70,9 @@ cp -r fuzz/seeds/transport_message/. fuzz/corpus/transport_message_decode/
 cp -r fuzz/seeds/endpoint_from_str/. fuzz/corpus/endpoint_str/
 ```
 
-## Run continuous fuzzing
+## Usage
+
+- Run continuous fuzzing
 
 You can let `libFuzzer` keep mutating inputs:
 
@@ -80,48 +88,89 @@ You can let `libFuzzer` keep mutating inputs:
   fuzz/corpus/endpoint_str
 ```
 
-## Useful options
-
-Run for a fixed number of executions:
-
-```bash
-./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
-  -timeout=5 \
-  -runs=10000 \
-  fuzz/corpus/scouting_message_decode
-./build-fuzz/fuzz/z_fuzz_transport_message_decode \
-  -timeout=5 \
-  -runs=10000 \
-  fuzz/corpus/transport_message_decode
-./build-fuzz/fuzz/z_fuzz_endpoint_str \
-  -timeout=5 \
-  -runs=10000 \
-  fuzz/corpus/endpoint_str
-```
-
-Limit generated input size:
-
-```bash
-./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
-  -timeout=5 \
-  -max_len=256 \
-  fuzz/corpus/scouting_message_decode
-./build-fuzz/fuzz/z_fuzz_transport_message_decode \
-  -timeout=5 \
-  -max_len=256 \
-  fuzz/corpus/transport_message_decode
-./build-fuzz/fuzz/z_fuzz_endpoint_str \
-  -timeout=5 \
-  -max_len=256 \
-  fuzz/corpus/endpoint_str
-```
-
-Replay a saved crashing input:
+- Replay a saved crashing input:
 
 ```bash
 ./build-fuzz/fuzz/z_fuzz_scouting_message_decode path/to/crash-input
 ./build-fuzz/fuzz/z_fuzz_transport_message_decode path/to/crash-input
 ./build-fuzz/fuzz/z_fuzz_endpoint_str path/to/crash-input
+```
+
+## Coverage report
+
+Run each fuzz target with its own profile output file:
+
+```bash
+LLVM_PROFILE_FILE=scouting_message_decode.profraw \
+./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -timeout=5 \
+  -runs=10000 \
+  fuzz/corpus/scouting_message_decode
+
+LLVM_PROFILE_FILE=transport_message_decode.profraw \
+./build-fuzz/fuzz/z_fuzz_transport_message_decode \
+  -timeout=5 \
+  -runs=10000 \
+  fuzz/corpus/transport_message_decode
+
+LLVM_PROFILE_FILE=endpoint_str.profraw \
+./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -timeout=5 \
+  -runs=10000 \
+  fuzz/corpus/endpoint_str
+```
+
+Merge the raw profile data for each target:
+
+```bash
+llvm-profdata merge -sparse scouting_message_decode.profraw \
+  -o scouting_message_decode.profdata
+llvm-profdata merge -sparse transport_message_decode.profraw \
+  -o transport_message_decode.profdata
+llvm-profdata merge -sparse endpoint_str.profraw \
+  -o endpoint_str.profdata
+```
+
+Generate a filtered summary report for the important files of each target:
+
+`llvm-cov` needs both the fuzz target executable and `libzenohpico.so`.
+This build links the harness against the shared library, so passing only the
+executable mostly shows coverage from the harness itself and inline functions
+defined in headers.
+Adding `-object=./build-fuzz/lib/libzenohpico.so` lets `llvm-cov` report
+coverage for the library implementation files under `src/`.
+We then use `grep -E` to keep the report focused on the main parser and codec
+files exercised by each fuzz target.
+
+```bash
+llvm-cov report ./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=scouting_message_decode.profdata
+llvm-cov report ./build-fuzz/fuzz/z_fuzz_transport_message_decode \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=transport_message_decode.profdata
+llvm-cov report ./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=endpoint_str.profdata
+```
+
+Inspect annotated source coverage for each target:
+
+```bash
+llvm-cov show ./build-fuzz/fuzz/z_fuzz_scouting_message_decode \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=scouting_message_decode.profdata \
+  src/protocol/codec/message.c
+
+llvm-cov show ./build-fuzz/fuzz/z_fuzz_transport_message_decode \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=transport_message_decode.profdata \
+  src/protocol/codec/transport.c
+
+llvm-cov show ./build-fuzz/fuzz/z_fuzz_endpoint_str \
+  -object=./build-fuzz/lib/libzenohpico.so \
+  -instr-profile=endpoint_str.profdata \
+  src/link/endpoint.c
 ```
 
 ## Clean up

--- a/fuzz/fuzz_transport_message_decode.c
+++ b/fuzz/fuzz_transport_message_decode.c
@@ -25,7 +25,24 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     _z_zbuf_t zbf = _z_slice_as_zbuf(&slice);
     _z_transport_message_t msg = {0};
 
-    (void)_z_transport_message_decode(&msg, &zbf);
+    if (_z_transport_message_decode(&msg, &zbf) == _Z_RES_OK) {
+        // Re-encode valid decoded messages to exercise the transport encode path.
+        _z_wbuf_t wbf = _z_wbuf_null();
+
+        if (_z_wbuf_init(&wbf, size + 64, true) == _Z_RES_OK) {
+            if (_z_transport_message_encode(&wbf, &msg) == _Z_RES_OK) {
+                _z_zbuf_t encoded = _z_wbuf_to_zbuf(&wbf);
+                _z_transport_message_t roundtrip = {0};
+
+                (void)_z_transport_message_decode(&roundtrip, &encoded);
+                _z_zbuf_clear(&encoded);
+            }
+
+            _z_wbuf_clear(&wbf);
+        }
+    }
+
+    _z_zbuf_clear(&zbf);
 
     return 0;
 }


### PR DESCRIPTION
## Description

This PR improves the fuzzing workflow by documenting how to collect and inspect LLVM coverage, and by extending the transport fuzz target to exercise both decode and encode paths.

### What does this PR do?

- Documents how to inspect coverage for each fuzz target, including focused reporting for the most relevant files.
- Extends `fuzz/fuzz_transport_message_decode.c` to round-trip valid decoded transport messages through encode and decode again, increasing coverage of the transport codec encode path.

### Why is this change needed?

The existing transport fuzz target only exercised decoding, so the encode side of the transport codec was not being covered.
At the same time, the fuzzing documentation did not clearly explain how to build with coverage instrumentation or how to inspect the resulting reports.

The coverage improvement:

```
Filename                                                     Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
src/protocol/codec/transport.c                                   582               367    36.94%          23                11    52.17%         451               217    51.88%         236               138    41.53%
src/protocol/codec/transport.c                                   582               148    74.57%          23                 2    91.30%         451                56    87.58%         236                48    79.66%
```

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->