### PR TITLE
fix(serial): make a serial-only build work on a board with no IP stack

### DIFF
--- a/include/zenoh-pico/link/transport/socket.h
+++ b/include/zenoh-pico/link/transport/socket.h
@@ -20,6 +20,22 @@
 
 #include "zenoh-pico/system/platform.h"
 
+/* Does this build actually use sockets?
+ *
+ * Being on a socket-capable platform is not the same as having a socket link.
+ * A serial-only image -- e.g. Zephyr with CONFIG_NETWORKING=n -- has no IP
+ * stack at all, so code that reaches for `struct sockaddr`, `socklen_t` or
+ * `AF_INET` cannot compile there, however capable the platform nominally is.
+ *
+ * Files that provide a socket implementation with a not-available stub
+ * alongside it select between the two on this. */
+#if Z_FEATURE_LINK_TCP == 1 || Z_FEATURE_LINK_TLS == 1 || Z_FEATURE_LINK_WS == 1 || Z_FEATURE_LINK_UDP_UNICAST == 1 || \
+    Z_FEATURE_LINK_UDP_MULTICAST == 1
+#define Z_HAS_SOCKET_LINK 1
+#else
+#define Z_HAS_SOCKET_LINK 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/link/transport/common/address.c
+++ b/src/link/transport/common/address.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include "zenoh-pico/config.h"
+#include "zenoh-pico/link/transport/socket.h"
 
 #if defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD)
 #include <arpa/inet.h>
@@ -22,15 +23,16 @@
 #if defined(ZENOH_FREERTOS_LWIP)
 #include "lwip/inet.h"
 #endif
-#if defined(ZENOH_ZEPHYR)
+#if defined(ZENOH_ZEPHYR) && Z_HAS_SOCKET_LINK
 #include <zephyr/net/socket.h>
 #endif
 
 #include "zenoh-pico/link/transport/socket.h"
 #include "zenoh-pico/utils/logging.h"
 
-#if defined(ZENOH_WINDOWS) || defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD) || \
-    defined(ZENOH_FREERTOS_LWIP) || defined(ZENOH_ZEPHYR)
+#if (defined(ZENOH_WINDOWS) || defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD) || \
+     defined(ZENOH_FREERTOS_LWIP) || defined(ZENOH_ZEPHYR)) &&                                       \
+    Z_HAS_SOCKET_LINK
 
 static z_result_t _z_ipv4_port_to_endpoint(const uint8_t *address, uint16_t port, char *dst, size_t dst_len) {
     char ip[INET_ADDRSTRLEN] = {0};

--- a/src/link/transport/common/endpoints.c
+++ b/src/link/transport/common/endpoints.c
@@ -13,8 +13,9 @@
 //
 
 #include "zenoh-pico/config.h"
+#include "zenoh-pico/link/transport/socket.h"
 
-#if defined(ZENOH_WINDOWS)
+#if defined(ZENOH_WINDOWS) && Z_HAS_SOCKET_LINK
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -63,7 +64,7 @@ z_result_t _z_socket_get_endpoints(const _z_sys_net_socket_t *sock, char *local,
     return _Z_RES_OK;
 }
 
-#elif defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD) || defined(ZENOH_ZEPHYR)
+#elif (defined(ZENOH_LINUX) || defined(ZENOH_MACOS) || defined(ZENOH_BSD) || defined(ZENOH_ZEPHYR)) && Z_HAS_SOCKET_LINK
 
 #include <stddef.h>
 

--- a/src/link/transport/serial/uart_zephyr.c
+++ b/src/link/transport/serial/uart_zephyr.c
@@ -20,8 +20,10 @@
 
 #if KERNEL_VERSION_MAJOR == 2
 #include <drivers/uart.h>
+#include <kernel.h>
 #else
 #include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
 #endif
 
 #include "zenoh-pico/utils/logging.h"
@@ -81,11 +83,57 @@ static void _z_zephyr_uart_close(_z_sys_net_socket_t *sock) {
     }
 }
 
