### PR TITLE
Do not run ubuntu integration tests without ASAN

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -84,9 +84,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-ccache-integration-${{ hashFiles('CMakeLists.txt', 'GNUmakefile', 'cmake/**', 'src/**', 'include/**', 'tests/**') }}
+          key: ${{ runner.os }}-asan${{ matrix.asan }}-ccache-integration-${{ hashFiles('CMakeLists.txt', 'GNUmakefile', 'cmake/**', 'src/**', 'include/**', 'tests/**') }}
           restore-keys: |
-            ${{ runner.os }}-ccache-integration-
+            ${{ runner.os }}-asan${{ matrix.asan }}-ccache-integration-
 
       - name: Compile debug
         run: make all

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,12 +22,18 @@ env:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        include:
+        - name: ubuntu-latest with ASAN
+          os: ubuntu-latest
+          asan: 1
+        - name: macOS-latest
+          os: macOS-latest
+          asan: 0
 
     steps:
       - name: Clone this repository
@@ -100,6 +106,7 @@ jobs:
           Z_FEATURE_ADVANCED_PUBLICATION: 1
           Z_FEATURE_ADVANCED_SUBSCRIPTION: 1
           Z_FEATURE_ADMIN_SPACE: 1
+          ASAN: ${{ matrix.asan }}
 
       - name: Download and extract Zenoh
         if: runner.os == 'Linux'
@@ -129,80 +136,10 @@ jobs:
           BUILD_TESTING: OFF # Workaround for Windows as it seems the previous step is being ignored
           BUILD_INTEGRATION: ON # Workaround for Windows as it seems the previous step is being ignored
           Z_FEATURE_LINK_TLS: 1
-          Z_FEATURE_LOCAL_QUERYABLE: 1
-          Z_FEATURE_LOCAL_SUBSCRIBER: 1
-          Z_FEATURE_UNSTABLE_API: 1
-
-  asan-build:
-    name: Build on ubuntu-latest with ASAN
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Clone this repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Setup mbedtls (Linux)
-        if: runner.os == 'Linux'
-        uses: eclipse-zenoh/ci/setup-mbedtls@main
-        with:
-          mbedtls-version: mbedtls-3.6.5
-
-      - name: Install ccache (Linux)
-        run: |
-          sudo apt-get update && sudo apt-get install -y ccache
-
-      - name: Cache ccache
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-ccache-integration-asan-${{ hashFiles('CMakeLists.txt', 'GNUmakefile', 'cmake/**', 'src/**', 'include/**', 'tests/**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-integration-asan-
-            ${{ runner.os }}-ccache-integration-
-
-      - name: Install TLS dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew list mbedtls >/dev/null 2>&1 || brew install mbedtls
-
-      - name: Compile debug
-        run: make all
-        env:
-          CC: ccache cc
-          CXX: ccache c++
-          CCACHE_DIR: ~/.ccache
-          CCACHE_BASEDIR: ${{ github.workspace }}
-          CCACHE_COMPILERCHECK: content
-          BUILD_TYPE: Debug
-          BUILD_TESTING: OFF
-          BUILD_INTEGRATION: ON
-          Z_FEATURE_LINK_TLS: 1
           Z_FEATURE_UNSTABLE_API: 1
           Z_FEATURE_LOCAL_QUERYABLE: 1
           Z_FEATURE_LOCAL_SUBSCRIBER: 1
           Z_FEATURE_ADVANCED_PUBLICATION: 1
           Z_FEATURE_ADVANCED_SUBSCRIPTION: 1
-          ASAN: 1
-
-      - name: Download and extract Zenoh
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_LINUX_ASSET }}
-          out-file-path: build/tests
-          extract: true
-
-      - name: Test debug
-        run: make test
-        timeout-minutes: 40
-        env:
-          BUILD_TYPE: Debug # Workaround for Windows as it seems the previous step is being ignored
-          BUILD_TESTING: OFF # Workaround for Windows as it seems the previous step is being ignored
-          BUILD_INTEGRATION: ON # Workaround for Windows as it seems the previous step is being ignored
-          Z_FEATURE_LINK_TLS: 1
-          Z_FEATURE_UNSTABLE_API: 1
-          Z_FEATURE_LOCAL_SUBSCRIBER: 1
+          Z_FEATURE_ADMIN_SPACE: 1
+          ASAN: ${{ matrix.asan }}


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Only run ubuntu integration tests with ASAN (since those without ASAN are identical, but do not catch memory errors)

### What does this PR do?
<!-- Describe the changes and their purpose -->
Only run ubuntu integration tests with ASAN (since those without ASAN are identical, but do not catch memory errors)

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Reduce CI time


### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->