### PR TITLE
ci: derive zenoh version for CI tests from zenoh-pico version.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,6 @@ jobs:
     name: Modular build on ubuntu-latest
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       matrix:
         feature_publication: [1, 0]
@@ -245,8 +243,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -413,8 +411,6 @@ jobs:
     name: Build and test in single thread on ubuntu-latest (unstable=${{ matrix.unstable_api }})
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       matrix:
         unstable_api: [0, 1]
@@ -442,8 +438,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -478,8 +474,6 @@ jobs:
     name: Test multicast and unicast fragmentation
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -504,8 +498,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -538,8 +532,6 @@ jobs:
     name: Test attachments
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -564,8 +556,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -597,8 +589,6 @@ jobs:
     name: Test examples memory leak
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Setup mbedtls
         uses: eclipse-zenoh/ci/setup-mbedtls@main
@@ -628,8 +618,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -684,8 +674,6 @@ jobs:
     name: Connection restore test
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -710,8 +698,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 
@@ -757,8 +745,6 @@ jobs:
     name: Test routed peer client communication
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -783,8 +769,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: zenoh-standalone
           extract: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZENOH_ASSET: zenoh-1.9.0-x86_64-unknown-linux-gnu-standalone.zip
-
+  ZENOH_ASSET: zenoh-1.10.0-x86_64-unknown-linux-gnu-standalone.zip
 jobs:
   run_tests:
     name: Run unit tests on ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  ZENOH_ASSET: zenoh-1.10.0-x86_64-unknown-linux-gnu-standalone.zip
 jobs:
+  zenoh_version:
+    name: Get Zenoh version
+    uses: ./.github/workflows/zenoh-version.yaml
+
   run_tests:
     name: Run unit tests on ubuntu-latest
     runs-on: ubuntu-latest
@@ -210,6 +212,9 @@ jobs:
   modular_build:
     name: Modular build on ubuntu-latest
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       matrix:
         feature_publication: [1, 0]
@@ -407,6 +412,9 @@ jobs:
   st_build:
     name: Build and test in single thread on ubuntu-latest (unstable=${{ matrix.unstable_api }})
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       matrix:
         unstable_api: [0, 1]
@@ -469,6 +477,9 @@ jobs:
   fragment_test:
     name: Test multicast and unicast fragmentation
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -526,6 +537,9 @@ jobs:
   attachment_test:
     name: Test attachments
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -582,6 +596,9 @@ jobs:
   memory_leak_test:
     name: Test examples memory leak
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Setup mbedtls
         uses: eclipse-zenoh/ci/setup-mbedtls@main
@@ -666,6 +683,9 @@ jobs:
   connection_restore_test:
     name: Connection restore test
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -736,6 +756,9 @@ jobs:
   routed_peer_client_test:
     name: Test routed peer client communication
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,14 +16,18 @@ name: integration
 on:
   workflow_call:
 
-env:
-  ZENOH_LINUX_ASSET: zenoh-1.9.0-x86_64-unknown-linux-gnu-standalone.zip
-  ZENOH_MACOS_ASSET: zenoh-1.9.0-aarch64-apple-darwin-standalone.zip
-
 jobs:
+  zenoh_version:
+    name: Get Zenoh version
+    uses: ./.github/workflows/zenoh-version.yaml
+
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: zenoh_version
+    env:
+      ZENOH_LINUX_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
+      ZENOH_MACOS_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-aarch64-apple-darwin-standalone.zip
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +140,9 @@ jobs:
   asan-build:
     name: Build on ubuntu-latest with ASAN
     runs-on: ubuntu-latest
+    needs: zenoh_version
+    env:
+      ZENOH_LINUX_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       fail-fast: false
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,9 +25,6 @@ jobs:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: zenoh_version
-    env:
-      ZENOH_LINUX_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
-      ZENOH_MACOS_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-aarch64-apple-darwin-standalone.zip
     strategy:
       fail-fast: false
       matrix:
@@ -110,8 +107,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_LINUX_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: build/tests
           extract: true
 
@@ -120,8 +117,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_MACOS_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-aarch64-apple-darwin-standalone.zip
           out-file-path: build/tests
           extract: true
 
@@ -141,8 +138,6 @@ jobs:
     name: Build on ubuntu-latest with ASAN
     runs-on: ubuntu-latest
     needs: zenoh_version
-    env:
-      ZENOH_LINUX_ASSET: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
     strategy:
       fail-fast: false
 
@@ -198,8 +193,8 @@ jobs:
         uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           repository: eclipse-zenoh/zenoh
-          latest: true
-          fileName: ${{ env.ZENOH_LINUX_ASSET }}
+          tag: ${{ needs.zenoh_version.outputs.zenoh-version }}
+          fileName: zenoh-${{ needs.zenoh_version.outputs.zenoh-version }}-x86_64-unknown-linux-gnu-standalone.zip
           out-file-path: build/tests
           extract: true
 

--- a/.github/workflows/zenoh-version.yaml
+++ b/.github/workflows/zenoh-version.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2026 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+name: Get Zenoh version
+
+on:
+  workflow_call:
+    outputs:
+      zenoh-version:
+        description: Zenoh version from version.txt
+        value: ${{ jobs.get_zenoh_version.outputs.zenoh-version }}
+
+jobs:
+  get_zenoh_version:
+    runs-on: ubuntu-latest
+    outputs:
+      zenoh-version: ${{ steps.version.outputs.zenoh-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - id: version
+        name: Read Zenoh version
+        shell: bash
+        run: echo "zenoh-version=$(tr -d '\r\n' < version.txt)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description
Derive zenoh version for CI tests from zenoh-pico version.txt

### What does this PR do?
Updates the zenoh artifact to use for CI checks

### Why is this change needed?
Use the zenoh artifact compatible with current zenoh-pico version and unblocks CI.

### Related Issues
N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->