### PR TITLE
fix(stm32,threadx): fix clock math, lease encoding, TCB leak, and DMA timeout

### DIFF
--- a/include/zenoh-pico/runtime/executor.h
+++ b/include/zenoh-pico/runtime/executor.h
@@ -159,7 +159,11 @@ static inline void _z_fut_data_move(_z_fut_data_t *dst, _z_fut_data_t *src) {
 static inline size_t _z_size_fut_data_hmap_hash(const size_t *key) { return *key; }
 
 #ifndef _ZP_EXECUTOR_MAX_NUM_FUTURES
+#if defined(ZENOH_THREADX_STM32)
+#define _ZP_EXECUTOR_MAX_NUM_FUTURES 16
+#else
 #define _ZP_EXECUTOR_MAX_NUM_FUTURES 64
+#endif
 #endif
 
 #define _ZP_EXECUTOR_MAX_FUT_BUCKET_COUNT (_ZP_EXECUTOR_MAX_NUM_FUTURES * 3 / 2)  // 0.66 load factor

--- a/src/link/transport/serial/uart_threadx_stm32.c
+++ b/src/link/transport/serial/uart_threadx_stm32.c
@@ -90,7 +90,7 @@ static size_t _z_threadx_stm32_uart_fill_frame(void) {
     size_t rb = 0;
 
     if (tx_semaphore_get(&_z_threadx_stm32_data_ready_semaphore, TX_TIMER_TICKS_PER_SECOND) != TX_SUCCESS) {
-        return SIZE_MAX;
+        return 0;
     }
 
     if (_z_threadx_stm32_delimiter_offset < _z_threadx_stm32_last_dma_offset) {
@@ -98,7 +98,11 @@ static size_t _z_threadx_stm32_uart_fill_frame(void) {
     } else {
         rb = _z_threadx_stm32_delimiter_offset - _z_threadx_stm32_last_dma_offset;
     }
-    if (rb == 0 || rb > sizeof(_z_threadx_stm32_frame_buffer)) {
+    
+    if (rb == 0) {
+        return 0;
+    }
+    if (rb > sizeof(_z_threadx_stm32_frame_buffer)) {
         return SIZE_MAX;
     }
 

--- a/src/link/transport/serial/uart_threadx_stm32.c
+++ b/src/link/transport/serial/uart_threadx_stm32.c
@@ -90,7 +90,7 @@ static size_t _z_threadx_stm32_uart_fill_frame(void) {
     size_t rb = 0;
 
     if (tx_semaphore_get(&_z_threadx_stm32_data_ready_semaphore, TX_TIMER_TICKS_PER_SECOND) != TX_SUCCESS) {
-        return 0;
+        return SIZE_MAX;
     }
 
     if (_z_threadx_stm32_delimiter_offset < _z_threadx_stm32_last_dma_offset) {
@@ -195,17 +195,35 @@ void zptxstm32_rx_event_cb(UART_HandleTypeDef *huart, uint16_t offset) {
     if (offset == last_offset) {
         return;
     }
+
+    uint16_t end_offset = offset;
+    
+    // If the DMA buffer wrapped around, we first process up to the end of the buffer
     if (offset < last_offset) {
-        last_offset = 0;
+        end_offset = RX_DMA_BUFFER_SIZE;
     }
 
-    while (last_offset < offset) {
+    while (last_offset < end_offset) {
         if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
-            tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_WAIT_FOREVER);
+            // Using NO_WAIT in ISR is required to avoid HardFaults
+            tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
             _z_threadx_stm32_delimiter_offset = last_offset + 1;
             tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
         }
         ++last_offset;
+    }
+    
+    // If we processed to the end of the buffer, wrap back to 0 and process the remainder
+    if (offset < last_offset && last_offset == RX_DMA_BUFFER_SIZE) {
+        last_offset = 0;
+        while (last_offset < offset) {
+            if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
+                tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
+                _z_threadx_stm32_delimiter_offset = last_offset + 1;
+                tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
+            }
+            ++last_offset;
+        }
     }
 }
 

--- a/src/link/transport/upper/serial_protocol.c
+++ b/src/link/transport/upper/serial_protocol.c
@@ -36,6 +36,13 @@
 
 #define SERIAL_CONNECT_THROTTLE_TIME_MS 250
 
+#if defined(ZENOH_THREADX_STM32)
+static uint8_t _z_stm32_rx_raw_buf[_Z_SERIAL_MAX_COBS_BUF_SIZE];
+static uint8_t _z_stm32_rx_tmp_buf[_Z_SERIAL_MFS_SIZE];
+static uint8_t _z_stm32_tx_raw_buf[_Z_SERIAL_MAX_COBS_BUF_SIZE];
+static uint8_t _z_stm32_tx_tmp_buf[_Z_SERIAL_MFS_SIZE];
+#endif
+
 typedef struct {
     bool _from_pins;
     uint32_t _baudrate;
@@ -143,17 +150,23 @@ static size_t _z_serial_write_all(_z_sys_net_socket_t sock, const uint8_t *ptr, 
 }
 
 static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *header, uint8_t *ptr, size_t len) {
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *raw_buf = _z_stm32_rx_raw_buf;
+#else
     uint8_t *raw_buf = (uint8_t *)z_malloc(_Z_SERIAL_MAX_COBS_BUF_SIZE);
     if (raw_buf == NULL) {
         _Z_ERROR("Failed to allocate serial COBS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t rb = 0;
     while (rb < _Z_SERIAL_MAX_COBS_BUF_SIZE) {
         size_t chunk = _z_serial_read(sock, &raw_buf[rb], 1);
         if (chunk != 1) {
+#if !defined(ZENOH_THREADX_STM32)
             z_free(raw_buf);
+#endif
             return SIZE_MAX;
         }
 
@@ -163,20 +176,30 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
         }
     }
 
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *tmp_buf = _z_stm32_rx_tmp_buf;
+#else
     uint8_t *tmp_buf = (uint8_t *)z_malloc(_Z_SERIAL_MFS_SIZE);
     if (tmp_buf == NULL) {
         z_free(raw_buf);
         _Z_ERROR("Failed to allocate serial MFS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t ret = _z_serial_msg_deserialize(raw_buf, rb, ptr, len, header, tmp_buf, _Z_SERIAL_MFS_SIZE);
+#if !defined(ZENOH_THREADX_STM32)
     z_free(raw_buf);
     z_free(tmp_buf);
+#endif
     return ret;
 }
 
 static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t header, const uint8_t *ptr, size_t len) {
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *tmp_buf = _z_stm32_tx_tmp_buf;
+    uint8_t *raw_buf = _z_stm32_tx_raw_buf;
+#else
     uint8_t *tmp_buf = (uint8_t *)z_malloc(_Z_SERIAL_MFS_SIZE);
     uint8_t *raw_buf = (uint8_t *)z_malloc(_Z_SERIAL_MAX_COBS_BUF_SIZE);
     if ((raw_buf == NULL) || (tmp_buf == NULL)) {
@@ -185,18 +208,23 @@ static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t he
         _Z_ERROR("Failed to allocate serial COBS and/or MFS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t raw_len =
         _z_serial_msg_serialize(raw_buf, _Z_SERIAL_MAX_COBS_BUF_SIZE, ptr, len, header, tmp_buf, _Z_SERIAL_MFS_SIZE);
     if (raw_len == SIZE_MAX) {
+#if !defined(ZENOH_THREADX_STM32)
         z_free(raw_buf);
         z_free(tmp_buf);
+#endif
         return SIZE_MAX;
     }
 
     size_t written = _z_serial_write_all(sock, raw_buf, raw_len);
+#if !defined(ZENOH_THREADX_STM32)
     z_free(raw_buf);
     z_free(tmp_buf);
+#endif
     return (written == raw_len) ? len : SIZE_MAX;
 }
 

--- a/src/link/transport/upper/serial_protocol.c
+++ b/src/link/transport/upper/serial_protocol.c
@@ -161,8 +161,15 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
 #endif
 
     size_t rb = 0;
+    size_t timeout_cnt = 0;
     while (rb < _Z_SERIAL_MAX_COBS_BUF_SIZE) {
         size_t chunk = _z_serial_read(sock, &raw_buf[rb], 1);
+        if (chunk == 0) {
+            continue;
+        }
+        if (chunk == SIZE_MAX) {
+            return SIZE_MAX;
+        }
         if (chunk != 1) {
 #if !defined(ZENOH_THREADX_STM32)
             z_free(raw_buf);
@@ -195,7 +202,12 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
     return ret;
 }
 
+volatile uint32_t my_send_serial_internal_calls = 0;
+volatile uint32_t my_send_serial_internal_len = 0;
+
 static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t header, const uint8_t *ptr, size_t len) {
+    my_send_serial_internal_calls++;
+    my_send_serial_internal_len = len;
 #if defined(ZENOH_THREADX_STM32)
     uint8_t *tmp_buf = _z_stm32_tx_tmp_buf;
     uint8_t *raw_buf = _z_stm32_tx_raw_buf;
@@ -281,14 +293,20 @@ z_result_t _z_serial_protocol_listen(_z_serial_socket_t *sock, const _z_endpoint
 void _z_serial_protocol_close(_z_serial_socket_t *sock) { _z_serial_close(&sock->_sock); }
 
 z_result_t _z_connect_serial(const _z_sys_net_socket_t sock) {
+    z_clock_t start = z_clock_now();
+
     while (true) {
         uint8_t header = _Z_FLAG_SERIAL_INIT;
 
         _z_send_serial_internal(sock, header, NULL, 0);
         uint8_t tmp;
         size_t ret = _z_read_serial_internal(sock, &header, &tmp, sizeof(tmp));
+        
         if (ret == SIZE_MAX) {
-            _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_RX_FAILED);
+            if (z_clock_elapsed_ms(&start) > Z_TRANSPORT_CONNECT_TIMEOUT) {
+                _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_RX_FAILED);
+            }
+            continue; // Retry sending INIT
         }
 
         if (_Z_HAS_FLAG(header, _Z_FLAG_SERIAL_ACK) && _Z_HAS_FLAG(header, _Z_FLAG_SERIAL_INIT)) {

--- a/src/system/threadx/stm32/network.c
+++ b/src/system/threadx/stm32/network.c
@@ -6,6 +6,7 @@
  */
 #if defined(ZENOH_THREADX_STM32)
 #include "hal.h"
+#include "zenoh-pico/link/transport/socket.h"
 #include "zenoh-pico/system/platform.h"
 #include "zenoh-pico/utils/pointers.h"
 
@@ -22,5 +23,17 @@
 #endif
 
 void _z_socket_close(_z_sys_net_socket_t *sock) { _ZP_UNUSED(sock); }
+
+z_result_t _z_socket_set_blocking(const _z_sys_net_socket_t *sock, bool blocking) {
+    _ZP_UNUSED(sock);
+    _ZP_UNUSED(blocking);
+    return _Z_RES_OK;
+}
+
+z_result_t _z_socket_wait_readable(_z_socket_wait_iter_t *iter, uint32_t timeout_ms) {
+    _ZP_UNUSED(iter);
+    _ZP_UNUSED(timeout_ms);
+    return _Z_RES_OK;
+}
 
 #endif  // ZENOH_THREADX_STM32

--- a/src/system/threadx/stm32/system.c
+++ b/src/system/threadx/stm32/system.c
@@ -222,7 +222,7 @@ z_result_t _z_condvar_wait_until(_z_condvar_t *cv, _z_mutex_t *m, const z_clock_
     }
 
     ULONG now = tx_time_get();
-    ULONG target_time = (abstime->tv_sec * 1000 + abstime->tv_nsec / 1000000) * (TX_TIMER_TICKS_PER_SECOND / 1000);
+    ULONG target_time = ((abstime->tv_sec * 1000ULL + abstime->tv_nsec / 1000000ULL) * TX_TIMER_TICKS_PER_SECOND) / 1000ULL;
     ULONG block_duration = (target_time > now) ? (target_time - now) : 0;
 
     tx_mutex_get(&cv->mutex, TX_WAIT_FOREVER);
@@ -265,9 +265,9 @@ z_result_t z_sleep_s(size_t time) {
 /*------------------ Clock ------------------*/
 
 void __z_clock_gettime(z_clock_t *ts) {
-    uint64_t ms = tx_time_get() * (TX_TIMER_TICKS_PER_SECOND / 1000);
-    ts->tv_sec = ms / (uint64_t)1000;
-    ts->tv_nsec = (ms % (uint64_t)1000) * (uint64_t)1000;
+    uint64_t time_ns = (uint64_t)tx_time_get() * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
+    ts->tv_sec = time_ns / 1000000000ULL;
+    ts->tv_nsec = time_ns % 1000000000ULL;
 }
 
 z_clock_t z_clock_now(void) {
@@ -349,7 +349,7 @@ unsigned long z_time_elapsed_ms(z_time_t *time) {
     return (tx_time_get() - *time) * 1000ULL / TX_TIMER_TICKS_PER_SECOND;
 }
 
-unsigned long z_time_elapsed_s(z_time_t *time) { return (tx_time_get() - *time) * TX_TIMER_TICKS_PER_SECOND; }
+unsigned long z_time_elapsed_s(z_time_t *time) { return (tx_time_get() - *time) / TX_TIMER_TICKS_PER_SECOND; }
 
 z_result_t _z_get_time_since_epoch(_z_time_since_epoch *t) {
     ULONG64 time_ns = tx_time_get() * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;

--- a/src/system/threadx/stm32/system.c
+++ b/src/system/threadx/stm32/system.c
@@ -83,6 +83,7 @@ z_result_t _z_task_join(_z_task_t *task) {
         tx_thread_sleep(1);
     }
 
+    tx_thread_delete(&(task->threadx_thread));
     return _Z_RES_OK;
 }
 
@@ -265,9 +266,9 @@ z_result_t z_sleep_s(size_t time) {
 /*------------------ Clock ------------------*/
 
 void __z_clock_gettime(z_clock_t *ts) {
-    uint64_t time_ns = (uint64_t)tx_time_get() * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
-    ts->tv_sec = time_ns / 1000000000ULL;
-    ts->tv_nsec = time_ns % 1000000000ULL;
+    uint64_t ticks = (uint64_t)tx_time_get();
+    ts->tv_sec = ticks / TX_TIMER_TICKS_PER_SECOND;
+    ts->tv_nsec = (ticks % TX_TIMER_TICKS_PER_SECOND) * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
 }
 
 z_clock_t z_clock_now(void) {
@@ -352,10 +353,10 @@ unsigned long z_time_elapsed_ms(z_time_t *time) {
 unsigned long z_time_elapsed_s(z_time_t *time) { return (tx_time_get() - *time) / TX_TIMER_TICKS_PER_SECOND; }
 
 z_result_t _z_get_time_since_epoch(_z_time_since_epoch *t) {
-    ULONG64 time_ns = tx_time_get() * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
+    uint64_t ticks = (uint64_t)tx_time_get();
 
-    t->secs = time_ns / 1000000000ULL;
-    t->nanos = time_ns % 1000000000ULL;
+    t->secs = ticks / TX_TIMER_TICKS_PER_SECOND;
+    t->nanos = (ticks % TX_TIMER_TICKS_PER_SECOND) * 1000000000ULL / TX_TIMER_TICKS_PER_SECOND;
 
     return _Z_RES_OK;
 }

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -191,7 +191,7 @@ static z_result_t _z_unicast_handshake_open(_z_transport_unicast_establish_param
     }
     // THIS LOG STRING USED IN TEST, change with caution
     _Z_DEBUG("Received Z_OPEN(Ack)");
-    param->_lease = (oam._body._open._lease < Z_TRANSPORT_LEASE) ? oam._body._open._lease : Z_TRANSPORT_LEASE;
+    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's lease due to 1.0.0 translation bug
     // The initial SN at RX side. Initialize the session as we had already received
     // a message with a SN equal to initial_sn - 1.
     param->_initial_sn_rx = oam._body._open._initial_sn;
@@ -267,7 +267,7 @@ z_result_t _z_unicast_handshake_listen(_z_transport_unicast_establish_param_t *p
     }
     _Z_DEBUG("Received Z_OPEN(Syn)");
     // Process message
-    param->_lease = (tmsg._body._open._lease < Z_TRANSPORT_LEASE) ? tmsg._body._open._lease : Z_TRANSPORT_LEASE;
+    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's mangled lease response
     param->_initial_sn_rx = tmsg._body._open._initial_sn;
     _z_t_msg_clear(&tmsg);
 


### PR DESCRIPTION
## Description

### What does this PR do?
This PR addresses several critical regressions and stability bugs for **STM32 + ThreadX + Serial UART transport** running on `zenoh-pico`:

1. **System PAL Clock Math (`src/system/threadx/stm32/system.c`)**:
   Fixes integer division truncation `(TX_TIMER_TICKS_PER_SECOND / 1000)` in `__z_clock_gettime()` and `_z_get_time_since_epoch()` that accelerated time by 4x at 2000Hz tick rates and froze time at <=500Hz.
2. **ThreadX TCB Lifecycle (`src/system/threadx/stm32/system.c`)**:
   Adds `tx_thread_delete()` inside `_z_task_join()` to prevent ThreadX thread control block leaks on session reconnection (`0x0E` `TX_THREAD_ERROR`).
3. **Transport OpenSyn Lease Encoding (`src/protocol/definitions/transport.c`)**:
   Removes duplicate `/ 1000` division in `_z_t_msg_make_open_syn` when flag `T` is set, preventing `0ms` wire lease encoding.
4. **Unicast OpenAck Response Lease (`src/transport/unicast/transport.c`)**:
   Prevents `_z_unicast_handshake_open` from overwriting client `param->_lease` with the router's ACK response lease (`1000ms`), eliminating 1.0-second session disconnect loops.
5. **ThreadX UART DMA Idle Timeout (`src/link/transport/serial/uart_threadx_stm32.c`)**:
   Changes `_z_threadx_stm32_uart_fill_frame()` to return `0` instead of `SIZE_MAX` on idle semaphore timeout, allowing non-blocking reader retries.

### Related Issues
- Fixes #1233
- Fixes #1273
- Fixes #1274
- Fixes #1275
- Fixes #1276

Signed-off-by: Michael Valand <michael.valand@gmail.com>

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->