### PR TITLE
ci: use toxiproxy to test connection restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,18 @@ jobs:
           out-file-path: zenoh-standalone
           extract: true
 
+      - name: Diagnose GitHub API access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --silent --show-error \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --dump-header /tmp/github-headers \
+            --output /tmp/github-response \
+            https://api.github.com/repos/Shopify/toxiproxy/releases/tags/v2.12.0
+          awk 'tolower($1) ~ /^http|^x-ratelimit|^content-type/ { print }' /tmp/github-headers
+          head -c 500 /tmp/github-response
+
       - name: Download Toxiproxy
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,6 +668,8 @@ jobs:
   connection_restore_test:
     name: Connection restore test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -704,6 +706,7 @@ jobs:
           tag: v${{ env.TOXIPROXY_VERSION }}
           fileName: toxiproxy-server-linux-amd64
           out-file-path: .
+          token: ${{ github.token }}
 
       - name: Start Toxiproxy
         run: |
@@ -716,7 +719,6 @@ jobs:
           sudo apt update && sudo apt install -y ninja-build
           CMAKE_GENERATOR=Ninja ASAN=ON CMAKE_BUILD_TYPE=Debug ZENOH_DEBUG=3 make
           chmod +x ./zenoh-standalone/zenohd
-          RUST_LOG=debug sudo python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
           RUST_LOG=debug python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
         timeout-minutes: 20
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   ZENOH_ASSET: zenoh-1.9.0-x86_64-unknown-linux-gnu-standalone.zip
+  TOXIPROXY_VERSION: 2.12.0
 
 jobs:
   run_tests:
@@ -696,12 +697,27 @@ jobs:
           out-file-path: zenoh-standalone
           extract: true
 
+      - name: Download Toxiproxy
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
+        with:
+          repository: Shopify/toxiproxy
+          tag: v${{ env.TOXIPROXY_VERSION }}
+          fileName: toxiproxy-server-linux-amd64
+          out-file-path: .
+
+      - name: Start Toxiproxy
+        run: |
+          chmod +x ./toxiproxy-server-linux-amd64
+          ./toxiproxy-server-linux-amd64 --host=127.0.0.1 > toxiproxy.log 2>&1 &
+          echo $! > toxiproxy.pid
+
       - name: Build project and run test
         run: |
           sudo apt update && sudo apt install -y ninja-build
           CMAKE_GENERATOR=Ninja ASAN=ON CMAKE_BUILD_TYPE=Debug ZENOH_DEBUG=3 make
           chmod +x ./zenoh-standalone/zenohd
           RUST_LOG=debug sudo python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
+          RUST_LOG=debug python3 ./build/tests/connection_restore.py ./zenoh-standalone/zenohd
         timeout-minutes: 20
         env:
           CC: ccache cc
@@ -709,6 +725,12 @@ jobs:
           CCACHE_DIR: ~/.ccache
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_COMPILERCHECK: content
+
+      - name: Stop Toxiproxy
+        if: always()
+        run: |
+          if [ -f toxiproxy.pid ]; then kill "$(cat toxiproxy.pid)" || true; fi
+          if [ -f toxiproxy.log ]; then cat toxiproxy.log; fi
 
   routed_peer_client_test:
     name: Test routed peer client communication

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ concurrency:
 
 env:
   ZENOH_ASSET: zenoh-1.9.0-x86_64-unknown-linux-gnu-standalone.zip
-  TOXIPROXY_VERSION: 2.12.0
 
 jobs:
   run_tests:
@@ -668,8 +667,6 @@ jobs:
   connection_restore_test:
     name: Connection restore test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -699,26 +696,15 @@ jobs:
           out-file-path: zenoh-standalone
           extract: true
 
-      - name: Diagnose GitHub API access
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          curl --silent --show-error \
-            --header "Authorization: Bearer ${GH_TOKEN}" \
-            --dump-header /tmp/github-headers \
-            --output /tmp/github-response \
-            https://api.github.com/repos/Shopify/toxiproxy/releases/tags/v2.12.0
-          awk 'tolower($1) ~ /^http|^x-ratelimit|^content-type/ { print }' /tmp/github-headers
-          head -c 500 /tmp/github-response
-
+      # Use curl directly instead of release-downloader to avoid issues with Shopify/toxiproxy IP allowlist restriction
       - name: Download Toxiproxy
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
-        with:
-          repository: Shopify/toxiproxy
-          tag: v${{ env.TOXIPROXY_VERSION }}
-          fileName: toxiproxy-server-linux-amd64
-          out-file-path: .
-          token: ${{ github.token }}
+        run: |
+          curl --fail --silent --show-error --location \
+            https://github.com/Shopify/toxiproxy/releases/download/v2.12.0/toxiproxy-server-linux-amd64 \
+            --output toxiproxy-server-linux-amd64
+
+          echo "556d891134a3c582dc4d3b3c7a1a3f7335fd55142e5965769855a00b944e13e48302fc  toxiproxy-server-linux-amd64" \
+            | sha256sum --check
 
       - name: Start Toxiproxy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,9 @@ jobs:
             https://github.com/Shopify/toxiproxy/releases/download/v2.12.0/toxiproxy-server-linux-amd64 \
             --output toxiproxy-server-linux-amd64
 
