### PR TITLE
fix(emscripten): usleep() instead of emscripten_sleep() for pthreads builds

### DIFF
--- a/src/system/emscripten/system.c
+++ b/src/system/emscripten/system.c
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "zenoh-pico/config.h"
 #include "zenoh-pico/system/common/system_error.h"
@@ -128,13 +129,25 @@ z_result_t _z_condvar_wait_until(_z_condvar_t *cv, _z_mutex_t *m, const z_clock_
 #endif  // Z_FEATURE_MULTI_THREAD == 1
 
 /*------------------ Sleep ------------------*/
+// emscripten_sleep() requires the module to be built with Asyncify (or JSPI),
+// which is incompatible with a pthreads build. A pthreads build has a real OS
+// thread, so a plain blocking usleep() works and is preferred there; keep
+// emscripten_sleep() as the fallback for non-pthreads (Asyncify) builds.
 z_result_t z_sleep_us(size_t time) {
+#if defined(__EMSCRIPTEN_PTHREADS__)
+    usleep((useconds_t)time);
+#else
     emscripten_sleep((time / 1000) + (time % 1000 == 0 ? 0 : 1));
+#endif
     return 0;
 }
 
 z_result_t z_sleep_ms(size_t time) {
+#if defined(__EMSCRIPTEN_PTHREADS__)
+    usleep((useconds_t)time * 1000);
+#else
     emscripten_sleep(time);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
## Update: superseded by a more thorough non-blocking rewrite

The approach below (a real, blocking `usleep()` for pthreads builds) was
itself superseded by a project pivot away from pthreads entirely — real
pthreads requires WebAssembly `--shared-memory`, which deadlocks
completely once loaded into a non-pthreads host (confirmed: a
pthreads-enabled `rclpy` build loaded into JupyterLite's `xeus-python`
kernel never responds again once it blocks).

What actually shipped needs neither pthreads nor Asyncify: every
genuinely blocking call in zenoh-pico's own Emscripten platform layer
(`z_open_ws`/`_z_read_ws`/`_z_send_ws` in `network.c`, and the
client-side Init/Open handshake in `transport/unicast/transport.c`) was
rewritten to make exactly one non-blocking attempt per call and return
immediately — no `usleep()`, no `emscripten_sleep()`, nothing that
blocks or sleeps at all — with the *caller* responsible for retrying
across separate top-level calls, each with a real yield back to the
browser's event loop in between (a JS-driven tick loop, or Python's own
`await asyncio.sleep()`, driven through
esol-community/rmw_zenoh_pico#7's own non-blocking `session_connect()`
rewrite).

This PR's branch (based on an older zenoh-pico tag than the fork
currently pins) isn't updated to that approach here, since I haven't
verified the newer patches still apply cleanly against this base without
testing them against it directly — happy to open a proper follow-up PR
with the full non-blocking rewrite (six small, focused patches: a
`ws/` locator validity-check fix, the non-blocking I/O rewrite, a
resumable client handshake state machine, single-threaded-mode
mutex/condvar stubs, and a missing `<stddef.h>` include) if there's
interest, rather than leaving this one open against a now-superseded
approach. Full current source for all of it:
https://github.com/Tobias-Fischer/ros-rolling/tree/pico-update-tmp/extra_recipes/zenoh-pico

## Summary
- `z_sleep_ms`/`z_sleep_us` in the Emscripten platform layer call `emscripten_sleep()`, which requires the module to be built with Asyncify (or JSPI).
- A `pthreads`-enabled build (`-pthread -sUSE_PTHREADS=1`) has a real OS thread available, where a plain blocking `usleep()` works correctly and is both simpler and cheaper than pulling in Asyncify.
- Without this fix, any pthreads build calling `z_sleep_ms` (e.g. `_z_open_ws()`'s post-connect wait for the WebSocket to actually open, in `ws_emscripten.c`) crashes at runtime with:
  ```
  Please compile your program with async support in order to use asynchronous operations like emscripten_sleep
  ```
- Falls back to the existing `emscripten_sleep()` behavior when `__EMSCRIPTEN_PTHREADS__` isn't defined, so non-pthreads (Asyncify) builds are unaffected.

Found and fixed while getting a `rclc`/`rmw_zenoh_pico`-based ROS 2 node running as a real pthreads WebAssembly build in the browser, talking to a native `zenohd` router over WebSocket.

## Test plan
- [x] Confirmed the crash reproduces without this fix in a real browser (Emscripten 4.0.9, `-pthread -sUSE_PTHREADS=1 -sPROXY_TO_PTHREAD=1`), and disappears with it — a `zenoh-pico` WebSocket session now connects to a native router end-to-end.
- [ ] Not run through zenoh-pico's own CI/test suite locally (no CMake configure environment set up for this fork) — please let CI confirm the standard emscripten build targets still pass.

## Full write-up

All the changes this required, across every repo, are documented together in [Tobias-Fischer/ros2-emscripten-zenoh-demo](https://github.com/Tobias-Fischer/ros2-emscripten-zenoh-demo) — including a working `rclc` *and* `rclpy` browser demo verified end-to-end against a native `zenohd` router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->

