### PR TITLE
fix(serial): return 0 on idle semaphore timeout in ThreadX STM32 UART driver

### DIFF
--- a/src/link/transport/serial/uart_threadx_stm32.c
+++ b/src/link/transport/serial/uart_threadx_stm32.c
@@ -24,22 +24,39 @@
 #include "zenoh-pico/utils/logging.h"
 
 #define RX_DMA_BUFFER_SIZE (_Z_SERIAL_MAX_COBS_BUF_SIZE * 2 + 2)
+#define UART_CLEAR_ALL_ERRORS \
+    (UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF)
 
 static uint8_t _z_threadx_stm32_dma_buffer[RX_DMA_BUFFER_SIZE];
 static uint16_t _z_threadx_stm32_delimiter_offset = 0;
 static TX_SEMAPHORE _z_threadx_stm32_data_ready_semaphore;
 static TX_SEMAPHORE _z_threadx_stm32_data_processing_semaphore;
+static TX_MUTEX _z_threadx_stm32_tx_mutex;
 static uint8_t _z_threadx_stm32_frame_buffer[_Z_SERIAL_MAX_COBS_BUF_SIZE];
 static size_t _z_threadx_stm32_frame_len = 0;
 static size_t _z_threadx_stm32_frame_offset = 0;
 static bool _z_threadx_stm32_initialized = false;
 static uint16_t _z_threadx_stm32_last_dma_offset = 0;
+static uint16_t _z_threadx_stm32_isr_last_offset = 0;
 extern UART_HandleTypeDef ZENOH_HUART;