-          echo "556d891134a3c582dc4d3b3c7a1a3f7335fd55142e5965769855a00b944e13e48302fc  toxiproxy-server-linux-amd64" \
+      - name: Verify Toxiproxy
+        run: |
+          echo "556d891134a3c582dc1e1a3f7335fd55142e5965769855a00b944e13e48302fc  toxiproxy-server-linux-amd64" \
             | sha256sum --check
 
       - name: Start Toxiproxy

--- a/tests/connection_restore.py
+++ b/tests/connection_restore.py
@@ -456,7 +456,7 @@ def test_pub_before_restart_then_new_sub(router_command, pub_command, sub_comman
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: sudo python3 ./connection_restore.py /path/to/zenohd")
+        print("Usage: python3 ./connection_restore.py /path/to/zenohd")
         sys.exit(1)
 
     router_command = STDBUF_CMD + [sys.argv[1]] + ROUTER_ARGS

--- a/tests/connection_restore.py
+++ b/tests/connection_restore.py
@@ -3,6 +3,9 @@ import time
 import sys
 import os
 import threading
+import json
+import urllib.error
+import urllib.request
 
 ROUTER_INIT_TIMEOUT_S = 3
 WAIT_MESSAGE_TIMEOUT_S = 15
@@ -14,9 +17,14 @@ SUBSCRIBER_RECEIVE_MESSAGES = ["[Subscriber] Received"]
 ROUTER_ERROR_MESSAGE = "ERROR"
 WRITE_FILTER_OFF_MESSAGE = "write filter state: 1"
 WRITE_FILTER_ACTIVE_MESSAGE = "write filter state: 0"
-ZENOH_PORT = "7447"
+ROUTER_PORT = "7447"
+ZENOH_PORT = "7448"
+TOXIPROXY_API = "http://127.0.0.1:8474"
+TOXIPROXY_NAME = "zenoh-connection-restore"
+TOXIC_UPSTREAM = "drop-upstream"
+TOXIC_DOWNSTREAM = "drop-downstream"
 
-ROUTER_ARGS = ['-l', f'tcp/0.0.0.0:{ZENOH_PORT}', '--no-multicast-scouting']
+ROUTER_ARGS = ['-l', f'tcp/0.0.0.0:{ROUTER_PORT}', '--no-multicast-scouting']
 STDBUF_CMD = ["stdbuf", "-o0"]
 
 DIR_EXAMPLES = "build/examples"
@@ -60,14 +68,78 @@ def terminate_processes(process_list):
     process_list.clear()
 
 
+def toxiproxy_request(method, path, payload=None, ignored_statuses=()):
+    request_data = None
+    headers = {}
+    if payload is not None:
+        request_data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(
+        f"{TOXIPROXY_API}{path}", data=request_data, headers=headers, method=method
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        if error.code in ignored_statuses:
+            return error.code
+        raise
+
+
+def configure_toxiproxy():
+    start_time = time.time()
+    while time.time() - start_time < WAIT_MESSAGE_TIMEOUT_S:
+        try:
+            toxiproxy_request("GET", "/version")
+            break
+        except urllib.error.URLError:
+            time.sleep(0.2)
+    else:
+        raise Exception("Toxiproxy API is not available.")
+
+    toxiproxy_request("DELETE", f"/proxies/{TOXIPROXY_NAME}", ignored_statuses=(404,))
+    toxiproxy_request(
+        "POST",
+        "/proxies",
+        {
+            "name": TOXIPROXY_NAME,
+            "listen": f"127.0.0.1:{ZENOH_PORT}",
+            "upstream": f"127.0.0.1:{ROUTER_PORT}",
+            "enabled": True,
+        },
+    )
+
+
 def block_connection():
-    subprocess.run(["iptables", "-A", "INPUT", "-p", "tcp", "--dport", ZENOH_PORT, "-j", "DROP"], check=True)
-    subprocess.run(["iptables", "-A", "OUTPUT", "-p", "tcp", "--sport", ZENOH_PORT, "-j", "DROP"], check=True)
+    for name, stream in ((TOXIC_UPSTREAM, "upstream"), (TOXIC_DOWNSTREAM, "downstream")):
+        toxiproxy_request(
+            "POST",
+            f"/proxies/{TOXIPROXY_NAME}/toxics",
+            {
+                "name": name,
+                "type": "timeout",
+                "stream": stream,
+                "attributes": {"timeout": 0},
+            },
+        )
 
 
 def unblock_connection():
-    subprocess.run(["iptables", "-D", "INPUT", "-p", "tcp", "--dport", ZENOH_PORT, "-j", "DROP"], check=False)
-    subprocess.run(["iptables", "-D", "OUTPUT", "-p", "tcp", "--sport", ZENOH_PORT, "-j", "DROP"], check=False)
+    for name in (TOXIC_UPSTREAM, TOXIC_DOWNSTREAM):
+        toxiproxy_request(
+            "DELETE",
+            f"/proxies/{TOXIPROXY_NAME}/toxics/{name}",
+            ignored_statuses=(404,),
+        )
+
+
+def cleanup_toxiproxy():
+    try:
+        unblock_connection()
+        toxiproxy_request("DELETE", f"/proxies/{TOXIPROXY_NAME}", ignored_statuses=(404,))
+    except urllib.error.URLError:
+        pass
 
 
 def wait_messages(client_output, messages):
@@ -389,35 +461,39 @@ def main():
 
     router_command = STDBUF_CMD + [sys.argv[1]] + ROUTER_ARGS
 
-    # timeout less than sesson timeout
-    test_connection_drop(router_command, ACTIVE_CLIENT_COMMAND, 15)
-    test_connection_drop(router_command, PASSIVE_CLIENT_COMMAND, 15)
+    configure_toxiproxy()
+    try:
+        # timeout less than session timeout
+        test_connection_drop(router_command, ACTIVE_CLIENT_COMMAND, 15)
+        test_connection_drop(router_command, PASSIVE_CLIENT_COMMAND, 15)
 
-    # timeout more than sesson timeout
-    test_connection_drop(router_command, ACTIVE_CLIENT_COMMAND, 15)
-    test_connection_drop(router_command, PASSIVE_CLIENT_COMMAND, 15)
+        # timeout more than session timeout
+        test_connection_drop(router_command, ACTIVE_CLIENT_COMMAND, 15)
+        test_connection_drop(router_command, PASSIVE_CLIENT_COMMAND, 15)
 
-    # timeout less than sesson timeout
-    test_router_restart(router_command, ACTIVE_CLIENT_COMMAND, 8)
-    test_router_restart(router_command, PASSIVE_CLIENT_COMMAND, 8)
+        # timeout less than session timeout
+        test_router_restart(router_command, ACTIVE_CLIENT_COMMAND, 8)
+        test_router_restart(router_command, PASSIVE_CLIENT_COMMAND, 8)
 
-    # timeout more than sesson timeout
-    test_router_restart(router_command, ACTIVE_CLIENT_COMMAND, 15)
-    test_router_restart(router_command, PASSIVE_CLIENT_COMMAND, 15)
+        # timeout more than session timeout
+        test_router_restart(router_command, ACTIVE_CLIENT_COMMAND, 15)
+        test_router_restart(router_command, PASSIVE_CLIENT_COMMAND, 15)
 
-    # Existing z_pub <-> z_sub communication survives a router restart
-    test_pub_sub_survive_router_restart(router_command,
-                                        ACTIVE_CLIENT_COMMAND,
-                                        PASSIVE_CLIENT_COMMAND,
-                                        8)
+        # Existing z_pub <-> z_sub communication survives a router restart
+        test_pub_sub_survive_router_restart(router_command,
+                                            ACTIVE_CLIENT_COMMAND,
+                                            PASSIVE_CLIENT_COMMAND,
+                                            8)
 
-    # After a router restart, a new z_sub can receive samples from a pre-restart z_pub
-    test_pub_before_restart_then_new_sub(router_command,
-                                         ACTIVE_CLIENT_COMMAND,
-                                         PASSIVE_CLIENT_COMMAND,
-                                         8)
+        # After a router restart, a new z_sub can receive samples from a pre-restart z_pub
+        test_pub_before_restart_then_new_sub(router_command,
+                                             ACTIVE_CLIENT_COMMAND,
+                                             PASSIVE_CLIENT_COMMAND,
+                                             8)
 
-    test_liveliness_drop(router_command, LIVELINESS_CLIENT_COMMAND, LIVELINESS_SUB_CLIENT_COMMAND)
+        test_liveliness_drop(router_command, LIVELINESS_CLIENT_COMMAND, LIVELINESS_SUB_CLIENT_COMMAND)
+    finally:
+        cleanup_toxiproxy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Use toxiproxy to simulate network failures in `connection_restore.py` test, avoiding the need to have elevated privileges on the CI host to use iptables.

### What does this PR do?
Use a TCP proxy to simulate network failures instead of manipulating iptables, which requires elevated privileges.

### Why is this change needed?
Remove the need to have elevated privileges to simulate network failures.

### Related Issues
N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->