### PR TITLE
freertos: configure TCP send timeout

### DIFF
--- a/src/system/freertos/freertos_plus_tcp/network.c
+++ b/src/system/freertos/freertos_plus_tcp/network.c
@@ -28,7 +28,12 @@ z_result_t _z_socket_set_blocking(const _z_sys_net_socket_t *sock, bool blocking
     BaseType_t result =
         FreeRTOS_setsockopt(sock->_socket, 0, FREERTOS_SO_RCVTIMEO, &option_value, sizeof(option_value));
 
-    if (result != pdPASS) {
+    if (result != 0) {
+        _Z_ERROR_RETURN(_Z_ERR_GENERIC);
+    }
+
+    result = FreeRTOS_setsockopt(sock->_socket, 0, FREERTOS_SO_SNDTIMEO, &option_value, sizeof(option_value));
+    if (result != 0) {
         _Z_ERROR_RETURN(_Z_ERR_GENERIC);
     }
     return _Z_RES_OK;


### PR DESCRIPTION
## Description

Configure both receive and send timeouts when changing the FreeRTOS+TCP socket blocking mode.

### What does this PR do?

- Applies `Z_CONFIG_SOCKET_TIMEOUT` to `FREERTOS_SO_SNDTIMEO` as well as `FREERTOS_SO_RCVTIMEO`.
- Checks `FreeRTOS_setsockopt()` against its documented success return value (`0`). The pinned FreeRTOS+TCP implementation follows the Berkeley convention and returns `0` on success, while the previous `pdPASS` comparison treated a successful call as an error.

### Why is this change needed?

If a router disappears without sending RST/FIN, the TCP send buffer can fill and leave a publisher blocked indefinitely. The lease task then cannot make progress and auto-reconnect never gets a chance to recover the session. A send timeout bounds that wait and lets the existing error/reconnect path run.

### Related Issues

Fixes #1267

### Validation

- `clang-format -n -Werror src/system/freertos/freertos_plus_tcp/network.c`
- `git diff --check`
- Confirmed against the pinned FreeRTOS+TCP source (`34148c3`) that `FREERTOS_SO_RCVTIMEO` and `FREERTOS_SO_SNDTIMEO` return `0` on success.
- The official FreeRTOS+TCP example configured successfully on macOS. Its build requires Linux's `bits/pthread_stack_min.h`, so the full Debug/Release build is left to the repository's Ubuntu CI.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->