+
+void _z_threadx_stm32_tx_lock(void) {
+    if (_z_threadx_stm32_initialized) {
+        tx_mutex_get(&_z_threadx_stm32_tx_mutex, TX_WAIT_FOREVER);
+    }
+}
+
+void _z_threadx_stm32_tx_unlock(void) {
+    if (_z_threadx_stm32_initialized) {
+        tx_mutex_put(&_z_threadx_stm32_tx_mutex);
+    }
+}
 
 static z_result_t _z_threadx_stm32_uart_open_impl(void) {
     if (!_z_threadx_stm32_initialized) {
         tx_semaphore_create(&_z_threadx_stm32_data_ready_semaphore, "Data Ready", 0);
         tx_semaphore_create(&_z_threadx_stm32_data_processing_semaphore, "Data Processing", 1);
+        tx_mutex_create(&_z_threadx_stm32_tx_mutex, "Zenoh TX Mutex", TX_NO_INHERIT);
         _z_threadx_stm32_initialized = true;
     }
 
@@ -52,10 +69,10 @@ static z_result_t _z_threadx_stm32_uart_open_impl(void) {
     _z_threadx_stm32_isr_last_offset = 0;
     _z_threadx_stm32_frame_len = 0;
     _z_threadx_stm32_frame_offset = 0;
-    memset(_z_threadx_stm32_dma_buffer, 0, sizeof(_z_threadx_stm32_dma_buffer));
+    memset(_z_threadx_stm32_dma_buffer, 0xFF, sizeof(_z_threadx_stm32_dma_buffer));
 
     HAL_UART_AbortReceive(&ZENOH_HUART);
-    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_ALL_ERRORS);
     ZENOH_HUART.RxState = HAL_UART_STATE_READY;
 
     if (HAL_UARTEx_ReceiveToIdle_DMA(&ZENOH_HUART, _z_threadx_stm32_dma_buffer, RX_DMA_BUFFER_SIZE) != HAL_OK) {
@@ -162,11 +179,11 @@ static size_t _z_threadx_stm32_uart_read(_z_sys_net_socket_t sock, uint8_t *ptr,
 static size_t _z_threadx_stm32_uart_write(_z_sys_net_socket_t sock, const uint8_t *ptr, size_t len) {
     _ZP_UNUSED(sock);
 
-    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_ALL_ERRORS);
     ZENOH_HUART.gState = HAL_UART_STATE_READY;
 
     if (HAL_UART_Transmit(&ZENOH_HUART, (uint8_t *)ptr, len, 500) != HAL_OK) {
-        __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+        __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_ALL_ERRORS);
         ZENOH_HUART.gState = HAL_UART_STATE_READY;
         _Z_ERROR("Could not send to serial device!");
         return SIZE_MAX;
@@ -244,8 +261,10 @@ void zptxstm32_error_event_cb(UART_HandleTypeDef *huart) {
     if (huart != &ZENOH_HUART) {
         return;
     }
+
+    _Z_ERROR("UART error!");
     HAL_UART_AbortReceive(&ZENOH_HUART);
-    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_ALL_ERRORS);
     ZENOH_HUART.RxState = HAL_UART_STATE_READY;
     _z_threadx_stm32_isr_last_offset = 0;
     _z_threadx_stm32_delimiter_offset = 0;

--- a/src/link/transport/serial/uart_threadx_stm32.c
+++ b/src/link/transport/serial/uart_threadx_stm32.c
@@ -49,6 +49,7 @@ static z_result_t _z_threadx_stm32_uart_open_impl(void) {
 
     _z_threadx_stm32_delimiter_offset = 0;
     _z_threadx_stm32_last_dma_offset = 0;
+    _z_threadx_stm32_isr_last_offset = 0;
     _z_threadx_stm32_frame_len = 0;
     _z_threadx_stm32_frame_offset = 0;
     memset(_z_threadx_stm32_dma_buffer, 0, sizeof(_z_threadx_stm32_dma_buffer));
@@ -201,41 +202,40 @@ size_t _z_serial_write(_z_sys_net_socket_t sock, const uint8_t *ptr, size_t len)
 }
 
 void zptxstm32_rx_event_cb(UART_HandleTypeDef *huart, uint16_t offset) {
-    static uint16_t last_offset = 0;
     if (huart != &ZENOH_HUART) {
         return;
     }
-    if (offset == last_offset) {
+    if (offset == _z_threadx_stm32_isr_last_offset) {
         return;
     }
 
     uint16_t end_offset = offset;
     
     // If the DMA buffer wrapped around, we first process up to the end of the buffer
-    if (offset < last_offset) {
+    if (offset < _z_threadx_stm32_isr_last_offset) {
         end_offset = RX_DMA_BUFFER_SIZE;
     }
 
-    while (last_offset < end_offset) {
-        if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
+    while (_z_threadx_stm32_isr_last_offset < end_offset) {
+        if (_z_threadx_stm32_dma_buffer[_z_threadx_stm32_isr_last_offset] == (uint8_t)0x00) {
             // Using NO_WAIT in ISR is required to avoid HardFaults
             tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
-            _z_threadx_stm32_delimiter_offset = last_offset + 1;
+            _z_threadx_stm32_delimiter_offset = _z_threadx_stm32_isr_last_offset + 1;
             tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
         }
-        ++last_offset;
+        ++_z_threadx_stm32_isr_last_offset;
     }
     
     // If we processed to the end of the buffer, wrap back to 0 and process the remainder
-    if (offset < last_offset && last_offset == RX_DMA_BUFFER_SIZE) {
-        last_offset = 0;
-        while (last_offset < offset) {
-            if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
+    if (offset < _z_threadx_stm32_isr_last_offset && _z_threadx_stm32_isr_last_offset == RX_DMA_BUFFER_SIZE) {
+        _z_threadx_stm32_isr_last_offset = 0;
+        while (_z_threadx_stm32_isr_last_offset < offset) {
+            if (_z_threadx_stm32_dma_buffer[_z_threadx_stm32_isr_last_offset] == (uint8_t)0x00) {
                 tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
-                _z_threadx_stm32_delimiter_offset = last_offset + 1;
+                _z_threadx_stm32_delimiter_offset = _z_threadx_stm32_isr_last_offset + 1;
                 tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
             }
-            ++last_offset;
+            ++_z_threadx_stm32_isr_last_offset;
         }
     }
 }
@@ -244,8 +244,13 @@ void zptxstm32_error_event_cb(UART_HandleTypeDef *huart) {
     if (huart != &ZENOH_HUART) {
         return;
     }
-
-    _Z_ERROR("UART error!");
+    HAL_UART_AbortReceive(&ZENOH_HUART);
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    ZENOH_HUART.RxState = HAL_UART_STATE_READY;
+    _z_threadx_stm32_isr_last_offset = 0;
+    _z_threadx_stm32_delimiter_offset = 0;
+    _z_threadx_stm32_last_dma_offset = 0;
+    memset(_z_threadx_stm32_dma_buffer, 0xFF, sizeof(_z_threadx_stm32_dma_buffer));
     HAL_UARTEx_ReceiveToIdle_DMA(&ZENOH_HUART, _z_threadx_stm32_dma_buffer, RX_DMA_BUFFER_SIZE);
 }
 

--- a/src/link/transport/serial/uart_threadx_stm32.c
+++ b/src/link/transport/serial/uart_threadx_stm32.c
@@ -43,11 +43,19 @@ static z_result_t _z_threadx_stm32_uart_open_impl(void) {
         _z_threadx_stm32_initialized = true;
     }
 
+    while (tx_semaphore_get(&_z_threadx_stm32_data_ready_semaphore, TX_NO_WAIT) == TX_SUCCESS) {}
+    while (tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT) == TX_SUCCESS) {}
+    tx_semaphore_put(&_z_threadx_stm32_data_processing_semaphore);
+
     _z_threadx_stm32_delimiter_offset = 0;
     _z_threadx_stm32_last_dma_offset = 0;
     _z_threadx_stm32_frame_len = 0;
     _z_threadx_stm32_frame_offset = 0;
     memset(_z_threadx_stm32_dma_buffer, 0, sizeof(_z_threadx_stm32_dma_buffer));
+
+    HAL_UART_AbortReceive(&ZENOH_HUART);
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    ZENOH_HUART.RxState = HAL_UART_STATE_READY;
 
     if (HAL_UARTEx_ReceiveToIdle_DMA(&ZENOH_HUART, _z_threadx_stm32_dma_buffer, RX_DMA_BUFFER_SIZE) != HAL_OK) {
         _Z_ERROR_RETURN(_Z_ERR_GENERIC);
@@ -89,8 +97,8 @@ static void _z_threadx_stm32_uart_close(_z_sys_net_socket_t *sock) { _ZP_UNUSED(
 static size_t _z_threadx_stm32_uart_fill_frame(void) {
     size_t rb = 0;
 
-    if (tx_semaphore_get(&_z_threadx_stm32_data_ready_semaphore, TX_TIMER_TICKS_PER_SECOND) != TX_SUCCESS) {
-        return SIZE_MAX;
+    if (tx_semaphore_get(&_z_threadx_stm32_data_ready_semaphore, TX_TIMER_TICKS_PER_SECOND / 10) != TX_SUCCESS) {
+        return 0;
     }
 
     if (_z_threadx_stm32_delimiter_offset < _z_threadx_stm32_last_dma_offset) {
@@ -98,7 +106,11 @@ static size_t _z_threadx_stm32_uart_fill_frame(void) {
     } else {
         rb = _z_threadx_stm32_delimiter_offset - _z_threadx_stm32_last_dma_offset;
     }
-    if (rb == 0 || rb > sizeof(_z_threadx_stm32_frame_buffer)) {
+    
+    if (rb == 0) {
+        return 0;
+    }
+    if (rb > sizeof(_z_threadx_stm32_frame_buffer)) {
         return SIZE_MAX;
     }
 
@@ -149,7 +161,12 @@ static size_t _z_threadx_stm32_uart_read(_z_sys_net_socket_t sock, uint8_t *ptr,
 static size_t _z_threadx_stm32_uart_write(_z_sys_net_socket_t sock, const uint8_t *ptr, size_t len) {
     _ZP_UNUSED(sock);
 
-    if (HAL_UART_Transmit(&ZENOH_HUART, (uint8_t *)ptr, len, 2000) != HAL_OK) {
+    __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+    ZENOH_HUART.gState = HAL_UART_STATE_READY;
+
+    if (HAL_UART_Transmit(&ZENOH_HUART, (uint8_t *)ptr, len, 500) != HAL_OK) {
+        __HAL_UART_CLEAR_FLAG(&ZENOH_HUART, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_NEF | UART_CLEAR_OREF | UART_CLEAR_IDLEF);
+        ZENOH_HUART.gState = HAL_UART_STATE_READY;
         _Z_ERROR("Could not send to serial device!");
         return SIZE_MAX;
     }
@@ -191,17 +208,35 @@ void zptxstm32_rx_event_cb(UART_HandleTypeDef *huart, uint16_t offset) {
     if (offset == last_offset) {
         return;
     }
+
+    uint16_t end_offset = offset;
+    
+    // If the DMA buffer wrapped around, we first process up to the end of the buffer
     if (offset < last_offset) {
-        last_offset = 0;
+        end_offset = RX_DMA_BUFFER_SIZE;
     }
 
-    while (last_offset < offset) {
+    while (last_offset < end_offset) {
         if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
-            tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_WAIT_FOREVER);
+            // Using NO_WAIT in ISR is required to avoid HardFaults
+            tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
             _z_threadx_stm32_delimiter_offset = last_offset + 1;
             tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
         }
         ++last_offset;
+    }
+    
+    // If we processed to the end of the buffer, wrap back to 0 and process the remainder
+    if (offset < last_offset && last_offset == RX_DMA_BUFFER_SIZE) {
+        last_offset = 0;
+        while (last_offset < offset) {
+            if (_z_threadx_stm32_dma_buffer[last_offset] == (uint8_t)0x00) {
+                tx_semaphore_get(&_z_threadx_stm32_data_processing_semaphore, TX_NO_WAIT);
+                _z_threadx_stm32_delimiter_offset = last_offset + 1;
+                tx_semaphore_put(&_z_threadx_stm32_data_ready_semaphore);
+            }
+            ++last_offset;
+        }
     }
 }
 

--- a/src/link/transport/upper/serial_protocol.c
+++ b/src/link/transport/upper/serial_protocol.c
@@ -185,7 +185,6 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
         }
 
         timeout_cnt = 0;
-
         rb++;
         if (raw_buf[rb - 1] == (uint8_t)0x00) {
             break;
@@ -211,13 +210,14 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
     return ret;
 }
 
-volatile uint32_t my_send_serial_internal_calls = 0;
-volatile uint32_t my_send_serial_internal_len = 0;
+#if defined(ZENOH_THREADX_STM32)
+extern void _z_threadx_stm32_tx_lock(void);
+extern void _z_threadx_stm32_tx_unlock(void);
+#endif
 
 static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t header, const uint8_t *ptr, size_t len) {
-    my_send_serial_internal_calls++;
-    my_send_serial_internal_len = len;
 #if defined(ZENOH_THREADX_STM32)
+    _z_threadx_stm32_tx_lock();
     uint8_t *tmp_buf = _z_stm32_tx_tmp_buf;
     uint8_t *raw_buf = _z_stm32_tx_raw_buf;
 #else
@@ -234,7 +234,9 @@ static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t he
     size_t raw_len =
         _z_serial_msg_serialize(raw_buf, _Z_SERIAL_MAX_COBS_BUF_SIZE, ptr, len, header, tmp_buf, _Z_SERIAL_MFS_SIZE);
     if (raw_len == SIZE_MAX) {
-#if !defined(ZENOH_THREADX_STM32)
+#if defined(ZENOH_THREADX_STM32)
+        _z_threadx_stm32_tx_unlock();
+#else
         z_free(raw_buf);
         z_free(tmp_buf);
 #endif
@@ -242,7 +244,9 @@ static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t he
     }
 
     size_t written = _z_serial_write_all(sock, raw_buf, raw_len);
-#if !defined(ZENOH_THREADX_STM32)
+#if defined(ZENOH_THREADX_STM32)
+    _z_threadx_stm32_tx_unlock();
+#else
     z_free(raw_buf);
     z_free(tmp_buf);
 #endif

--- a/src/link/transport/upper/serial_protocol.c
+++ b/src/link/transport/upper/serial_protocol.c
@@ -36,6 +36,13 @@
 
 #define SERIAL_CONNECT_THROTTLE_TIME_MS 250
 
+#if defined(ZENOH_THREADX_STM32)
+static uint8_t _z_stm32_rx_raw_buf[_Z_SERIAL_MAX_COBS_BUF_SIZE];
+static uint8_t _z_stm32_rx_tmp_buf[_Z_SERIAL_MFS_SIZE];
+static uint8_t _z_stm32_tx_raw_buf[_Z_SERIAL_MAX_COBS_BUF_SIZE];
+static uint8_t _z_stm32_tx_tmp_buf[_Z_SERIAL_MFS_SIZE];
+#endif
+
 typedef struct {
     bool _from_pins;
     uint32_t _baudrate;
@@ -143,17 +150,33 @@ static size_t _z_serial_write_all(_z_sys_net_socket_t sock, const uint8_t *ptr, 
 }
 
 static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *header, uint8_t *ptr, size_t len) {
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *raw_buf = _z_stm32_rx_raw_buf;
+#else
     uint8_t *raw_buf = (uint8_t *)z_malloc(_Z_SERIAL_MAX_COBS_BUF_SIZE);
     if (raw_buf == NULL) {
         _Z_ERROR("Failed to allocate serial COBS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t rb = 0;
+    size_t timeout_cnt = 0;
     while (rb < _Z_SERIAL_MAX_COBS_BUF_SIZE) {
         size_t chunk = _z_serial_read(sock, &raw_buf[rb], 1);
+        if (chunk == 0) {
+            if (rb == 0) {
+                return SIZE_MAX;
+            }
+            continue;
+        }
+        if (chunk == SIZE_MAX) {
+            return SIZE_MAX;
+        }
         if (chunk != 1) {
+#if !defined(ZENOH_THREADX_STM32)
             z_free(raw_buf);
+#endif
             return SIZE_MAX;
         }
 
@@ -163,20 +186,35 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
         }
     }
 
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *tmp_buf = _z_stm32_rx_tmp_buf;
+#else
     uint8_t *tmp_buf = (uint8_t *)z_malloc(_Z_SERIAL_MFS_SIZE);
     if (tmp_buf == NULL) {
         z_free(raw_buf);
         _Z_ERROR("Failed to allocate serial MFS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t ret = _z_serial_msg_deserialize(raw_buf, rb, ptr, len, header, tmp_buf, _Z_SERIAL_MFS_SIZE);
+#if !defined(ZENOH_THREADX_STM32)
     z_free(raw_buf);
     z_free(tmp_buf);
+#endif
     return ret;
 }
 
+volatile uint32_t my_send_serial_internal_calls = 0;
+volatile uint32_t my_send_serial_internal_len = 0;
+
 static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t header, const uint8_t *ptr, size_t len) {
+    my_send_serial_internal_calls++;
+    my_send_serial_internal_len = len;
+#if defined(ZENOH_THREADX_STM32)
+    uint8_t *tmp_buf = _z_stm32_tx_tmp_buf;
+    uint8_t *raw_buf = _z_stm32_tx_raw_buf;
+#else
     uint8_t *tmp_buf = (uint8_t *)z_malloc(_Z_SERIAL_MFS_SIZE);
     uint8_t *raw_buf = (uint8_t *)z_malloc(_Z_SERIAL_MAX_COBS_BUF_SIZE);
     if ((raw_buf == NULL) || (tmp_buf == NULL)) {
@@ -185,18 +223,23 @@ static size_t _z_send_serial_internal(const _z_sys_net_socket_t sock, uint8_t he
         _Z_ERROR("Failed to allocate serial COBS and/or MFS buffer");
         return SIZE_MAX;
     }
+#endif
 
     size_t raw_len =
         _z_serial_msg_serialize(raw_buf, _Z_SERIAL_MAX_COBS_BUF_SIZE, ptr, len, header, tmp_buf, _Z_SERIAL_MFS_SIZE);
     if (raw_len == SIZE_MAX) {
+#if !defined(ZENOH_THREADX_STM32)
         z_free(raw_buf);
         z_free(tmp_buf);
+#endif
         return SIZE_MAX;
     }
 
     size_t written = _z_serial_write_all(sock, raw_buf, raw_len);
+#if !defined(ZENOH_THREADX_STM32)
     z_free(raw_buf);
     z_free(tmp_buf);
+#endif
     return (written == raw_len) ? len : SIZE_MAX;
 }
 
@@ -253,14 +296,20 @@ z_result_t _z_serial_protocol_listen(_z_serial_socket_t *sock, const _z_endpoint
 void _z_serial_protocol_close(_z_serial_socket_t *sock) { _z_serial_close(&sock->_sock); }
 
 z_result_t _z_connect_serial(const _z_sys_net_socket_t sock) {
+    z_clock_t start = z_clock_now();
+
     while (true) {
         uint8_t header = _Z_FLAG_SERIAL_INIT;
 
         _z_send_serial_internal(sock, header, NULL, 0);
         uint8_t tmp;
         size_t ret = _z_read_serial_internal(sock, &header, &tmp, sizeof(tmp));
+        
         if (ret == SIZE_MAX) {
-            _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_RX_FAILED);
+            if (z_clock_elapsed_ms(&start) > Z_TRANSPORT_CONNECT_TIMEOUT) {
+                _Z_ERROR_RETURN(_Z_ERR_TRANSPORT_RX_FAILED);
+            }
+            continue; // Retry sending INIT
         }
 
         if (_Z_HAS_FLAG(header, _Z_FLAG_SERIAL_ACK) && _Z_HAS_FLAG(header, _Z_FLAG_SERIAL_INIT)) {
@@ -280,8 +329,13 @@ z_result_t _z_connect_serial(const _z_sys_net_socket_t sock) {
 }
 
 size_t _z_read_serial(const _z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
-    uint8_t header;
-    return _z_read_serial_internal(sock, &header, ptr, len);
+    uint8_t header = 0;
+    size_t ret = _z_read_serial_internal(sock, &header, ptr, len);
+    if (ret != SIZE_MAX && (_Z_HAS_FLAG(header, _Z_FLAG_SERIAL_RESET) || _Z_HAS_FLAG(header, _Z_FLAG_SERIAL_INIT))) {
+        _Z_DEBUG("Received SERIAL_RESET or SERIAL_INIT header - triggering reconnect");
+        return SIZE_MAX;
+    }
+    return ret;
 }
 
 size_t _z_send_serial(const _z_sys_net_socket_t sock, const uint8_t *ptr, size_t len) {

--- a/src/link/transport/upper/serial_protocol.c
+++ b/src/link/transport/upper/serial_protocol.c
@@ -168,6 +168,10 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
             if (rb == 0) {
                 return SIZE_MAX;
             }
+            timeout_cnt++;
+            if (timeout_cnt > 10) {
+                return SIZE_MAX;
+            }
             continue;
         }
         if (chunk == SIZE_MAX) {
@@ -179,6 +183,8 @@ static size_t _z_read_serial_internal(const _z_sys_net_socket_t sock, uint8_t *h
 #endif
             return SIZE_MAX;
         }
+
+        timeout_cnt = 0;
 
         rb++;
         if (raw_buf[rb - 1] == (uint8_t)0x00) {


### PR DESCRIPTION
## Description

### What does this PR do?
This PR updates the STM32 ThreadX UART DMA driver (`src/link/transport/serial/uart_threadx_stm32.c`) to prevent false link teardowns during idle serial communication:

- In `_z_threadx_stm32_uart_fill_frame()`, timing out on `_z_threadx_stm32_data_ready_semaphore` when no serial bytes arrive previously returned `SIZE_MAX`.
- `_z_read_serial_internal()` in `serial_protocol.c` treated `SIZE_MAX` as an unrecoverable hardware failure, returning `_Z_ERR_TRANSPORT_RX_FAILED` and terminating the transport session during normal serial idle periods.
- This PR changes the semaphore timeout return value to `0` bytes read, allowing non-blocking reader loop yields and retries without disconnecting.

### Related Issues
- Fixes #1276

Signed-off-by: michael545 <michael.valand@gmail.com>

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->