### PR TITLE
Fix heap buffer overflow in _z_svec_remove

### DIFF
--- a/src/collections/vec.c
+++ b/src/collections/vec.c
@@ -258,7 +258,7 @@ void _z_svec_remove(_z_svec_t *v, size_t pos, z_element_clear_f clear, z_element
     assert(pos < v->_len);
     clear((uint8_t *)v->_val + pos * element_size);
     __z_svec_move_inner((uint8_t *)v->_val + pos * element_size, (uint8_t *)v->_val + (pos + 1) * element_size, move,
-                        (v->_len - pos - 1) * element_size, element_size, use_elem_f);
+                        v->_len - pos - 1, element_size, use_elem_f);
 
     v->_len--;
 }

--- a/tests/z_collections_test.c
+++ b/tests/z_collections_test.c
@@ -15,12 +15,15 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
 
 #include "zenoh-pico/collections/fifo.h"
 #include "zenoh-pico/collections/lifo.h"
 #include "zenoh-pico/collections/ring.h"
 #include "zenoh-pico/collections/sortedmap.h"
 #include "zenoh-pico/collections/string.h"
+#include "zenoh-pico/collections/vec.h"
 
 #undef NDEBUG
 #include <assert.h>
@@ -472,6 +475,70 @@ void int_map_extract_test(void) {
     _z_str_intmap_clear(&map);
 }
 
+void svec_remove_non_last_element_test(void) {
+    typedef struct {
+        uint32_t a;
+        uint32_t b;
+    } test_svec_elem_t;
+
+    enum {
+        ELEMENT_COUNT = 4,
+        STORAGE_SIZE = 160
+    };
+
+    union {
+        test_svec_elem_t align;
+        uint8_t bytes[STORAGE_SIZE];
+    } storage;
+
+    uint8_t expected_guard[STORAGE_SIZE - ELEMENT_COUNT * sizeof(test_svec_elem_t)];
+
+    // Keep extra bytes after the logical vector storage as a guard region.
+    // _z_svec_remove() must move only the remaining elements and must not
+    // modify memory beyond the vector's logical element range.
+    for (size_t i = 0; i < sizeof(storage.bytes); i++) {
+        storage.bytes[i] = (uint8_t)(i ^ 0xA5);
+    }
+
+    test_svec_elem_t *elems = (test_svec_elem_t *)storage.bytes;
+
+    elems[0] = (test_svec_elem_t){10, 11};
+    elems[1] = (test_svec_elem_t){20, 21};
+    elems[2] = (test_svec_elem_t){30, 31};
+    elems[3] = (test_svec_elem_t){40, 41};
+
+    // Save the guard region so we can detect an oversized memmove().
+    memcpy(expected_guard,
+           storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t),
+           sizeof(expected_guard));
+
+    _z_svec_t vec = {
+        ._capacity = ELEMENT_COUNT,
+        ._len = ELEMENT_COUNT,
+        ._val = storage.bytes,
+        ._aliased = true,
+    };
+
+    // Remove a non-last element so the remaining elements must be shifted.
+    _z_svec_remove(&vec, 1, _z_noop_clear, NULL, sizeof(test_svec_elem_t), false);
+
+    assert(vec._len == 3);
+
+    elems = (test_svec_elem_t *)vec._val;
+
+    assert(elems[0].a == 10);
+    assert(elems[0].b == 11);
+    assert(elems[1].a == 30);
+    assert(elems[1].b == 31);
+    assert(elems[2].a == 40);
+    assert(elems[2].b == 41);
+
+    // Removing an element must not touch memory outside the logical vector.
+    assert(memcmp(storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t),
+                  expected_guard,
+                  sizeof(expected_guard)) == 0);
+}
+
 static bool slist_eq_f(const void *left, const void *right) { return strcmp((char *)left, (char *)right) == 0; }
 static bool slist_starts_with_f(const void *left, const void *right) {
     // SAFETY: left and right are guaranteed to be null-terminated.
@@ -781,6 +848,8 @@ int main(void) {
     int_map_iterator_deletion_test();
     int_map_extract_test();
     ring_iterator_test();
+
+    svec_remove_non_last_element_test();
 
     slist_test();
 

--- a/tests/z_collections_test.c
+++ b/tests/z_collections_test.c
@@ -13,9 +13,9 @@
 //
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 
 #include "zenoh-pico/collections/fifo.h"
@@ -481,10 +481,7 @@ void svec_remove_non_last_element_test(void) {
         uint32_t b;
     } test_svec_elem_t;
 
-    enum {
-        ELEMENT_COUNT = 4,
-        STORAGE_SIZE = 160
-    };
+    enum { ELEMENT_COUNT = 4, STORAGE_SIZE = 160 };
 
     union {
         test_svec_elem_t align;
@@ -508,9 +505,7 @@ void svec_remove_non_last_element_test(void) {
     elems[3] = (test_svec_elem_t){40, 41};
 
     // Save the guard region so we can detect an oversized memmove().
-    memcpy(expected_guard,
-           storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t),
-           sizeof(expected_guard));
+    memcpy(expected_guard, storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t), sizeof(expected_guard));
 
     _z_svec_t vec = {
         ._capacity = ELEMENT_COUNT,
@@ -534,9 +529,8 @@ void svec_remove_non_last_element_test(void) {
     assert(elems[2].b == 41);
 
     // Removing an element must not touch memory outside the logical vector.
-    assert(memcmp(storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t),
-                  expected_guard,
-                  sizeof(expected_guard)) == 0);
+    assert(memcmp(storage.bytes + ELEMENT_COUNT * sizeof(test_svec_elem_t), expected_guard, sizeof(expected_guard)) ==
+           0);
 }
 
 static bool slist_eq_f(const void *left, const void *right) { return strcmp((char *)left, (char *)right) == 0; }


### PR DESCRIPTION
## Description

### What does this PR do?

Fixes the element count passed by `_z_svec_remove()` to `__z_svec_move_inner()` and adds a regression test.

### Why is this change needed?

`__z_svec_move_inner()` expects a number of elements and multiplies it by `element_size` internally.

`_z_svec_remove()` was passing an already byte-scaled value, causing an oversized `memmove()` when removing a non-last element.

### Testing

Added `svec_remove_non_last_element_test()` in `z_collections_test.c`.

The test verifies that:
- the remaining elements are shifted correctly;
- memory beyond the logical vector range is not modified.

The test fails with the previous implementation and passes with this fix.

### Related Issues

Addresses Bug A in #1290.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->