### PR TITLE
zephyr: include <zephyr/version.h> when it is available

### DIFF
--- a/include/zenoh-pico/system/platform/zephyr.h
+++ b/include/zenoh-pico/system/platform/zephyr.h
@@ -15,7 +15,15 @@
 #ifndef ZENOH_PICO_SYSTEM_ZEPHYR_TYPES_H
 #define ZENOH_PICO_SYSTEM_ZEPHYR_TYPES_H
 
+#ifdef __has_include
+#if __has_include(<zephyr/version.h>)
+#include <zephyr/version.h>
+#else
 #include <version.h>
+#endif
+#else
+#include <version.h>
+#endif
 
 #if KERNEL_VERSION_MAJOR == 2
 #include <kernel.h>

--- a/src/link/transport/serial/uart_zephyr.c
+++ b/src/link/transport/serial/uart_zephyr.c
@@ -16,7 +16,15 @@
 
 #if Z_FEATURE_LINK_SERIAL == 1 && defined(ZENOH_ZEPHYR)
 
+#ifdef __has_include
+#if __has_include(<zephyr/version.h>)
+#include <zephyr/version.h>
+#else
 #include <version.h>
+#endif
+#else
+#include <version.h>
+#endif
 
 #if KERNEL_VERSION_MAJOR == 2
 #include <drivers/uart.h>

--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -16,7 +16,15 @@
 
 #if defined(ZENOH_ZEPHYR)
 
+#ifdef __has_include
+#if __has_include(<zephyr/version.h>)
+#include <zephyr/version.h>
+#else
 #include <version.h>
+#endif
+#else
+#include <version.h>
+#endif
 
 #if KERNEL_VERSION_MAJOR == 2
 #include <random/rand32.h>


### PR DESCRIPTION
## Description

### What does this PR do?

Selects `<zephyr/version.h>` over the bare `<version.h>` when the former is available, in the three Zephyr sources that need `KERNEL_VERSION_MAJOR`.

### Why is this change needed?

Zephyr generates the header at `include/generated/zephyr/version.h` and puts only `include/generated` on the include path. The bare `<version.h>` therefore does not resolve on any Zephyr that has dropped the legacy include path, and zenoh-pico fails to compile when built as a **west module** — the flow documented at [docs.zephyrproject.org/.../zenoh-pico.html](https://docs.zephyrproject.org/latest/develop/manifest/external/zenoh-pico.html).

Verified on Zephyr 4.4 (`4.4.99`), building an out-of-tree application against zenoh-pico 1.10.1 as a west module. From the failing build's `compile_commands.json`:

```
-I .../build/zephyr/include/generated
```

while the header lives at `.../build/zephyr/include/generated/zephyr/version.h`.

### Why `__has_include` rather than a version check?

Zephyr 2.x — still handled by the `#if KERNEL_VERSION_MAJOR == 2` branches immediately below each of these includes — has no `<zephyr/>` prefix. The version cannot be tested before including the header that defines `KERNEL_VERSION_MAJOR`, so the choice has to be made on header availability. Old Zephyr keeps the bare include and behaviour there is unchanged.

### Why did CI not catch this?

`.github/workflows/zephyr.yaml` builds via PlatformIO (`pio init --project-option="framework=zephyr"`), and PlatformIO's bundled Zephyr still ships the legacy include path. The west-module path is not exercised upstream.

## Testing

Built `zenoh-pico` 1.10.1 as a west module on Zephyr 4.4 for an ESP32 board (publisher + subscriber, TCP link, `Z_FEATURE_MULTI_THREAD`) with no local include patching — compiles and links clean. `clang-format --dry-run --Werror` passes on all three files.

## Note on #1287 / #1232

Both are fixed by #1304, which shipped in 1.10.1, and could probably be closed.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->