### PR TITLE
Clarify advanced recovery and payload integrity behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,16 @@ And on another shell, do:
 
 A publisher will start publishing over UDP multicast and the **zenoh** router will take care of forwarding data from the Zenoh-Pico publisher to the Zenoh-Pico subscriber.
 
+### 3.5. Payload integrity
+
+Zenoh-Pico relies on the underlying link and transport layers for ordinary transmission integrity. It detects malformed
+Zenoh protocol frames and, when advanced publication/subscription recovery is enabled, can detect and recover sequence
+gaps in samples that are still available from the publisher cache.
+
+Zenoh-Pico does not add an end-to-end checksum or authentication tag to TCP/UDP application payloads. If a valid Zenoh
+message is delivered with corrupted payload bytes and no sequence gap, the payload is passed to the application. Add an
+application-level checksum, hash, signature, or HMAC to the payload format when end-to-end data integrity is required.
+
 ## Troubleshooting
 
 ### Activate debug logs

--- a/examples/unix/c11/z_advanced_sub.c
+++ b/examples/unix/c11/z_advanced_sub.c
@@ -90,12 +90,12 @@ int main(int argc, char** argv) {
     ze_advanced_subscriber_options_t sub_opts;
     ze_advanced_subscriber_options_default(&sub_opts);
     ze_advanced_subscriber_history_options_default(&sub_opts.history);
-    // or sub_opts.history.is_enabled = true;
+    sub_opts.history.is_enabled = true;
     sub_opts.history.detect_late_publishers = true;
     ze_advanced_subscriber_recovery_options_default(&sub_opts.recovery);
-    // or sub_opts.recovery.is_enabled = true;
+    sub_opts.recovery.is_enabled = true;
     ze_advanced_subscriber_last_sample_miss_detection_options_default(&sub_opts.recovery.last_sample_miss_detection);
-    // or sub_opts.recovery.last_sample_miss_detection.is_enabled = true;
+    sub_opts.recovery.last_sample_miss_detection.is_enabled = true;
     sub_opts.recovery.last_sample_miss_detection.periodic_queries_period_ms = 0;
     // use publisher heartbeats by default, otherwise enable periodic queries as follows:
     // sub_opts.recovery.last_sample_miss_detection.periodic_queries_period_ms = 1000;

--- a/include/zenoh-pico/api/advanced_publisher.h
+++ b/include/zenoh-pico/api/advanced_publisher.h
@@ -113,8 +113,9 @@ typedef struct {
  *   z_publisher_options_t publisher_options: Base publisher options.
  *   ze_advanced_publisher_cache_options_t cache: Publisher cache settings.
  *   ze_advanced_publisher_sample_miss_detection_options_t sample_miss_detection: Allow
- *     matching Subscribers to detect lost samples and optionally ask for retransmission.
- *     Retransmission can only be done if history is enabled on subscriber side.
+ *     matching Advanced Subscribers to detect sequence gaps and optionally ask for retransmission.
+ *     Retransmission requires publisher-side caching and subscriber-side recovery. Subscriber
+ *     history is used for initial or late-joiner historical data queries.
  *   bool publisher_detection: Allow this publisher to be detected through liveliness.
  *   z_loaned_keyexpr_t *publisher_detection_metadata: An optional key expression to be added
  *     to the liveliness token key expression. It can be used to convey meta data.

--- a/include/zenoh-pico/api/advanced_subscriber.h
+++ b/include/zenoh-pico/api/advanced_subscriber.h
@@ -210,6 +210,9 @@ typedef struct {
 /**
  * Settings for recovering lost messages for Advanced Subscriber.
  *
+ * Recovery detects sequence gaps in samples produced by Advanced Publishers. It does not
+ * validate application payload integrity when a sample is delivered with a valid sequence.
+ *
  * Members:
  *   bool is_enabled: Must be set to ``true``, to enable the lost sample recovery.
  *   ze_advanced_subscriber_last_sample_miss_detection_options_t last_sample_miss_detection:
@@ -235,7 +238,8 @@ typedef struct {
  *     History can only be retransmitted by Publishers that enable caching.
  *   ze_advanced_subscriber_recovery_options_t recovery: Settings for retransmission of detected
  *     lost Samples. Retransmission of lost samples can only be done by Publishers that enable
- *     caching and sample_miss_detection.
+ *     caching and sample_miss_detection. Recovery does not detect payload corruption without a
+ *     sequence gap.
  *   uint64_t query_timeout_ms: Timeout to be used for history and recovery queries.  Default value
  *     will be used if set to ``0``.
  *   bool subscriber_detection: Allow this subscriber to be detected through liveliness.

--- a/tests/utils/tcp_proxy.c
+++ b/tests/utils/tcp_proxy.c
@@ -64,6 +64,11 @@ struct tcp_proxy {
     int nconns;
 
     pthread_mutex_t mtx;  // guards enabled + conns[]
+
+    bool corrupt_pending;
+    char corrupt_needle[128];
+    char corrupt_replacement[128];
+    size_t corrupt_len;
 };
 
 // ---- utilities ----
@@ -157,6 +162,19 @@ static void pair_close(tcp_pair_t* pr) {
     }
 }
 
+static void maybe_corrupt_next(tcp_proxy_t* p, char* buf, size_t len) {
+    if (!p->corrupt_pending || p->corrupt_len == 0 || len < p->corrupt_len) {
+        return;
+    }
+    for (size_t i = 0; i <= len - p->corrupt_len; i++) {
+        if (memcmp(buf + i, p->corrupt_needle, p->corrupt_len) == 0) {
+            memcpy(buf + i, p->corrupt_replacement, p->corrupt_len);
+            p->corrupt_pending = false;
+            return;
+        }
+    }
+}
+
 // ---- thread ----
 // When disabled, we still recv() (to ACK at TCP level) but DROP data instead of forwarding.
 static void* proxy_thread(void* arg) {
@@ -230,6 +248,7 @@ static void* proxy_thread(void* arg) {
                     pair_close(pr);
                 } else {
                     if (forward_enabled) {
+                        maybe_corrupt_next(p, buf, (size_t)nread);
                         size_t off = 0;
                         size_t total = (size_t)nread;
                         while (off < total) {
@@ -252,6 +271,7 @@ static void* proxy_thread(void* arg) {
                     pair_close(pr);
                 } else {
                     if (forward_enabled) {
+                        maybe_corrupt_next(p, buf, (size_t)nread);
                         size_t off = 0;
                         size_t total = (size_t)nread;
                         while (off < total) {
@@ -421,4 +441,23 @@ void tcp_proxy_drop_for_ms(tcp_proxy_t* p, int ms) {
     tcp_proxy_set_enabled(p, false);
     msleep_(ms);
     tcp_proxy_set_enabled(p, true);
+}
+
+void tcp_proxy_corrupt_next(tcp_proxy_t* p, const char* needle, const char* replacement) {
+    if (p == NULL || needle == NULL || replacement == NULL) {
+        return;
+    }
+
+    size_t needle_len = strlen(needle);
+    size_t replacement_len = strlen(replacement);
+    if (needle_len == 0 || needle_len != replacement_len || needle_len >= sizeof(p->corrupt_needle)) {
+        return;
+    }
+
+    pthread_mutex_lock(&p->mtx);
+    memcpy(p->corrupt_needle, needle, needle_len + 1);
+    memcpy(p->corrupt_replacement, replacement, replacement_len + 1);
+    p->corrupt_len = needle_len;
+    p->corrupt_pending = true;
+    pthread_mutex_unlock(&p->mtx);
 }

--- a/tests/utils/tcp_proxy.h
+++ b/tests/utils/tcp_proxy.h
@@ -44,4 +44,7 @@ void tcp_proxy_close_all(tcp_proxy_t* p);
 // Convenience: drop (blackhole) for ms, then restore to enabled = true.
 void tcp_proxy_drop_for_ms(tcp_proxy_t* p, int ms);
 
+// Replace the next matching byte sequence with an equal-length replacement.
+void tcp_proxy_corrupt_next(tcp_proxy_t* p, const char* needle, const char* replacement);
+
 #endif  // TCP_PROXY_H

--- a/tests/z_api_advanced_pubsub_test.c
+++ b/tests/z_api_advanced_pubsub_test.c
@@ -720,12 +720,14 @@ static void test_advanced_local_pubsub(void) {
 #endif
 
 int main(int argc, char **argv) {
-    (void)argc;
-    (void)argv;
-    test_advanced_history(false);
+    bool retransmission_only = argc > 1 && strcmp(argv[1], "--retransmission-only") == 0;
+
+    if (!retransmission_only) {
+        test_advanced_history(false);
 #if defined(ZENOH_LINUX)
-    test_advanced_history(true);
+        test_advanced_history(true);
 #endif
+    }
 #ifdef Z_ADVANCED_PUBSUB_TEST_USE_TCP_PROXY
     test_advanced_retransmission();
     test_advanced_retransmission_periodic();

--- a/tests/z_api_advanced_pubsub_test.c
+++ b/tests/z_api_advanced_pubsub_test.c
@@ -602,6 +602,51 @@ static void test_advanced_retransmission_sample_miss(void) {
     tcp_proxy_destroy(tcp_proxy);
 }
 
+static void test_payload_corruption_is_delivered(void) {
+    printf("test_payload_corruption_is_delivered\n");
+
+    const char *expr = "zenoh-pico/advanced-pubsub/test/payload_corruption";
+    const char *expected_corrupted = "Xayload-ok";
+
+    tcp_proxy_t *tcp_proxy;
+    z_owned_session_t s1, s2;
+    setup_two_peers_with_proxy(&s1, &s2, &tcp_proxy, 9000);
+
+    z_view_keyexpr_t k;
+    ASSERT_OK(z_view_keyexpr_from_str(&k, expr));
+
+    z_owned_closure_sample_t closure;
+    z_owned_fifo_handler_sample_t handler;
+    ASSERT_OK(z_fifo_channel_sample_new(&closure, &handler, 1));
+
+    z_owned_subscriber_t sub;
+    ASSERT_OK(z_declare_subscriber(z_loan(s1), &sub, z_loan(k), z_move(closure), NULL));
+
+    z_owned_publisher_t pub;
+    ASSERT_OK(z_declare_publisher(z_loan(s2), &pub, z_loan(k), NULL));
+    z_sleep_ms(TEST_SLEEP_MS);
+
+    tcp_proxy_corrupt_next(tcp_proxy, "payload-ok", expected_corrupted);
+
+    z_owned_bytes_t payload;
+    ASSERT_OK(z_bytes_copy_from_str(&payload, "payload-ok"));
+    ASSERT_OK(z_publisher_put(z_loan(pub), z_move(payload), NULL));
+    z_sleep_ms(TEST_SLEEP_MS);
+
+    expect_next(z_loan(handler), expected_corrupted);
+    expect_empty(z_loan(handler));
+
+    z_drop(z_move(sub));
+    z_drop(z_move(pub));
+    z_drop(z_move(handler));
+
+    z_drop(z_move(s1));
+    z_drop(z_move(s2));
+
+    tcp_proxy_stop(tcp_proxy);
+    tcp_proxy_destroy(tcp_proxy);
+}
+
 /* TODO: Test disabled due to session reconnection issues
 static void test_advanced_late_joiner(void) {
     printf("test_advanced_late_joiner\n");
@@ -734,6 +779,7 @@ int main(int argc, char **argv) {
     test_advanced_retransmission_heartbeat();
     test_advanced_sample_miss();
     test_advanced_retransmission_sample_miss();
+    test_payload_corruption_is_delivered();
     // test_advanced_late_joiner();
 #endif
 #if Z_FEATURE_LOCAL_SUBSCRIBER == 1 && Z_FEATURE_LOCAL_QUERYABLE == 1


### PR DESCRIPTION
## Description

This PR clarifies and tests the boundary between advanced sample recovery and payload integrity in zenoh-pico.

### What does this PR do?

- Adds a `--retransmission-only` mode to `z_api_advanced_pubsub_test` so TCP proxy based recovery tests can run without starting a Zenoh router.
- Adds TCP proxy support for one-shot equal-length byte corruption.
- Adds a regression test showing that a valid Zenoh message with corrupted payload bytes is delivered as-is.
- Clarifies advanced publisher/subscriber API comments:
  - recovery detects sequence gaps
  - recovery does not validate application payload integrity
  - retransmission requires publisher cache and subscriber recovery
- Enables history/recovery options in the advanced subscriber example.
- Documents the TCP/UDP payload integrity boundary in the README.

### Why is this change needed?

Advanced publication/subscription can recover missing samples when sequence gaps are detected, but it does not provide end-to-end payload integrity checking. A valid Zenoh frame with corrupted payload bytes is still delivered to the application.

This PR makes that behavior explicit in tests, examples, and documentation so users do not confuse sample loss recovery with payload checksum/authentication.

### Related Issues

None.

### Testing

bash
cmake --build build-advanced --parallel --target z_api_advanced_pubsub_test z_advanced_sub z_advanced_pub
./build-advanced/tests/z_api_advanced_pubsub_test --retransmission-only

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `documentation`

## 📚 Documentation Update Requirements

Since this PR updates documentation:

- [ ] **Accuracy verified** - Technical details are correct
- [ ] **Examples tested** - Code examples actually work
- [ ] **Links valid** - All links work and point to correct versions
- [ ] **Grammar/spelling** - Text is clear and well-written
- [ ] **Formatting correct** - Markdown/formatting renders properly
- [ ] **Up-to-date** - Reflects current codebase state

**Suggestion:** Have someone unfamiliar with the feature review for clarity.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->