+/* Bound the wait, yield between polls, and report a receive error.
+ *
+ * The previous loop spun on `uart_poll_in` with no timeout, no yield and no
+ * error check, and returned `len` whatever happened. Three consequences, all
+ * observed on an MR-CANHUBK344 (S32K344) carrying zenoh over a 115200 line:
+ *
+ *   * No timeout. A peer that stops mid-frame parks this thread forever. The
+ *     other ports do not do this: `tty_posix` returns `SIZE_MAX` when the read
+ *     fails, and callers such as `_z_read_exact_serial` already handle it.
+ *
+ *   * No yield. On a cooperatively scheduled or equal-priority system this
+ *     starves every other thread, including the one that would have refilled
+ *     the line. `k_yield()` and not `z_sleep_ms(1)`: the shortest sleep is a
+ *     whole tick, and at 115200 a byte arrives every 87 us, so sleeping loses
+ *     bytes that yielding does not.
+ *
+ *   * No `uart_err_check`. `uart_poll_in` reports "no character available"; it
+ *     has no way to say "a character was destroyed before you asked". A UART
+ *     overrun is therefore SILENT, and a receiver that only reads the return
+ *     value cannot tell a quiet link from one it is failing to keep up with.
+ *     That indistinguishability cost a long investigation that ended in a bug
+ *     report against the peer, which turned out to be innocent: the overrun
+ *     flag was set on exactly the frame that was truncated and nowhere else.
+ *
+ * The return value now follows the contract the posix port already uses:
+ * `SIZE_MAX` on failure, otherwise the number of bytes actually read.
+ */
+#ifndef Z_ZEPHYR_SERIAL_READ_TIMEOUT_MS
+#define Z_ZEPHYR_SERIAL_READ_TIMEOUT_MS 1000
+#endif
+
 static size_t _z_zephyr_uart_read(_z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
     for (size_t i = 0; i < len; i++) {
         int res = -1;
+        int64_t deadline = k_uptime_get() + (int64_t)Z_ZEPHYR_SERIAL_READ_TIMEOUT_MS;
         while (res != 0) {
             res = uart_poll_in(sock._serial, &ptr[i]);
+            if (res != 0) {
+                if (k_uptime_get() > deadline) {
+                    return SIZE_MAX;
+                }
+                k_yield();
+            }
+        }
+
+        /* Checked per byte rather than per read: the flag is sticky until it is
+         * read, so taking it here attributes the loss to the byte that was
+         * actually damaged. */
+        int err = uart_err_check(sock._serial);
+        if (err > 0 && (err & UART_ERROR_OVERRUN) != 0) {
+            _Z_ERROR("serial RX overrun after %zu byte(s) -- frame will be dropped", i);
         }
     }
 

--- a/src/transport/peer.c
+++ b/src/transport/peer.c
@@ -151,12 +151,20 @@ bool _z_transport_peer_multicast_eq(const _z_transport_peer_multicast_t *left,
 
 void _z_transport_peer_unicast_clear(_z_transport_peer_unicast_t *src) {
     _z_zbuf_clear(&src->flow_buff);
+#if Z_FEATURE_UNICAST_PEER == 1
+    /* Only the peer-mode paths ever take ownership of a socket: the inbound
+     * accept in `accept.c` and `_z_new_peer` pass owns_socket=true, while the
+     * client path passes false. With Z_FEATURE_UNICAST_PEER off the flag is
+     * therefore always false and this branch is dead -- but it still drags
+     * `_z_socket_close` into the link, which a socket-free build (serial only,
+     * no IP stack) has no implementation for. */
     if (src->_owns_socket) {
 #if Z_FEATURE_LINK_TLS == 1
         _z_close_tls_socket(&src->_socket);
 #endif
         _z_socket_close(&src->_socket);
     }
+#endif
     _z_transport_peer_common_clear(&src->common);
 }
 


### PR DESCRIPTION
## Description

Two things stop zenoh-pico running over serial on an MCU with no network: the
Zephyr UART read is unbounded and silent about errors, and the build cannot be
configured without sockets. Fixed here as one story, since neither alone gets a
serial-only image onto the wire.

### What does this PR do?

**1 -- the Zephyr UART read** (`src/link/transport/serial/uart_zephyr.c`).
It spins on `uart_poll_in` with no timeout, no yield and no error check, and
returns `len` regardless of what happened.

```c
static size_t _z_zephyr_uart_read(_z_sys_net_socket_t sock, uint8_t *ptr, size_t len) {
    for (size_t i = 0; i < len; i++) {
        int res = -1;
        while (res != 0) {
            res = uart_poll_in(sock._serial, &ptr[i]);
        }
    }
    return len;
}
```

- Bounds the wait. New `Z_ZEPHYR_SERIAL_READ_TIMEOUT_MS` (default 1000,
  overridable); returns `SIZE_MAX` on expiry.
- Yields between polls: `k_yield()`, not `z_sleep_ms(1)`. Shortest sleep is a
  whole tick; at 115200 a byte lands every ~87 us, so sleeping drops bytes.
- Checks `uart_err_check` per byte, logs `UART_ERROR_OVERRUN`. Per byte because
  the flag is sticky until read -- that attributes the loss to the damaged byte.

`SIZE_MAX` is not new API. `tty_posix.c` in the same directory already returns
it, and callers already handle it (`_z_read_exact_serial` breaks on it,
`_z_connect_serial` maps it to `_Z_ERR_TRANSPORT_RX_FAILED`). Zephyr was the one
backend that could never produce it.

```c
// src/link/transport/serial/tty_posix.c
ssize_t rb = read(sock._fd, ptr, count);
if (rb <= 0) {
    return SIZE_MAX;
}
```

**2 -- building with no socket link.** Three files chose their implementation
from the *platform* alone, so a platform that merely *could* do sockets took the
socket path even when no socket link was enabled. A serial-only Zephyr image
(`CONFIG_NETWORKING=n`) then failed to compile on `AF_INET` / `AF_INET6` /
`socklen_t` / `struct sockaddr`.

New `Z_HAS_SOCKET_LINK` in `include/zenoh-pico/link/transport/socket.h`:

```c
#if Z_FEATURE_LINK_TCP == 1 || Z_FEATURE_LINK_TLS == 1 || Z_FEATURE_LINK_WS == 1 || \
    Z_FEATURE_LINK_UDP_UNICAST == 1 || Z_FEATURE_LINK_UDP_MULTICAST == 1
#define Z_HAS_SOCKET_LINK 1
#else
#define Z_HAS_SOCKET_LINK 0
#endif
```

- `link/transport/common/address.c`, `link/transport/common/endpoints.c` --
  require it alongside the platform check. Both already carried a
  `_Z_ERR_TRANSPORT_NOT_AVAILABLE` stub for exactly this case; it was simply
  unreachable on a socket-capable platform. No new stubs written.
- `transport/peer.c` -- guard the socket-ownership close on
  `Z_FEATURE_UNICAST_PEER`. Only the peer paths take ownership (`accept.c` and
  `_z_new_peer` pass `owns_socket=true`; the client path passes `false`), so
  with that feature off the branch is dead -- but it still pulled
  `_z_socket_close` into the link.

### Why is this change needed?

Three runtime failure modes, all observed on an NXP MR-CANHUBK344 (S32K344,
Cortex-M7), Zephyr 4.4, zenoh-pico over 115200 to a `zenohd` router.

- **No timeout -> hang.** No exit from the inner loop. A peer that stops
  mid-frame parks the calling thread forever. On a single-core MCU that is
  usually the thread driving the session, so the link does not fail, it hangs --
  the lease never fires because the lease task cannot run.
- **No yield -> starvation.** Under cooperative scheduling, or at equal
  priority, the spin never releases the CPU, including to whoever would refill
  the line.
- **No `uart_err_check` -> silent data loss.** `uart_poll_in` says "no character
  available"; it cannot say "a character was destroyed before you asked". A
  receiver reading only the return value cannot tell a quiet link from one it is
  failing to keep up with.

The third cost the most. It ended in a bug report filed against the peer
implementation. The peer was innocent -- once the flag was read, it was set on
exactly the frame that had been truncated and on no other. The receiver had been
dropping bytes and reporting success.

And the build reason: serial is a legitimate transport for a board with no
network, but requiring an IP stack to compile it is not free on a small MCU --
a Zephyr net stack costs tens of KiB of RAM in an image whose only link is a
UART.

### Open question for reviewers

The overrun is logged, not returned as failure -- the function still returns
`len`. An overrun corrupts the current frame and the framing layer already drops
it on CRC32, so failing the read would tear down a link over recoverable frame
loss. The missing piece was the diagnostic, not the teardown. Happy to switch to
`SIZE_MAX` if you prefer the stricter contract.

### Testing

On `mr_canhubk3/s32k344`, serial only, `CONFIG_NETWORKING=n`, to `rmw_zenohd`,
with ROS 2 on top:

- builds with no IP stack linked; FLASH 326560 B, RAM 285376 B
- session opens and holds, no reconnects across a 3.5 min soak
- steady 2.000 Hz (min 0.464 s, max 0.519 s)
- overrun log fires only on frames actually truncated

No behaviour change for a build that has a socket link, and none on a serial
link that never stalls and never overruns.

### Related Issues

None filed upstream by us.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->