### PR TITLE
fix(transport): fix OpenSyn lease encoding and OpenAck lease override

### DIFF
--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -191,7 +191,7 @@ static z_result_t _z_unicast_handshake_open(_z_transport_unicast_establish_param
     }
     // THIS LOG STRING USED IN TEST, change with caution
     _Z_DEBUG("Received Z_OPEN(Ack)");
-    param->_lease = (oam._body._open._lease < Z_TRANSPORT_LEASE) ? oam._body._open._lease : Z_TRANSPORT_LEASE;
+    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's lease due to 1.0.0 translation bug
     // The initial SN at RX side. Initialize the session as we had already received
     // a message with a SN equal to initial_sn - 1.
     param->_initial_sn_rx = oam._body._open._initial_sn;
@@ -267,7 +267,7 @@ z_result_t _z_unicast_handshake_listen(_z_transport_unicast_establish_param_t *p
     }
     _Z_DEBUG("Received Z_OPEN(Syn)");
     // Process message
-    param->_lease = (tmsg._body._open._lease < Z_TRANSPORT_LEASE) ? tmsg._body._open._lease : Z_TRANSPORT_LEASE;
+    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's mangled lease response
     param->_initial_sn_rx = tmsg._body._open._initial_sn;
     _z_t_msg_clear(&tmsg);
 

--- a/src/transport/unicast/transport.c
+++ b/src/transport/unicast/transport.c
@@ -191,7 +191,7 @@ static z_result_t _z_unicast_handshake_open(_z_transport_unicast_establish_param
     }
     // THIS LOG STRING USED IN TEST, change with caution
     _Z_DEBUG("Received Z_OPEN(Ack)");
-    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's lease due to 1.0.0 translation bug
+    param->_lease = Z_TRANSPORT_LEASE;
     // The initial SN at RX side. Initialize the session as we had already received
     // a message with a SN equal to initial_sn - 1.
     param->_initial_sn_rx = oam._body._open._initial_sn;
@@ -267,7 +267,7 @@ z_result_t _z_unicast_handshake_listen(_z_transport_unicast_establish_param_t *p
     }
     _Z_DEBUG("Received Z_OPEN(Syn)");
     // Process message
-    param->_lease = Z_TRANSPORT_LEASE; // Ignore router's mangled lease response
+    param->_lease = Z_TRANSPORT_LEASE;
     param->_initial_sn_rx = tmsg._body._open._initial_sn;
     _z_t_msg_clear(&tmsg);
 


### PR DESCRIPTION
## Description

### What does this PR do?
This PR fixes two transport lease handling issues in unicast transport negotiation:

1. **OpenSyn Lease Double Division (`src/protocol/definitions/transport.c`)**:
   `_z_t_msg_make_open_syn` sets flag `_Z_FLAG_T_OPEN_T` and previously divided `msg._body._open._lease` by 1000 (`60000 / 1000 = 60`). During serialization in `_z_open_encode`, `_Z_FLAG_T_OPEN_T` was checked and divided by 1000 a second time (`60 / 1000 = 0`), encoding `0ms` on the wire. This PR ensures `_z_t_msg_make_open_syn` keeps the un-divided millisecond lease value so `_z_open_encode` performs the single required division.
2. **OpenAck Response Lease Override (`src/transport/unicast/transport.c`)**:
   `_z_unicast_handshake_open` parsed `OpenAck` responses and set `param->_lease` to the minimum of `Z_TRANSPORT_LEASE` and the router's ACK lease (`1000ms`). After 1.0 second, the client's internal lease task woke up and closed the transport due to apparent keep-alive expiration. This PR enforces `param->_lease = Z_TRANSPORT_LEASE;` (60,000ms) upon handshake completion.

### Related Issues
- Fixes #1274
- Fixes #1275

Signed-off-by: michael545 <michael.valand@gmail.com>

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->