### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -34,6 +34,7 @@ file(GLOB_RECURSE Sources
   "../src/link/*.c"
   "../src/net/*.c"
   "../src/protocol/*.c"
+  "../src/runtime/*.c"
   "../src/session/*.c"
   "../src/transport/*.c"
   "../src/utils/*.c"


### PR DESCRIPTION
Fix CMakeLists for zephyr

## Description
Add a include path in zephyr CMakeLists

### What does this PR do?
Make zenoh-pico build OK in zephyr environnement 

### Why is this change needed?
It does not build for zephyr environnement

### Related Issues
#1287

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->