### PR TITLE
fix(transport): preserve sequence number when copying fragments

### DIFF
--- a/src/protocol/definitions/transport.c
+++ b/src/protocol/definitions/transport.c
@@ -298,6 +298,7 @@ _z_transport_message_t _z_t_msg_make_fragment(_z_zint_t sn, _z_slice_t payload, 
 }
 
 void _z_t_msg_copy_fragment(_z_t_msg_fragment_t *clone, _z_t_msg_fragment_t *msg) {
+    clone->_sn = msg->_sn;
     clone->_payload = msg->_payload;
     _z_slice_copy(&clone->_payload, &msg->_payload);
     clone->first = msg->first;


### PR DESCRIPTION
## Description

Preserve the sequence number when copying a fragment message,
consistently with `_z_t_msg_copy_frame()`.

### What does this PR do?

Add `clone->_sn = msg->_sn;` to `_z_t_msg_copy_fragment()`.

### Why is this change needed?

The helper copies the payload and extension flags but leaves `_sn`
unchanged. For example, copying a fragment with SN=42 into a destination
with SN=999 leaves the destination SN at 999 instead of 42.

The frame copy helper already preserves the sequence number.
Is leaving `_sn` unchanged for fragments intentional? If so, please
let me know the intended semantics.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->