### PR TITLE
fix: parse standard UUID text representation

### DIFF
--- a/src/utils/uuid.c
+++ b/src/utils/uuid.c
@@ -26,7 +26,7 @@
 void _z_uuid_to_bytes(uint8_t *bytes, const char *uuid_str) {
     uint8_t n_dash = 0;
     for (uint8_t i = 0; i < 32; i += 2) {
-        if (i == 8 || i == 12 || i == 16 || i == 18) {
+        if (i == 8 || i == 12 || i == 16 || i == 20) {
             n_dash += 1;
         }
         char val[5] = {'0', 'x', uuid_str[i + n_dash], uuid_str[i + 1 + n_dash], '\0'};

--- a/tests/z_utils_test.c
+++ b/tests/z_utils_test.c
@@ -20,9 +20,21 @@
 #include "zenoh-pico/utils/pointers.h"
 #include "zenoh-pico/utils/query_params.h"
 #include "zenoh-pico/utils/time_range.h"
+#include "zenoh-pico/utils/uuid.h"
 
 #undef NDEBUG
 #include <assert.h>
+
+static void test_uuid_to_bytes(void) {
+    const char uuid[] = "00112233-4455-6677-8899-aabbccddeeff";
+    const uint8_t expected[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    uint8_t actual[sizeof(expected)];
+
+    _z_uuid_to_bytes(actual, uuid);
+
+    assert(memcmp(actual, expected, sizeof(expected)) == 0);
+}
 
 static void test_query_params(void) {
 #define TEST_PARAMS(str, expected, n)                                 \
@@ -394,6 +406,7 @@ static void test_time_range_contains_fully_bounded_mixed(void) {
 }
 
 int main(void) {
+    test_uuid_to_bytes();
     test_query_params();
     test_time_range();
     test_time_range_contains_null_pointer();


### PR DESCRIPTION
## Description

### What does this PR do?

- Correct the final dash position used when parsing the standard UUID text representation (`8-4-4-4-12`).
- Add a regression test that converts `00112233-4455-6677-8899-aabbccddeeff` to the expected 16 bytes.

### Why is this change needed?

The parser skipped the last dash two characters too early, so standard UUID strings were decoded with incorrect bytes. This restores compatibility with RFC-style UUID strings used by other libraries and configuration producers.

### Validation

- Built the `z_utils_test` target with CMake/Ninja and MSVC.
- Ran `z_utils_test.exe` successfully.
- `ctest -R '^z_utils_test$' --output-on-failure` — 1/1 passed.

### Related Issues

Fixes #1229.

### Development disclosure

OpenAI Codex assisted with the implementation and test development. The patch was independently cross-reviewed and validated with MSVC as well as a GCC/AddressSanitizer test run.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->