### PR TITLE
fix: z_pub -v <string> aborts for any value longer than about 240 byte

### DIFF
--- a/examples/arduino/z_pub.ino
+++ b/examples/arduino/z_pub.ino
@@ -94,7 +94,7 @@ void setup() {
 void loop() {
     delay(1000);
     char buf[256];
-    sprintf(buf, "[%4d] %s", idx++, VALUE);
+    snprintf(buf, sizeof(buf), "[%4d] %s", idx++, VALUE);
 
     Serial.print("Writing Data ('");
     Serial.print(KEYEXPR);

--- a/examples/espidf/z_pub.c
+++ b/examples/espidf/z_pub.c
@@ -152,7 +152,7 @@ void app_main() {
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         sleep(1);
-        sprintf(buf, "[%4d] %s", idx, VALUE);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, VALUE);
         printf("Putting Data ('%s': '%s')...\n", KEYEXPR, buf);
 
         // Create payload

--- a/examples/mbed/z_pub.cpp
+++ b/examples/mbed/z_pub.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, VALUE);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, VALUE);
         printf("Putting Data ('%s': '%s')...\n", KEYEXPR, buf);
 
         // Create payload

--- a/examples/unix/c11/z_advanced_pub.c
+++ b/examples/unix/c11/z_advanced_pub.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
         z_owned_bytes_t payload;
         z_bytes_copy_from_str(&payload, buf);

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; idx < n; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
 
         // Create payload

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; idx < n; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, value);
         printf("Putting Data ('%s': '%s')...\n", keyexpr, buf);
 
         // Create payload
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 
         // Add attachment value
         char buf_ind[16];
-        sprintf(buf_ind, "%d", idx);
+        snprintf(buf_ind, sizeof(buf_ind), "%d", idx);
         kvs[1] = (kv_pair_t){.key = "index", .value = buf_ind};
         ze_owned_serializer_t serializer;
         ze_serializer_empty(&serializer);

--- a/examples/unix/c11/z_querier.c
+++ b/examples/unix/c11/z_querier.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; idx != n; ++idx) {
         z_sleep_s(1);
-        sprintf(buf, "[%4d] %s", idx, value ? value : "");
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, value ? value : "");
         printf("Querying '%s' with payload '%s'...\n", selector, buf);
         z_querier_get_options_t get_options;
         z_querier_get_options_default(&get_options);

--- a/examples/zephyr/z_pub.c
+++ b/examples/zephyr/z_pub.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     char buf[256];
     for (int idx = 0; 1; ++idx) {
         sleep(1);
-        sprintf(buf, "[%4d] %s", idx, VALUE);
+        snprintf(buf, sizeof(buf), "[%4d] %s", idx, VALUE);
         printf("Putting Data ('%s': '%s')...\n", KEYEXPR, buf);
 
         // Create payload


### PR DESCRIPTION
`z_pub -v <arg>` aborts for any value longer than about 240 bytes:

```sh
$ z_pub -v "$(python3 -c 'print("P"*718)')"
```

It's due to buffer overflow on sprint when the string length exceeds the fixed size `char buf[256]`. The patch replaces sprintf with snprintf. In this way, truncation happens instead of the overflow.

This bug leads unintended bytes change in memory. It can be possibly used to tamper the control flow, embed the shell code and other security issues.

OTOH, I suggest to forbid unsafe functions such as sprintf, puts in the project.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->